### PR TITLE
Correct attributes:uid, gid and modified time

### DIFF
--- a/azure-storage-cpp-lite/include/blob/blob_client.h
+++ b/azure-storage-cpp-lite/include/blob/blob_client.h
@@ -415,7 +415,7 @@ namespace microsoft_azure { namespace storage {
         /// <param name="destPath">The target file path.</param>
         /// <param name="parallel">A size_t value indicates the maximum parallelism can be used in this request.</param>
         /// <returns>A <see cref="storage_outcome" /> object that represents the properties (etag, last modified time and size) from the first chunk retrieved.</returns>
-        storage_outcome<chunk_property> download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, size_t parallel = 9);
+        void download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, chunk_property &returned_properties, size_t parallel = 9);
 
         /// <summary>
         /// Gets the property of a blob.

--- a/azure-storage-cpp-lite/include/blob/blob_client.h
+++ b/azure-storage-cpp-lite/include/blob/blob_client.h
@@ -414,7 +414,8 @@ namespace microsoft_azure { namespace storage {
         /// <param name="size">The size of the data to download from the blob, in bytes.</param>
         /// <param name="destPath">The target file path.</param>
         /// <param name="parallel">A size_t value indicates the maximum parallelism can be used in this request.</param>
-        void download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, size_t parallel = 9);
+        /// <returns>A <see cref="storage_outcome" /> object that represents the properties (etag, last modified time and size) from the first chunk retrieved.</returns>
+        storage_outcome<chunk_property> download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, size_t parallel = 9);
 
         /// <summary>
         /// Gets the property of a blob.

--- a/azure-storage-cpp-lite/include/blob/blob_client.h
+++ b/azure-storage-cpp-lite/include/blob/blob_client.h
@@ -415,7 +415,7 @@ namespace microsoft_azure { namespace storage {
         /// <param name="destPath">The target file path.</param>
         /// <param name="parallel">A size_t value indicates the maximum parallelism can be used in this request.</param>
         /// <returns>A <see cref="storage_outcome" /> object that represents the properties (etag, last modified time and size) from the first chunk retrieved.</returns>
-        void download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, blob_property &returned_properties, size_t parallel = 9);
+        void download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, time_t &returned_last_modified, size_t parallel = 9);
 
         /// <summary>
         /// Gets the property of a blob.

--- a/azure-storage-cpp-lite/include/blob/blob_client.h
+++ b/azure-storage-cpp-lite/include/blob/blob_client.h
@@ -415,7 +415,7 @@ namespace microsoft_azure { namespace storage {
         /// <param name="destPath">The target file path.</param>
         /// <param name="parallel">A size_t value indicates the maximum parallelism can be used in this request.</param>
         /// <returns>A <see cref="storage_outcome" /> object that represents the properties (etag, last modified time and size) from the first chunk retrieved.</returns>
-        void download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, chunk_property &returned_properties, size_t parallel = 9);
+        void download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, blob_property &returned_properties, size_t parallel = 9);
 
         /// <summary>
         /// Gets the property of a blob.

--- a/azure-storage-cpp-lite/include/constants.dat
+++ b/azure-storage-cpp-lite/include/constants.dat
@@ -49,6 +49,7 @@ DAT(header_if_match, "If-Match")
 DAT(header_if_modified_since, "If-Modified-Since")
 DAT(header_if_none_match, "If-None-Match")
 DAT(header_if_unmodified_since, "If-Unmodified-Since")
+DAT(header_last_modified, "Last-Modified")
 DAT(header_origin, "Origin")
 DAT(header_user_agent, "User-Agent")
 

--- a/azure-storage-cpp-lite/include/get_blob_property_request_base.h
+++ b/azure-storage-cpp-lite/include/get_blob_property_request_base.h
@@ -7,6 +7,7 @@
 #include "http_base.h"
 #include "storage_account.h"
 #include "storage_request_base.h"
