### PR TITLE
Refactored blob_client_wrapper::download_blob_to_file

### DIFF
--- a/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
@@ -2,6 +2,9 @@
 * No exceptions will throw.
 */
 #include <sys/stat.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <fcntl.h>
 #include <iostream>
 #include <fstream>
 
@@ -440,7 +443,7 @@ namespace microsoft_azure {
                 int block_size = 4*1024*1024;
                 if(MaxBlobSize < fileSize)
                 {
-                    block_size = fileSize; 
+                    block_size = fileSize;
                 }
 
                 std::ifstream ifs;
@@ -467,7 +470,7 @@ namespace microsoft_azure {
                         int length = block_size;
                         if(offset + length > fileSize)
                         {
-                            length = fileSize - offset;  
+                            length = fileSize - offset;
                         }
 
                         char* buffer = new char[block_size];
@@ -623,24 +626,23 @@ namespace microsoft_azure {
                 return;
             }
 
-
+            const size_t downloaders = std::min(parallel, static_cast<size_t>(m_concurrency));
             try
             {
-                parallel = parallel;
-                //download_blob_to_stream(container, blob, 0, 0, ofs);
+                int errcode = 0;
+                const auto blobProperty = get_blob_property(container, blob);
+                const auto length = blobProperty.size;
+                auto fd = open(destPath.c_str(), O_CREAT|O_WRONLY, 0770);
+                if (-1 == fd) {
+                    return;
+                }
+                if (-1 == ftruncate(fd, length)) {
+                    close(fd);
+                    return;
+                }
 
-                std::mutex ofs_mutex;
-                std::condition_variable cv;
-                std::mutex cv_mutex;
-                std::condition_variable writeCV;
-                
-                auto blobProperty = get_blob_property(container, blob);
-                auto length = blobProperty.size;
-                //std::cout << "Size: " << length << std::endl;
-                unsigned long long range = 4*1024*1024; 
+                unsigned long long range = 4*1024*1024;
                 std::vector<std::future<int>> task_list;
-                std::mutex mutex;
-                unsigned long long current = 0;
 
                 for(unsigned long long offset = 0; offset < length; offset += range)
                 {
@@ -648,74 +650,46 @@ namespace microsoft_azure {
                     {
                         range = length - offset;
                     }
-                    
+
+                    while(task_list.size() > downloaders)
                     {
-                        while(task_list.size() > m_concurrency)
+                        for(auto iter = task_list.begin(); iter != task_list.end() && task_list.size() > downloaders;)
                         {
-                            for(auto iter = task_list.begin(); iter != task_list.end() && task_list.size() > m_concurrency; )
-                            {
-                                iter->wait();
-                                iter = task_list.erase(iter);
+                            iter->wait();
+                            auto result = iter->get();
+                            if (0 != result) {
+                                errcode = result;
                             }
+                            iter = task_list.erase(iter);
                         }
                     }
-                    auto single_download = std::async(std::launch::async, [offset, range, this, &destPath, &current, &ofs_mutex, &mutex, &cv_mutex, &cv, &writeCV, &parallel, &container, &blob](){
-                        {
-                            std::unique_lock<std::mutex> lk(cv_mutex);
-                            cv.wait(lk, [&parallel, &mutex]() {
-                                std::lock_guard<std::mutex> lock(mutex);
-                                if(parallel > 0)
-                                {
-                                    --parallel;
-                                    //std::cout << "parallel: " << parallel << std::endl;
-                                    return true;
-                                }
-                                return false;
-                            });
-                        }
-                        char* buffer = new char[range];
+
+                    if (0 != errcode) {
+                        break;
+                    }
+
+                    auto single_download = std::async(std::launch::async, [offset, range, this, &destPath, &container, &blob](){
+                        std::vector<char> buffer(range);
                         std::ostringstream os;
-                        os.rdbuf()->pubsetbuf(buffer, range);
+                        os.rdbuf()->pubsetbuf(&buffer[0], range);
 
                         download_blob_to_stream(container, blob, offset, range, os);
-
-                        {
-                            std::unique_lock<std::mutex> lk(ofs_mutex);
-                            writeCV.wait(lk, [&current, offset]() { 
-                                //std::cout << "offset: " << offset << std::endl;
-                                return current >= offset; });
-                            //if((unsigned long long)ofs.tellp() != offset)
-                            //{
-                            //    ofs.seekp(offset, std::ios_base::beg);
-                            //}
-                            std::ofstream ofs;
-                            if(offset == 0)
-                            {
-                                ofs.open(destPath, std::ofstream::out);
-                            }
-                            else
-                            {
-                                ofs.open(destPath, std::ofstream::out | std::ofstream::app);
-                            }
-                            ofs.write(os.str().c_str(), range);
-                            ofs.close();
-                            delete[] buffer;
-
-                            if(offset + range > current)
-                            {
-                                current = offset + range;
-                            }
-                            //std::cout << "current: " << current << std::endl;
-                            writeCV.notify_all();
+                        if (errno != 0) {
+                            return errno;
                         }
-
-                        {
-                            std::lock_guard<std::mutex> lock(mutex);
-                            ++parallel;
-                            //std::cout << "parallel done: " << parallel << std::endl;
-                            cv.notify_one();
+                        auto fd = open(destPath.c_str(), O_WRONLY);
+                        if (-1 == fd) {
+                            return errno;
                         }
-                        return errno;
+                        auto r = pwrite(fd, os.str().c_str(), range, offset);
+                        while (r != static_cast<ssize_t>(range) && r != -1) {
+                            r = pwrite(fd, os.str().c_str(), range, offset);
+                        }
+                        close(fd);
+                        if (-1 == r) {
+                            return errno;
+                        }
+                        return 0;
                     });
                     task_list.push_back(std::move(single_download));
                 }
@@ -723,8 +697,12 @@ namespace microsoft_azure {
                 for(size_t i = 0; i < task_list.size(); ++i)
                 {
                     task_list[i].wait();
+                    auto result = task_list[i].get();
+                    if (0 != result) {
+                        errcode = result;
+                    }
                 }
-                //std::cout << "End" << std::endl;
+                errno = errcode;
             }
             catch(std::exception ex)
             {
@@ -824,14 +802,14 @@ namespace microsoft_azure {
 
         void blob_client_wrapper::start_copy(const std::string &sourceContainer, const std::string &sourceBlob, const std::string &destContainer, const std::string &destBlob)
         {
-            
+
             if(!is_valid())
             {
                 errno = client_not_init;
                 return;
             }
             if(sourceContainer.length() == 0 || sourceBlob.length() == 0 ||
-                destContainer.length() == 0 || destBlob.length() == 0) 
+                destContainer.length() == 0 || destBlob.length() == 0)
             {
                 errno = invalid_parameters;
                 return;

--- a/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
@@ -640,6 +640,7 @@ namespace microsoft_azure {
                     close(fd);
                     return;
                 }
+                close(fd);
 
                 unsigned long long range = 4*1024*1024;
                 std::vector<std::future<int>> task_list;


### PR DESCRIPTION
1. Simplified by removing unnecessary synchronization mechanisms
2. Added errors handling

Future steps:
1. Optimize - make a range request and get size from content-range  instead of making get_block_property call
2. Fix for race  conditions between files upload and download