### PR TITLE
Exponential retries

### DIFF
--- a/azure-storage-cpp-lite/include/retry.h
+++ b/azure-storage-cpp-lite/include/retry.h
@@ -67,8 +67,10 @@ namespace microsoft_azure {
             retry_info evaluate(const retry_context &context) const override {
                 if (context.numbers() == 0) {
                     return retry_info(true, std::chrono::seconds(0));
-                } else if (context.numbers() < 100 && can_retry(context.result())) {
-                    return retry_info(true, std::chrono::seconds(5+rand()%5));
+                } else if (context.numbers() < 300 && can_retry(context.result())) {
+                    double delay = (pow(2, context.numbers()-1)-1) * 4;
+                    delay *= (((double)rand())/RAND_MAX)/2 + 0.8;
+                    return retry_info(true, std::chrono::seconds((int)delay));
                 }
                 return retry_info(false, std::chrono::seconds(0));
             }

--- a/azure-storage-cpp-lite/include/retry.h
+++ b/azure-storage-cpp-lite/include/retry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <algorithm>
 
 #include "storage_EXPORTS.h"
 
@@ -67,9 +68,10 @@ namespace microsoft_azure {
             retry_info evaluate(const retry_context &context) const override {
                 if (context.numbers() == 0) {
                     return retry_info(true, std::chrono::seconds(0));
-                } else if (context.numbers() < 300 && can_retry(context.result())) {
-                    double delay = (pow(2, context.numbers()-1)-1) * 4;
+                } else if (context.numbers() < 60 && can_retry(context.result())) {
+                    double delay = (pow(2, context.numbers()-1)-1);
                     delay *= (((double)rand())/RAND_MAX)/2 + 0.8;
+                    delay = std::min(delay, 60.0); // Maximum backoff delay of 1 minute
                     return retry_info(true, std::chrono::seconds((int)delay));
                 }
                 return retry_info(false, std::chrono::seconds(0));

--- a/azure-storage-cpp-lite/include/retry.h
+++ b/azure-storage-cpp-lite/include/retry.h
@@ -68,10 +68,10 @@ namespace microsoft_azure {
             retry_info evaluate(const retry_context &context) const override {
                 if (context.numbers() == 0) {
                     return retry_info(true, std::chrono::seconds(0));
-                } else if (context.numbers() < 60 && can_retry(context.result())) {
-                    double delay = (pow(2, context.numbers()-1)-1);
-                    delay *= (((double)rand())/RAND_MAX)/2 + 0.8;
+                } else if (context.numbers() < 26 && can_retry(context.result())) {
+                    double delay = (pow(1.2, context.numbers()-1)-1);
                     delay = std::min(delay, 60.0); // Maximum backoff delay of 1 minute
+                    delay *= (((double)rand())/RAND_MAX)/2 + 0.75;
                     return retry_info(true, std::chrono::seconds((int)delay));
                 }
                 return retry_info(false, std::chrono::seconds(0));


### PR DESCRIPTION
With a max delay of 60s. All retries and delays included, a single operation should max out at about an hour.