+#include "get_blob_request_base.h"
 
 namespace microsoft_azure {
     namespace storage {
@@ -30,6 +31,14 @@ namespace microsoft_azure {
                 :last_modified{time(NULL)},
                 m_valid(valid)
             {
+            }
+
+            blob_property(const chunk_property property)
+                :m_valid(true)
+            {
+                last_modified = property.last_modified;
+                size = property.size;
+                etag = property.etag;
             }
 
             void set_valid(bool valid)

--- a/azure-storage-cpp-lite/include/get_blob_property_request_base.h
+++ b/azure-storage-cpp-lite/include/get_blob_property_request_base.h
@@ -51,7 +51,7 @@ namespace microsoft_azure {
             std::string etag;
             std::vector<std::pair<std::string, std::string>> metadata;
             std::string copy_status;
-            // utility::datetime m_last_modified;
+            time_t last_modified;
             // blob_type m_type;
             // azure::storage::lease_status m_lease_status;
             // azure::storage::lease_state m_lease_state;

--- a/azure-storage-cpp-lite/include/get_blob_property_request_base.h
+++ b/azure-storage-cpp-lite/include/get_blob_property_request_base.h
@@ -27,7 +27,8 @@ namespace microsoft_azure {
         {
         public:
             blob_property(bool valid)
-                :m_valid(valid)
+                :last_modified{time(NULL)},
+                m_valid(valid)
             {
             }
 

--- a/azure-storage-cpp-lite/include/get_blob_property_request_base.h
+++ b/azure-storage-cpp-lite/include/get_blob_property_request_base.h
@@ -33,14 +33,6 @@ namespace microsoft_azure {
             {
             }
 
-            blob_property(const chunk_property property)
-                :m_valid(true)
-            {
-                last_modified = property.last_modified;
-                size = property.size;
-                etag = property.etag;
-            }
-
             void set_valid(bool valid)
             {
                 m_valid = valid;

--- a/azure-storage-cpp-lite/include/get_blob_request_base.h
+++ b/azure-storage-cpp-lite/include/get_blob_request_base.h
@@ -32,12 +32,13 @@ namespace microsoft_azure {
         public:
             chunk_property()
                :totalSize{0},
-               size{0}
+               size{0} 
             {
             }
             long long totalSize;
             unsigned long long size;
             std::string etag;
+            time_t last_modified;
         };
     }
 }

--- a/azure-storage-cpp-lite/include/get_blob_request_base.h
+++ b/azure-storage-cpp-lite/include/get_blob_request_base.h
@@ -32,13 +32,14 @@ namespace microsoft_azure {
         public:
             chunk_property()
                :totalSize{0},
-               size{0} 
+               size{0},
+               last_modified{0} //returns 1970
             {
             }
             long long totalSize;
             unsigned long long size;
-            std::string etag;
             time_t last_modified;
+            std::string etag;
         };
     }
 }

--- a/azure-storage-cpp-lite/src/blob/blob_client.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client.cpp
@@ -22,6 +22,7 @@
 #include "executor.h"
 #include "utility.h"
 #include "tinyxml2_parser.h"
+#include <curl/curl.h>
 
 namespace microsoft_azure {
 namespace storage {
@@ -232,6 +233,7 @@ storage_outcome<blob_property> blob_client::get_blob_property(const std::string 
         blobProperty.content_type = http->get_header(constants::header_content_type);
         blobProperty.etag = http->get_header(constants::header_etag);
         blobProperty.copy_status = http->get_header(constants::header_ms_copy_status);
+        blobProperty.last_modified = curl_getdate(http->get_header(constants::header_last_modified).c_str(), NULL);
         std::string::size_type sz = 0;
         std::string contentLength = http->get_header(constants::header_content_length);
         if(contentLength.length() > 0)

--- a/azure-storage-cpp-lite/src/blob/blob_client.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client.cpp
@@ -65,6 +65,7 @@ storage_outcome<chunk_property> blob_client::get_chunk_to_stream_sync(const std:
         property.etag = http->get_header(constants::header_etag);
         property.totalSize = get_length_from_content_range(http->get_header(constants::header_content_range));
         std::istringstream(http->get_header(constants::header_content_length)) >> property.size;
+        property.last_modified = curl_getdate(http->get_header(constants::header_last_modified).c_str(), NULL);
         return storage_outcome<chunk_property>(property);
     }
     return storage_outcome<chunk_property>(storage_error(response.error()));

--- a/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
@@ -622,7 +622,7 @@ namespace microsoft_azure {
             }
         }
 
-        void blob_client_wrapper::download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, blob_property &returned_properties, size_t parallel)
+        void blob_client_wrapper::download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, time_t &returned_last_modified, size_t parallel)
         {
             if(!is_valid())
             {
@@ -725,7 +725,7 @@ namespace microsoft_azure {
                 return;
             }
 
-            returned_properties = (blob_property)firstChunk.response();
+            returned_last_modified = firstChunk.response().last_modified;
             return;
         }
 

--- a/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
@@ -622,7 +622,7 @@ namespace microsoft_azure {
             }
         }
 
-        void blob_client_wrapper::download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, chunk_property &properties, size_t parallel)
+        void blob_client_wrapper::download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, blob_property &returned_properties, size_t parallel)
         {
             if(!is_valid())
             {
@@ -725,7 +725,7 @@ namespace microsoft_azure {
                 return;
             }
 
-            properties = firstChunk.response();
+            returned_properties = (blob_property)firstChunk.response();
             return;
         }
 

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -26,6 +26,7 @@ struct options
 struct options options;
 struct str_options str_options;
 int file_cache_timeout_in_seconds;
+int default_permission;
 
 #define OPTION(t, p) { t, offsetof(struct options, p), 1 }
 const struct fuse_opt option_spec[] =
@@ -233,6 +234,16 @@ int main(int argc, char *argv[])
 
     // FUSE has a standard method of argument parsing, here we just follow the pattern.
     struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+
+    // Check for existence of allow_other flag and change the default permissions based on that
+    default_permission = 0770;
+    std::vector<std::string> string_args(argv, argv+argc);
+    for (size_t i = 1; i < string_args.size(); ++i) {
+      if (string_args[i].find("allow_other") != std::string::npos) {
+          default_permission = 0777; 
+      }
+    }
+
     int ret = 0;
     try
     {

--- a/blobfuse/blobfuse.h
+++ b/blobfuse/blobfuse.h
@@ -120,6 +120,8 @@ extern struct str_options str_options;
 
 extern int file_cache_timeout_in_seconds;
 
+extern int default_permission;
+
 // This is used to make all the calls to Storage
 // The C++ lite client does not store state, other than connection info, so we can use it between calls without issue.
 extern std::shared_ptr<blob_client_wrapper> azure_blob_client_wrapper;

--- a/blobfuse/directoryapis.cpp
+++ b/blobfuse/directoryapis.cpp
@@ -63,7 +63,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                 if (dir_ent->d_type == DT_DIR)
                 {
                     struct stat stbuf;
-                    stbuf.st_mode = S_IFDIR | 0770;
+                    stbuf.st_mode = S_IFDIR | default_permission;
                     stbuf.st_uid = fuse_get_context()->uid;
                     stbuf.st_gid = fuse_get_context()->gid;
                     stbuf.st_nlink = 2;
@@ -76,7 +76,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                     stat((mntPathString + dir_ent->d_name).c_str(), &buffer);
 
                     struct stat stbuf;
-                    stbuf.st_mode = S_IFREG | 0770; // Regular file (not a directory)
+                    stbuf.st_mode = S_IFREG | default_permission; // Regular file (not a directory)
                     stbuf.st_uid = fuse_get_context()->uid;
                     stbuf.st_gid = fuse_get_context()->gid;
                     stbuf.st_nlink = 1;
@@ -142,7 +142,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                     if ((prev_token_str.size() > 0) && (strcmp(prev_token_str.c_str(), directorySignifier.c_str()) != 0))
                     {
                         struct stat stbuf;
-                        stbuf.st_mode = S_IFREG | 0770; // Regular file (not a directory)
+                        stbuf.st_mode = S_IFREG | default_permission; // Regular file (not a directory)
                         stbuf.st_uid = fuse_get_context()->uid;
                         stbuf.st_gid = fuse_get_context()->gid;
                         stbuf.st_nlink = 1;
@@ -159,7 +159,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                     if (prev_token_str.size() > 0)
                     {
                         struct stat stbuf;
-                        stbuf.st_mode = S_IFDIR | 0770;
+                        stbuf.st_mode = S_IFDIR | default_permission;
                         stbuf.st_uid = fuse_get_context()->uid;
                         stbuf.st_gid = fuse_get_context()->gid;
                         stbuf.st_nlink = 2;

--- a/blobfuse/directoryapis.cpp
+++ b/blobfuse/directoryapis.cpp
@@ -64,6 +64,8 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                 {
                     struct stat stbuf;
                     stbuf.st_mode = S_IFDIR | 0770;
+                    stbuf.st_uid = fuse_get_context()->uid;
+                    stbuf.st_gid = fuse_get_context()->uid;
                     stbuf.st_nlink = 2;
                     stbuf.st_size = 4096;
                     filler(buf, dir_ent->d_name, &stbuf, 0);
@@ -75,6 +77,8 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
 
                     struct stat stbuf;
                     stbuf.st_mode = S_IFREG | 0770; // Regular file (not a directory)
+                    stbuf.st_uid = fuse_get_context()->uid;
+                    stbuf.st_gid = fuse_get_context()->uid;
                     stbuf.st_nlink = 1;
                     stbuf.st_size = buffer.st_size;
                     filler(buf, dir_ent->d_name, &stbuf, 0); // TODO: Add stat information.  Consider FUSE_FILL_DIR_PLUS.
@@ -139,6 +143,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                     {
                         struct stat stbuf;
                         stbuf.st_mode = S_IFREG | 0770; // Regular file (not a directory)
+                        stbuf.st_uid = fuse_get_context()->uid;
                         stbuf.st_nlink = 1;
                         stbuf.st_size = listResults[i].content_length;
                         fillerResult = filler(buf, prev_token_str.c_str(), &stbuf, 0); // TODO: Add stat information.  Consider FUSE_FILL_DIR_PLUS.
@@ -154,6 +159,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                     {
                         struct stat stbuf;
                         stbuf.st_mode = S_IFDIR | 0770;
+                        stbuf.st_uid = fuse_get_context()->uid;
                         stbuf.st_nlink = 2;
                         fillerResult = filler(buf, prev_token_str.c_str(), &stbuf, 0);
                         if (AZS_PRINT)

--- a/blobfuse/directoryapis.cpp
+++ b/blobfuse/directoryapis.cpp
@@ -65,7 +65,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                     struct stat stbuf;
                     stbuf.st_mode = S_IFDIR | 0770;
                     stbuf.st_uid = fuse_get_context()->uid;
-                    stbuf.st_gid = fuse_get_context()->uid;
+                    stbuf.st_gid = fuse_get_context()->gid;
                     stbuf.st_nlink = 2;
                     stbuf.st_size = 4096;
                     filler(buf, dir_ent->d_name, &stbuf, 0);
@@ -78,7 +78,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                     struct stat stbuf;
                     stbuf.st_mode = S_IFREG | 0770; // Regular file (not a directory)
                     stbuf.st_uid = fuse_get_context()->uid;
-                    stbuf.st_gid = fuse_get_context()->uid;
+                    stbuf.st_gid = fuse_get_context()->gid;
                     stbuf.st_nlink = 1;
                     stbuf.st_size = buffer.st_size;
                     filler(buf, dir_ent->d_name, &stbuf, 0); // TODO: Add stat information.  Consider FUSE_FILL_DIR_PLUS.
@@ -144,6 +144,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                         struct stat stbuf;
                         stbuf.st_mode = S_IFREG | 0770; // Regular file (not a directory)
                         stbuf.st_uid = fuse_get_context()->uid;
+                        stbuf.st_gid = fuse_get_context()->gid;
                         stbuf.st_nlink = 1;
                         stbuf.st_size = listResults[i].content_length;
                         fillerResult = filler(buf, prev_token_str.c_str(), &stbuf, 0); // TODO: Add stat information.  Consider FUSE_FILL_DIR_PLUS.
@@ -160,6 +161,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                         struct stat stbuf;
                         stbuf.st_mode = S_IFDIR | 0770;
                         stbuf.st_uid = fuse_get_context()->uid;
+                        stbuf.st_gid = fuse_get_context()->gid;
                         stbuf.st_nlink = 2;
                         fillerResult = filler(buf, prev_token_str.c_str(), &stbuf, 0);
                         if (AZS_PRINT)

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -162,9 +162,6 @@ int azs_open(const char *path, struct fuse_file_info *fi)
         }
     }
 
-    // TODO: Actual access control
-    fchmod(res, 0770);
-
     // Store the open file handle, and whether or not the file should be uploaded on close().
     // TODO: Optimize the scenario where the file is open for read/write, but no actual writing occurs, to not upload the blob.
     struct fhwrapper *fhwrap = new fhwrapper(res, (((fi->flags & O_WRONLY) == O_WRONLY) || ((fi->flags & O_RDWR) == O_RDWR)));
@@ -217,7 +214,8 @@ int azs_create(const char *path, mode_t mode, struct fuse_file_info *fi)
     ensure_files_directory_exists_in_cache(mntPathString);
 
     // FUSE will set the O_CREAT and O_WRONLY flags, but not O_EXCL, which is generally assumed for 'create' semantics.
-    res = open(mntPath, fi->flags | O_EXCL, mode);
+    // overwrite mode_t because user should always 770 permission until we have full ACL support
+    res = open(mntPath, fi->flags | O_EXCL, 0770);
     if (AZS_PRINT)
     {
         fprintf(stdout, "mntPath = %s, result = %d\n", mntPath, res);

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -109,8 +109,8 @@ int azs_open(const char *path, struct fuse_file_info *fi)
             }
 
             errno = 0;
-            blob_property properties = {false};
-            azure_blob_client_wrapper->download_blob_to_file(str_options.containerName, pathString.substr(1), mntPathString, properties);
+            time_t last_modified = {};
+            azure_blob_client_wrapper->download_blob_to_file(str_options.containerName, pathString.substr(1), mntPathString, last_modified);
             if (errno != 0)
             {
                 remove(mntPath);
@@ -119,7 +119,7 @@ int azs_open(const char *path, struct fuse_file_info *fi)
             
             // preserve the last modified time
             struct utimbuf new_time = {};
-            new_time.modtime = properties.last_modified;
+            new_time.modtime = last_modified;
             utime(mntPathString.c_str(), &new_time);
 
         }

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -109,7 +109,8 @@ int azs_open(const char *path, struct fuse_file_info *fi)
             }
 
             errno = 0;
-            auto outcome = azure_blob_client_wrapper->download_blob_to_file(str_options.containerName, pathString.substr(1), mntPathString);
+            chunk_property properties;
+            azure_blob_client_wrapper->download_blob_to_file(str_options.containerName, pathString.substr(1), mntPathString, properties);
             if (errno != 0)
             {
                 remove(mntPath);
@@ -117,8 +118,8 @@ int azs_open(const char *path, struct fuse_file_info *fi)
             }
             
             // preserve the last modified time
-            struct utimbuf new_time;
-            new_time.modtime = outcome.response().last_modified;
+            struct utimbuf new_time = {};
+            new_time.modtime = properties.last_modified;
             utime(mntPathString.c_str(), &new_time);
 
         }

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -109,7 +109,7 @@ int azs_open(const char *path, struct fuse_file_info *fi)
             }
 
             errno = 0;
-            chunk_property properties;
+            blob_property properties = {false};
             azure_blob_client_wrapper->download_blob_to_file(str_options.containerName, pathString.substr(1), mntPathString, properties);
             if (errno != 0)
             {

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -109,12 +109,18 @@ int azs_open(const char *path, struct fuse_file_info *fi)
             }
 
             errno = 0;
-            azure_blob_client_wrapper->download_blob_to_file(str_options.containerName, pathString.substr(1), mntPathString);
+            auto outcome = azure_blob_client_wrapper->download_blob_to_file(str_options.containerName, pathString.substr(1), mntPathString);
             if (errno != 0)
             {
                 remove(mntPath);
                 return 0 - map_errno(errno);
             }
+            
+            // preserve the last modified time
+            struct utimbuf new_time;
+            new_time.modtime = outcome.response().last_modified;
+            utime(mntPathString.c_str(), &new_time);
+
         }
     }
 

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -162,6 +162,9 @@ int azs_open(const char *path, struct fuse_file_info *fi)
         }
     }
 
+    // TODO: Actual access control
+    fchmod(res, 0770);
+
     // Store the open file handle, and whether or not the file should be uploaded on close().
     // TODO: Optimize the scenario where the file is open for read/write, but no actual writing occurs, to not upload the blob.
     struct fhwrapper *fhwrap = new fhwrapper(res, (((fi->flags & O_WRONLY) == O_WRONLY) || ((fi->flags & O_RDWR) == O_RDWR)));

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -170,7 +170,7 @@ int azs_open(const char *path, struct fuse_file_info *fi)
     }
 
     // TODO: Actual access control
