### PR TITLE
Fixing failures due to EEXIST error from the cache dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please take careful note of the following points, before using blobfuse:
 
 ## Installation
 
-In order to invoke blobfuse, you will need to install the dependencies (libfuse, libcurl, GnuTLS and cmake), clone this repository and build. The process is explained in the [blobfuse installation](https://github.com/Azure/azure-storage-fuse/wiki/Installation) page.
+You can install blobfuse from the Linux Software Repository for Microsoft products. The process is explained in the [blobfuse installation](https://github.com/Azure/azure-storage-fuse/wiki/Installation) page. Alternatively, you can clone this repository, install the dependencies (libfuse, libcurl and GnuTLS) and build from source code.
 
 ## Usage
 

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -90,10 +90,10 @@ int azs_open(const char *path, struct fuse_file_info *fi)
     if ((statret != 0) || ((time(NULL) - buf.st_mtime) > file_cache_timeout_in_seconds))  // TODO: Consider using "modified time" here, rather than "access time".
     {
         remove(mntPath);
-
-        if(0 != ensure_files_directory_exists_in_cache(mntPathString))
+	int status = ensure_files_directory_exists_in_cache(mntPathString);
+        if(status != 0 && errno != EEXIST)
         {
-            fprintf(stderr, "Failed to create file or direcotry on cache directory: %s, errno = %d.\n", mntPathString.c_str(),  errno);
+            fprintf(stderr, "Failed to create file or directory on cache directory: %s, errno = %d.\n", mntPathString.c_str(),  errno);
             return -1;
         }
         std::ofstream filestream(mntPathString, std::ofstream::binary | std::ofstream::out);

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -87,11 +87,11 @@ int azs_open(const char *path, struct fuse_file_info *fi)
     // If the file/blob being opened does not exist in the cache, or the version in the cache is too old, we need to download / refresh the data from the service.
     struct stat buf;
     int statret = stat(mntPath, &buf);
-    if ((statret != 0) || ((time(NULL) - buf.st_mtime) > file_cache_timeout_in_seconds))  // TODO: Consider using "modified time" here, rather than "access time".
+    if ((statret != 0) || ((time(NULL) - buf.st_mtime) > file_cache_timeout_in_seconds)) 
     {
         remove(mntPath);
-	int status = ensure_files_directory_exists_in_cache(mntPathString);
-        if(status != 0 && errno != EEXIST)
+
+        if(0 != ensure_files_directory_exists_in_cache(mntPathString))
         {
             fprintf(stderr, "Failed to create file or directory on cache directory: %s, errno = %d.\n", mntPathString.c_str(),  errno);
             return -1;

--- a/blobfuse/tests.py
+++ b/blobfuse/tests.py
@@ -16,6 +16,7 @@ import multiprocessing
 class TestFuse(unittest.TestCase):
     blobdir = "/path/to/mount" # Path to the mounted container
     localdir = "/mnt/tmp" # A local temp directory, not the same one used by blobfuse.
+    cachedir = "/mnt/blobfusetmp"
     src = ""
     dest = ""
     blobstage = ""
@@ -1118,6 +1119,34 @@ class TestFuse(unittest.TestCase):
         os.close(fd)
         os.remove(testFilePath)
         
+    def test_multiple_threads_create_cache_directory_simultaneous(self):
+        # This is to test the fix to a bug that reported failure if multiple threads simultaneously called ensure_directory_exists_in_cache.
+        # The directory would be successfully created, but many threads would fail because they would try to create it after another thread had already done so.
+        sourceDirName = "mediumblobs-2"
+        mediumBlobsSourceDir = os.path.join(self.blobstage, sourceDirName)
+        if not os.path.exists(mediumBlobsSourceDir):
+            os.makedirs(mediumBlobsSourceDir);
+        # We must use different files for each thread to avoid the synchronization that would occur if all threads access the same file
+        for i in range(0,20):
+            filename = str(uuid.uuid4())
+            filepath = os.path.join(mediumBlobsSourceDir, filename)
+            os.system("head -c 100M < /dev/zero >> " + filepath);
+
+        # This removes the cached entries of the files just created, so they are on the service but not local.
+        # This will force each thread to call ensure_directory_exists_in_cache when trying to access its file.
+        shutil.rmtree(self.cachedir + '/root/testing/' + sourceDirName)
+
+        threads = []
+
+        for filename in os.listdir(mediumBlobsSourceDir):
+            path = os.path.join(mediumBlobsSourceDir, filename)
+            threads.append(threading.Thread(target=self.read_file_func, args=(filepath, 0, 0, "",))) # Note that read_file_func also opens the file, which is the desired behavior
+
+        for thread in threads:
+            thread.start()
+
+        shutil.rmtree(mediumBlobsSourceDir)
+
         
 if __name__ == '__main__':
     unittest.main()

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -42,6 +42,14 @@ int ensure_files_directory_exists_in_cache(const std::string file_path)
             {
                 status = mkdir(copypath, 0770);
             }
+
+            // Ignore if some other thread was successful creating the path
+	    if(errno == EEXIST)
+            {
+                status = 0;
+                errno = 0;
+            }
+
             *slash = '/';
         }
         pp = slash + 1;

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -27,6 +27,7 @@ int ensure_files_directory_exists_in_cache(const std::string file_path)
     char *copypath = strdup(file_path.c_str());
 
     status = 0;
+    errno = 0;
     pp = copypath;
     while (status == 0 && (slash = strchr(pp, '/')) != 0)
     {


### PR DESCRIPTION
 ensure_files_directory_exists_in_cache causes intermittent 'operation not permitted' issues when opening multiple files (10+) in parallel. Fix is to not error out when EEXIST is the error.