### PR TITLE
Support for non-public clouds

### DIFF
--- a/azure-storage-cpp-lite/include/blob/blob_client.h
+++ b/azure-storage-cpp-lite/include/blob/blob_client.h
@@ -323,7 +323,8 @@ namespace microsoft_azure { namespace storage {
         /// <param name="account_name">The storage account name.</param>
         /// <param name="account_key">The storage account key.</param>
         /// <param name="concurrency">The maximum number requests could be executed in the same time.</param>
-        /// <param name="use_https">True if https should be used (instead of HTTP).  Note that this may cause a sizable perf loss, due to issues in libcurl.
+        /// <param name="use_https">True if https should be used (instead of HTTP).  Note that this may cause a sizable perf loss, due to issues in libcurl.</param>
+        /// <param name="account_uri">Storage account URI to allow non-public clouds as well as custom domains.</param>
         /// <returns>Return a <see cref="microsoft_azure::storage::blob_client_wrapper"> object.</returns>
         static blob_client_wrapper blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, bool use_https, const std::string &account_uri);
         /* C++ wrappers without exception but error codes instead */

--- a/azure-storage-cpp-lite/include/blob/blob_client.h
+++ b/azure-storage-cpp-lite/include/blob/blob_client.h
@@ -324,9 +324,9 @@ namespace microsoft_azure { namespace storage {
         /// <param name="account_key">The storage account key.</param>
         /// <param name="concurrency">The maximum number requests could be executed in the same time.</param>
         /// <param name="use_https">True if https should be used (instead of HTTP).  Note that this may cause a sizable perf loss, due to issues in libcurl.</param>
-        /// <param name="account_uri">Storage account URI to allow non-public clouds as well as custom domains.</param>
+        /// <param name="blob_endpoint">Blob endpoint URI to allow non-public clouds as well as custom domains.</param>
         /// <returns>Return a <see cref="microsoft_azure::storage::blob_client_wrapper"> object.</returns>
-        static blob_client_wrapper blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, bool use_https, const std::string &account_uri);
+        static blob_client_wrapper blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, bool use_https, const std::string &blob_endpoint);
         /* C++ wrappers without exception but error codes instead */
 
         /* container level*/

--- a/azure-storage-cpp-lite/include/blob/blob_client.h
+++ b/azure-storage-cpp-lite/include/blob/blob_client.h
@@ -325,7 +325,7 @@ namespace microsoft_azure { namespace storage {
         /// <param name="concurrency">The maximum number requests could be executed in the same time.</param>
         /// <param name="use_https">True if https should be used (instead of HTTP).  Note that this may cause a sizable perf loss, due to issues in libcurl.
         /// <returns>Return a <see cref="microsoft_azure::storage::blob_client_wrapper"> object.</returns>
-        static blob_client_wrapper blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, bool use_https);
+        static blob_client_wrapper blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, bool use_https, const std::string &account_uri);
         /* C++ wrappers without exception but error codes instead */
 
         /* container level*/

--- a/azure-storage-cpp-lite/include/storage_account.h
+++ b/azure-storage-cpp-lite/include/storage_account.h
@@ -20,7 +20,7 @@ namespace microsoft_azure {
                 file
             };
 
-            AZURE_STORAGE_API storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https = true, const std::string &account_uri = std::string());
+            AZURE_STORAGE_API storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https = true, const std::string &blob_endpoint = std::string());
 
             std::shared_ptr<storage_credential> credential() const {
                 return m_credential;

--- a/azure-storage-cpp-lite/include/storage_account.h
+++ b/azure-storage-cpp-lite/include/storage_account.h
@@ -20,7 +20,7 @@ namespace microsoft_azure {
                 file
             };
 
-            AZURE_STORAGE_API storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https = true, const std::string &domain_suffix = std::string());
+            AZURE_STORAGE_API storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https = true, const std::string &account_uri = std::string());
 
             std::shared_ptr<storage_credential> credential() const {
                 return m_credential;

--- a/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
@@ -118,11 +118,11 @@ namespace microsoft_azure {
 
         blob_client_wrapper blob_client_wrapper::blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency)
         {
-            return blob_client_wrapper_init(account_name, account_key, concurrency, false);
+            return blob_client_wrapper_init(account_name, account_key, concurrency, false, NULL);
         }
 
 
-        blob_client_wrapper blob_client_wrapper::blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, const bool use_https)
+        blob_client_wrapper blob_client_wrapper::blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, const bool use_https, const std::string &account_uri)
         {
             if(account_name.length() == 0 || account_key.length() == 0)
             {
@@ -142,7 +142,7 @@ namespace microsoft_azure {
             try
             {
                 std::shared_ptr<storage_credential>  cred = std::make_shared<shared_key_credential>(accountName, accountKey);
-                std::shared_ptr<storage_account> account = std::make_shared<storage_account>(accountName, cred, use_https);
+                std::shared_ptr<storage_account> account = std::make_shared<storage_account>(accountName, cred, use_https, account_uri);
                 std::shared_ptr<blob_client> blobClient= std::make_shared<microsoft_azure::storage::blob_client>(account, concurrency_limit);
                 errno = 0;
                 return blob_client_wrapper(blobClient);

--- a/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
@@ -122,7 +122,7 @@ namespace microsoft_azure {
         }
 
 
-        blob_client_wrapper blob_client_wrapper::blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, const bool use_https, const std::string &account_uri)
+        blob_client_wrapper blob_client_wrapper::blob_client_wrapper_init(const std::string &account_name, const std::string &account_key, const unsigned int concurrency, const bool use_https, const std::string &blob_endpoint)
         {
             if(account_name.length() == 0 || account_key.length() == 0)
             {
@@ -142,7 +142,7 @@ namespace microsoft_azure {
             try
             {
                 std::shared_ptr<storage_credential>  cred = std::make_shared<shared_key_credential>(accountName, accountKey);
-                std::shared_ptr<storage_account> account = std::make_shared<storage_account>(accountName, cred, use_https, account_uri);
+                std::shared_ptr<storage_account> account = std::make_shared<storage_account>(accountName, cred, use_https, blob_endpoint);
                 std::shared_ptr<blob_client> blobClient= std::make_shared<microsoft_azure::storage::blob_client>(account, concurrency_limit);
                 errno = 0;
                 return blob_client_wrapper(blobClient);

--- a/azure-storage-cpp-lite/src/storage_account.cpp
+++ b/azure-storage-cpp-lite/src/storage_account.cpp
@@ -5,7 +5,7 @@
 namespace microsoft_azure {
     namespace storage {
 
-        storage_account::storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https, const std::string &domain_suffix)
+        storage_account::storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https, const std::string &account_uri)
             : m_credential(credential) {
             if (use_https) {
                 append_all("https://");
@@ -14,18 +14,20 @@ namespace microsoft_azure {
                 append_all("http://");
             }
 
-            append_all(account_name);
+            if(account_uri.empty())
+            {
+                append_all(account_name);
 
-            m_blob_domain.append(".blob");
-            m_table_domain.append(".table");
-            m_queue_domain.append(".queue");
-            m_file_domain.append(".file");
+                m_blob_domain.append(".blob");
+                m_table_domain.append(".table");
+                m_queue_domain.append(".queue");
+                m_file_domain.append(".file");
 
-            if (!domain_suffix.empty()) {
-                append_all(domain_suffix);
-            }
-            else {
                 append_all(constants::default_endpoint_suffix);
+            }
+            else
+            {
+                append_all(account_uri);
             }
         }
 

--- a/azure-storage-cpp-lite/src/storage_account.cpp
+++ b/azure-storage-cpp-lite/src/storage_account.cpp
@@ -5,7 +5,8 @@
 namespace microsoft_azure {
     namespace storage {
 
-        storage_account::storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https, const std::string &account_uri)
+        // TODO: Clean up table queue and file services
+        storage_account::storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https, const std::string &blob_endpoint)
             : m_credential(credential) {
             if (use_https) {
                 append_all("https://");
@@ -14,7 +15,7 @@ namespace microsoft_azure {
                 append_all("http://");
             }
 
-            if(account_uri.empty())
+            if(blob_endpoint.empty())
             {
                 append_all(account_name);
 
@@ -27,7 +28,7 @@ namespace microsoft_azure {
             }
             else
             {
-                append_all(account_uri);
+                append_all(blob_endpoint);
             }
         }
 

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -137,6 +137,11 @@ int read_config(std::string configFile)
             str_options.containerName = containerNameStr;
 //            }
         }
+        else if(line.find("accountUri") != std::string::npos)
+        {
+            std::string accountUriStr(value);
+            str_options.accountUri = accountUriStr;
+        }
 
         data.clear();
     }
@@ -165,7 +170,7 @@ int read_config(std::string configFile)
 
 void *azs_init(struct fuse_conn_info * conn)
 {
-    azure_blob_client_wrapper = std::make_shared<blob_client_wrapper>(blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, 20, str_options.use_https));
+    azure_blob_client_wrapper = std::make_shared<blob_client_wrapper>(blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, 20, str_options.use_https, str_options.accountUri));
     if(errno != 0)
     {
         fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);
@@ -304,7 +309,7 @@ int main(int argc, char *argv[])
     // When running in daemon mode, the current process forks() and exits, while the child process lives on as a daemon.
     // So, here we create and destroy a temp blob client in order to test the connection info, and we create the real one in azs_init, which is called after the fork().
     {
-        blob_client_wrapper temp_azure_blob_client_wrapper = blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, str_options.use_https);
+        blob_client_wrapper temp_azure_blob_client_wrapper = blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, str_options.use_https, str_options.accountUri);
         if(errno != 0)
         {
             fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -137,10 +137,10 @@ int read_config(std::string configFile)
             str_options.containerName = containerNameStr;
 //            }
         }
-        else if(line.find("accountUri") != std::string::npos)
+        else if(line.find("blobEndpoint") != std::string::npos)
         {
-            std::string accountUriStr(value);
-            str_options.accountUri = accountUriStr;
+            std::string blobEndpointStr(value);
+            str_options.blobEndpoint = blobEndpointStr;
         }
 
         data.clear();
@@ -170,7 +170,7 @@ int read_config(std::string configFile)
 
 void *azs_init(struct fuse_conn_info * conn)
 {
-    azure_blob_client_wrapper = std::make_shared<blob_client_wrapper>(blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, 20, str_options.use_https, str_options.accountUri));
+    azure_blob_client_wrapper = std::make_shared<blob_client_wrapper>(blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, 20, str_options.use_https, str_options.blobEndpoint));
     if(errno != 0)
     {
         fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);
@@ -309,7 +309,7 @@ int main(int argc, char *argv[])
     // When running in daemon mode, the current process forks() and exits, while the child process lives on as a daemon.
     // So, here we create and destroy a temp blob client in order to test the connection info, and we create the real one in azs_init, which is called after the fork().
     {
-        blob_client_wrapper temp_azure_blob_client_wrapper = blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, str_options.use_https, str_options.accountUri);
+        blob_client_wrapper temp_azure_blob_client_wrapper = blob_client_wrapper::blob_client_wrapper_init(str_options.accountName, str_options.accountKey, defaultMaxConcurrency, str_options.use_https, str_options.blobEndpoint);
         if(errno != 0)
         {
             fprintf(stderr, "Creating blob client failed: errno = %d.\n", errno);

--- a/blobfuse/blobfuse.h
+++ b/blobfuse/blobfuse.h
@@ -110,7 +110,7 @@ struct fhwrapper
 struct str_options
 {
     std::string accountName;
-    std::string accountUri;
+    std::string blobEndpoint;
     std::string accountKey;
     std::string containerName;
     std::string tmpPath;

--- a/blobfuse/blobfuse.h
+++ b/blobfuse/blobfuse.h
@@ -110,6 +110,7 @@ struct fhwrapper
 struct str_options
 {
     std::string accountName;
+    std::string accountUri;
     std::string accountKey;
     std::string containerName;
     std::string tmpPath;


### PR DESCRIPTION
Issue #22 - Adds support for non-public clouds via the use of account URI from connection.cfg

Here is connection.cfg template:
```
accountName myaccount
accountKey mykey==
containerName mycontainer
blobEndpoint myaccount.blob.core.windows.net
```