-    fchmod(res, 0770);
+    fchmod(res, default_permission);
 
     // Store the open file handle, and whether or not the file should be uploaded on close().
     // TODO: Optimize the scenario where the file is open for read/write, but no actual writing occurs, to not upload the blob.
@@ -224,8 +224,7 @@ int azs_create(const char *path, mode_t mode, struct fuse_file_info *fi)
     ensure_files_directory_exists_in_cache(mntPathString);
 
     // FUSE will set the O_CREAT and O_WRONLY flags, but not O_EXCL, which is generally assumed for 'create' semantics.
-    // overwrite mode_t because user should always 770 permission until we have full ACL support
-    res = open(mntPath, fi->flags | O_EXCL, 0770);
+    res = open(mntPath, fi->flags | O_EXCL, default_permission);
     if (AZS_PRINT)
     {
         fprintf(stdout, "mntPath = %s, result = %d\n", mntPath, res);

--- a/blobfuse/tests.py
+++ b/blobfuse/tests.py
@@ -1095,6 +1095,52 @@ class TestFuse(unittest.TestCase):
         os.write(fd, data.encode())
         os.close(fd)
 
+    def test_file_owner_timestamp(self):
+        testFileName = "testUserAndTime"
+        testFilePath = os.path.join(self.blobstage, testFileName)
+
+        fd = os.open(testFilePath, os.O_CREAT | os.O_RDONLY)
+        testData = "random data"
+        self.write_file_func(testFilePath, testData)
+        os.close(fd)
+
+        # This verifies the getattr from the local cache
+        fileowner = os.stat(testFilePath).st_uid
+        filegroup = os.stat(testFilePath).st_gid
+        time_of_upload = os.stat(testFilePath).st_mtime
+
+        self.assertEqual(fileowner, os.getuid())
+        self.assertEqual(filegroup, os.getgid()) 
+
+        # This removes the cached entries of the files just created, so they are on the service but not local.
+        shutil.rmtree(self.cachedir + '/root/testing/')
+        time.sleep(1)
+
+        # check whether getattr from the service is working
+        fileowner = os.stat(testFilePath).st_uid
+        filegroup = os.stat(testFilePath).st_gid
+        blob_last_modified = os.stat(testFilePath).st_mtime
+
+        self.assertEqual(fileowner, os.getuid())
+        self.assertEqual(filegroup, os.getgid())
+        self.assertEqual(time_of_upload, blob_last_modified)
+
+        # prime the cache and check the attributes again
+        fd = os.open(testFilePath, os.O_RDONLY)
+
+        # check whether getattr from the cache is working
+        fileowner = os.stat(testFilePath).st_uid
+        filegroup = os.stat(testFilePath).st_gid
+        file_last_modified = os.stat(testFilePath).st_mtime
+
+        self.assertEqual(fileowner, os.getuid())
+        self.assertEqual(filegroup, os.getgid())
+        self.assertEqual(time_of_upload, file_last_modified)
+        
+        os.close(fd)
+        os.remove(testFilePath)
+
+
     def test_file_simultaneous_write(self):
         testFileName = "testFile"
         testFilePath = os.path.join(self.blobstage, testFileName)

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -303,8 +303,11 @@ int azs_getattr(const char *path, struct stat *stbuf)
     if (strlen(path) == 1)
     {
         stbuf->st_mode = S_IFDIR | 0770; // TODO: proper access control.
+        stbuf->st_uid = fuse_get_context()->uid;
+        stbuf->st_gid = fuse_get_context()->uid;
         stbuf->st_nlink = 2; // Directories should have a hard-link count of 2 + (# child directories).  We don't have that count, though, so we jsut use 2 for now.  TODO: Evaluate if we could keep this accurate or not.
         stbuf->st_size = 4096;
+        stbuf->st_mtime = time(NULL);
         return 0;
     }
 
@@ -347,6 +350,9 @@ int azs_getattr(const char *path, struct stat *stbuf)
             fprintf(stdout, "Blob found!  Name = %s\n", path);
         }
         stbuf->st_mode = S_IFREG | 0770; // Regular file (not a directory)
