### PR TITLE
Httpsfix2

### DIFF
--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -120,8 +120,16 @@ int read_config(std::string configFile)
 
 void *azs_init(struct fuse_conn_info * conn)
 {
-    /*cfg->kernel_cache = 1;
+    azure_blob_client_wrapper = std::make_shared<blob_client_wrapper>(blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, 20, str_options.use_https));
+    if(errno != 0)
+    {
+        fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);
+        // TODO: Improve this error case
+        return NULL;
+    }
+    /*
     cfg->attr_timeout = 360;
+    cfg->kernel_cache = 1;
     cfg->entry_timeout = 120;
     cfg->negative_timeout = 120;
     */
@@ -198,13 +206,13 @@ int main(int argc, char *argv[])
     std::string tmpPathStr(options.tmp_path);
     str_options.tmpPath = tmpPathStr;
     const int defaultMaxConcurrency = 20;
-    bool use_https = false;
+    str_options.use_https = false;
     if (options.use_https != NULL)
     {
         std::string https(options.use_https);
         if (https == "true")
         {
-            use_https = true;
+            str_options.use_https = true;
         }
     }
 
@@ -217,7 +225,8 @@ int main(int argc, char *argv[])
         return 1; 
     }
 
-    azure_blob_client_wrapper = std::make_shared<blob_client_wrapper>(blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, use_https));
+{
+    blob_client_wrapper temp_azure_blob_client_wrapper = blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, str_options.use_https);
     if(errno != 0)
     {
         fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);
@@ -225,13 +234,13 @@ int main(int argc, char *argv[])
     }
 
     // Check if the account name/key and container is correct.
-    if(azure_blob_client_wrapper->container_exists(str_options.containerName) == false
+    if(temp_azure_blob_client_wrapper.container_exists(str_options.containerName) == false
             || errno != 0)
     {
         fprintf(stderr, "Failed to connect to the storage container. There might be something wrong about the storage config, please double check the storage account name, account key and container name. errno = %d\n", errno);
         return 1;
     }
-
+}
     fuse_opt_add_arg(&args, "-omax_read=131072");
     fuse_opt_add_arg(&args, "-omax_write=131072");
     if(0 != ensure_files_directory_exists_in_cache(prepend_mnt_path_string("/placeholder")))

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -225,22 +225,27 @@ int main(int argc, char *argv[])
         return 1; 
     }
 
-{
-    blob_client_wrapper temp_azure_blob_client_wrapper = blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, str_options.use_https);
-    if(errno != 0)
+    // THe current implementation of blob_client_wrapper calls curl_global_init() in the constructor, and curl_global_cleanup in the destructor.
+    // Unfortunately, curl_global_init() has to be called in the same process as any HTTPS calls that are made, otherwise NSS is not configured properly.
+    // When running in daemon mode, the current process forks() and exits, while the child process lives on as a daemon.
+    // So, here we create and destroy a temp blob client in order to test the connection info, and we create the real one in azs_init, which is called after the fork().
     {
-        fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);
-        return 1;
+        blob_client_wrapper temp_azure_blob_client_wrapper = blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, str_options.use_https);
+        if(errno != 0)
+        {
+            fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);
+            return 1;
+        }
+
+        // Check if the account name/key and container is correct.
+        if(temp_azure_blob_client_wrapper.container_exists(str_options.containerName) == false
+                || errno != 0)
+        {
+            fprintf(stderr, "Failed to connect to the storage container. There might be something wrong about the storage config, please double check the storage account name, account key and container name. errno = %d\n", errno);
+            return 1;
+        }
     }
 
-    // Check if the account name/key and container is correct.
-    if(temp_azure_blob_client_wrapper.container_exists(str_options.containerName) == false
-            || errno != 0)
-    {
-        fprintf(stderr, "Failed to connect to the storage container. There might be something wrong about the storage config, please double check the storage account name, account key and container name. errno = %d\n", errno);
-        return 1;
-    }
-}
     fuse_opt_add_arg(&args, "-omax_read=131072");
     fuse_opt_add_arg(&args, "-omax_write=131072");
     if(0 != ensure_files_directory_exists_in_cache(prepend_mnt_path_string("/placeholder")))

--- a/blobfuse/blobfuse.h
+++ b/blobfuse/blobfuse.h
@@ -67,6 +67,7 @@ struct str_options
     std::string accountKey;
     std::string containerName;
     std::string tmpPath;
+    bool use_https;
 };
 
 extern struct str_options str_options;


### PR DESCRIPTION
Changing the creation of the azure_blob_client_wrapper to be in azs_init(), instead of main().  This causes curl_global_init() to be called in the correct process, fixing errors we're seeing when using HTTPS in daemon mode.  This replaces a prior PR, https://github.com/Azure/azure-storage-fuse/pull/39 - due to the concern about unintended consequences of doing the NSS initialization in a separate process as making the HTTPS requests.