### PR TITLE
linking uuid library at client target level for standalone build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(UNIX)
   add_definitions(-D_FILE_OFFSET_BITS=64)
   set(WARNING "-Wall -Wextra -Werror -pedantic -pedantic-errors")
   set(CMAKE_CXX_FLAGS "${CMAKE_THREAD_LIBS_INIT} ${WARNING} ${CMAKE_CXX_FLAGS}")
-  include_directories(${CMAKE_SOURCE_DIR}/blobfuse ${CMAKE_SOURCE_DIR}/azure-storage-cpp-lite/include ${CURL_INCLUDE_DIRS} ${GNUTLS_INCLUDE_DIR})
+  include_directories(${CMAKE_SOURCE_DIR}/blobfuse ${CMAKE_SOURCE_DIR}/azure-storage-cpp-lite/include ${CURL_INCLUDE_DIRS} ${GNUTLS_INCLUDE_DIR} ${UUID_INCLUDE_DIR})
 
   set(CMAKE_MACOSX_RPATH ON)
 

--- a/azure-storage-cpp-lite/CMakeLists.txt
+++ b/azure-storage-cpp-lite/CMakeLists.txt
@@ -116,6 +116,7 @@ else(MSVC)
   find_package(Threads REQUIRED)
   find_package(CURL REQUIRED)
   find_package(OpenSSL REQUIRED)
+  pkg_search_module(UUID REQUIRED uuid)
 
   if (NOT ${USE_OPENSSL})
     find_package(GnuTLS REQUIRED)
@@ -137,7 +138,7 @@ add_library(azure-storage SHARED ${AZURE_STORAGE_HEADER} ${AZURE_STORAGE_SOURCE}
 if(MSVC)
   target_link_libraries(azure-storage bcrypt libcurl)
 else(MSVC)
-  target_link_libraries(azure-storage ${CURL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY} ${EXTRA_LIBRARIES})
+  target_link_libraries(azure-storage ${CURL_LIBRARIES} ${UUID_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY} ${EXTRA_LIBRARIES})
 endif(MSVC)
 
 add_subdirectory(sample)

--- a/azure-storage-cpp-lite/CMakeLists.txt
+++ b/azure-storage-cpp-lite/CMakeLists.txt
@@ -129,7 +129,7 @@ else(MSVC)
   add_definitions(-std=c++11)
   set(WARNING "-Wall -Wextra -Werror -pedantic -pedantic-errors")
   set(CMAKE_CXX_FLAGS "${CMAKE_THREAD_LIBS_INIT} ${WARNING} ${CMAKE_CXX_FLAGS}")
-  include_directories(${CMAKE_SOURCE_DIR}/include ${CURL_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR} ${EXTRA_INCLUDE})
+  include_directories(${CMAKE_SOURCE_DIR}/include ${CURL_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR} ${UUID_INCLUDE_DIR} ${EXTRA_INCLUDE})
 endif(MSVC)
 
 set(CMAKE_MACOSX_RPATH ON)


### PR DESCRIPTION
Had already looked at standalone build of azure-storage-cpp-lite in #183 but found uuid dependency wasn't included at this level so would fail to build this target on ubuntu