+        stbuf->st_uid = fuse_get_context()->uid;
+        stbuf->st_gid = fuse_get_context()->uid;
+        stbuf->st_mtime = blob_property.last_modified;
         stbuf->st_nlink = 1;
         stbuf->st_size = blob_property.size;
         return 0;
@@ -376,7 +382,10 @@ int azs_getattr(const char *path, struct stat *stbuf)
             stbuf->st_mode = S_IFDIR | 0770;
             // If st_nlink = 2, means direcotry is empty.
             // Directory size will affect behaviour for mv, rmdir, cp etc.
+            stbuf->st_uid = fuse_get_context()->uid;
+            stbuf->st_gid = fuse_get_context()->uid;
             stbuf->st_nlink = dirSize == D_EMPTY ? 2 : 3;
+            stbuf->st_mtime = time(NULL);
             stbuf->st_size = 4096;
             return 0;
         }

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -385,7 +385,6 @@ int azs_getattr(const char *path, struct stat *stbuf)
             stbuf->st_uid = fuse_get_context()->uid;
             stbuf->st_gid = fuse_get_context()->gid;
             stbuf->st_nlink = dirSize == D_EMPTY ? 2 : 3;
-            stbuf->st_mtime = time(NULL);
             stbuf->st_size = 4096;
             return 0;
         }

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -304,7 +304,7 @@ int azs_getattr(const char *path, struct stat *stbuf)
     {
         stbuf->st_mode = S_IFDIR | 0770; // TODO: proper access control.
         stbuf->st_uid = fuse_get_context()->uid;
-        stbuf->st_gid = fuse_get_context()->uid;
+        stbuf->st_gid = fuse_get_context()->gid;
         stbuf->st_nlink = 2; // Directories should have a hard-link count of 2 + (# child directories).  We don't have that count, though, so we jsut use 2 for now.  TODO: Evaluate if we could keep this accurate or not.
         stbuf->st_size = 4096;
         stbuf->st_mtime = time(NULL);
@@ -351,7 +351,7 @@ int azs_getattr(const char *path, struct stat *stbuf)
         }
         stbuf->st_mode = S_IFREG | 0770; // Regular file (not a directory)
         stbuf->st_uid = fuse_get_context()->uid;
