### PR TITLE
Remove the traiiling slash in tmp_path

### DIFF
--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -271,7 +271,13 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    // remove last trailing slash in tmo_path
     std::string tmpPathStr(options.tmp_path);
+    if (!tmpPathStr.empty() && tmpPathStr[tmpPathStr.size() - 1] == '/')
+    {
+        tmpPathStr.erase(tmpPathStr.size() - 1);
+    }
+    
     str_options.tmpPath = tmpPathStr;
     const int defaultMaxConcurrency = 20;
     str_options.use_https = true;


### PR DESCRIPTION
Fixes #66.
Normalizing tmp_path string in blobfuse.cpp so we don't need to check for a trailing slash all the time.