### PR TITLE
Adding ability to use OAuth access token as credential to storage library

### DIFF
--- a/azure-storage-cpp-lite/include/storage_credential.h
+++ b/azure-storage-cpp-lite/include/storage_credential.h
@@ -75,6 +75,8 @@ namespace microsoft_azure {
                 return m_token;
             }
 
+            void set_token(const std::string& token);
+
         private:
             std::string m_token;
         };

--- a/azure-storage-cpp-lite/include/storage_credential.h
+++ b/azure-storage-cpp-lite/include/storage_credential.h
@@ -65,5 +65,19 @@ namespace microsoft_azure {
             void sign_request(const storage_request_base &, http_base &, const storage_url &, const storage_headers &) const override {}
         };
 
+        class token_credential : public storage_credential {
+        public:
+            AZURE_STORAGE_API token_credential(const std::string &token);
+
+            void sign_request(const storage_request_base &, http_base &, const storage_url &, const storage_headers &) const override;
+
+            const std::string &token() const {
+                return m_token;
+            }
+
+        private:
+            std::string m_token;
+        };
+
     }
 }

--- a/azure-storage-cpp-lite/src/storage_credential.cpp
+++ b/azure-storage-cpp-lite/src/storage_credential.cpp
@@ -80,5 +80,12 @@ namespace microsoft_azure {
             std::string transformed_url = transform_url(h.get_url());
             h.set_url(transformed_url);
         }
+
+        AZURE_STORAGE_API token_credential::token_credential(const std::string &token)
+            : m_token(token) {}
+
+        void token_credential::sign_request(const storage_request_base &, http_base &h, const storage_url &, const storage_headers &) const {
+            h.add_header(constants::header_authorization, "Bearer " + m_token);
+        }
     }
 }

--- a/azure-storage-cpp-lite/src/storage_credential.cpp
+++ b/azure-storage-cpp-lite/src/storage_credential.cpp
@@ -84,6 +84,10 @@ namespace microsoft_azure {
         AZURE_STORAGE_API token_credential::token_credential(const std::string &token)
             : m_token(token) {}
 
+        void token_credential::set_token(const std::string& token) {
+            m_token = token;
+        }
+
         void token_credential::sign_request(const storage_request_base &, http_base &h, const storage_url &, const storage_headers &) const {
             h.add_header(constants::header_authorization, "Bearer " + m_token);
         }


### PR DESCRIPTION
Adding [Azure Active Directory auth](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad) as a storage credential option. Similar naming convention to node and C# libraries that have a current implementation