-        stbuf->st_gid = fuse_get_context()->uid;
+        stbuf->st_gid = fuse_get_context()->gid;
         stbuf->st_mtime = blob_property.last_modified;
         stbuf->st_nlink = 1;
         stbuf->st_size = blob_property.size;
@@ -383,7 +383,7 @@ int azs_getattr(const char *path, struct stat *stbuf)
             // If st_nlink = 2, means direcotry is empty.
             // Directory size will affect behaviour for mv, rmdir, cp etc.
             stbuf->st_uid = fuse_get_context()->uid;
-            stbuf->st_gid = fuse_get_context()->uid;
+            stbuf->st_gid = fuse_get_context()->gid;
             stbuf->st_nlink = dirSize == D_EMPTY ? 2 : 3;
             stbuf->st_mtime = time(NULL);
             stbuf->st_size = 4096;

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -160,7 +160,7 @@ int ensure_files_directory_exists_in_cache(const std::string file_path)
             struct stat st;
             if (stat(copypath, &st) != 0)
             {
-                status = mkdir(copypath, 0770);
+                status = mkdir(copypath, default_permission);
             }
 
             // Ignore if some other thread was successful creating the path
@@ -302,7 +302,7 @@ int azs_getattr(const char *path, struct stat *stbuf)
     // If we're at the root, we know it's a directory
     if (strlen(path) == 1)
     {
-        stbuf->st_mode = S_IFDIR | 0770; // TODO: proper access control.
+        stbuf->st_mode = S_IFDIR | default_permission; // TODO: proper access control.
         stbuf->st_uid = fuse_get_context()->uid;
         stbuf->st_gid = fuse_get_context()->gid;
         stbuf->st_nlink = 2; // Directories should have a hard-link count of 2 + (# child directories).  We don't have that count, though, so we jsut use 2 for now.  TODO: Evaluate if we could keep this accurate or not.
@@ -349,7 +349,7 @@ int azs_getattr(const char *path, struct stat *stbuf)
         {
             fprintf(stdout, "Blob found!  Name = %s\n", path);
         }
-        stbuf->st_mode = S_IFREG | 0770; // Regular file (not a directory)
+        stbuf->st_mode = S_IFREG | default_permission; // Regular file (not a directory)
         stbuf->st_uid = fuse_get_context()->uid;
         stbuf->st_gid = fuse_get_context()->gid;
         stbuf->st_mtime = blob_property.last_modified;
@@ -379,7 +379,7 @@ int azs_getattr(const char *path, struct stat *stbuf)
             {
                 fprintf(stdout, "Directory %s found with return value: %d!\n", blobNameStr.c_str(), dirSize);
             }
-            stbuf->st_mode = S_IFDIR | 0770;
+            stbuf->st_mode = S_IFDIR | default_permission;
             // If st_nlink = 2, means direcotry is empty.
             // Directory size will affect behaviour for mv, rmdir, cp etc.
             stbuf->st_uid = fuse_get_context()->uid;


### PR DESCRIPTION
Addresses #95, #98, #99 

One caveat is that directory timestamps show the listing time (`now`) since there is no support for dirs in blob storage.