### PR TITLE
Fix by value exception catching

### DIFF
--- a/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
+++ b/azure-storage-cpp-lite/src/blob/blob_client_wrapper.cpp
@@ -186,7 +186,7 @@ namespace microsoft_azure {
                     errno = 0;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in create_container.  ex.what() = %s, container = %s.", ex.what(), container.c_str());
                 errno = unknown_error;
@@ -222,7 +222,7 @@ namespace microsoft_azure {
                     errno = 0;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in delete_container.  ex.what() = %s, container = %s.", ex.what(), container.c_str());
                 errno = unknown_error;
@@ -259,7 +259,7 @@ namespace microsoft_azure {
                     return false;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in container_exists.  ex.what() = %s, container = %s.", ex.what(), container.c_str());
                 errno = unknown_error;
@@ -293,7 +293,7 @@ namespace microsoft_azure {
                 }
                 return result.response().containers;
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in list_containers.  ex.what() = %s, prefix = %s.", ex.what(), prefix.c_str());
                 errno = unknown_error;
@@ -333,7 +333,7 @@ namespace microsoft_azure {
                     return result.response();
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in list_blobs_hierarchial.  ex.what() = %s, container = %s, prefix = %s.", ex.what(), container.c_str(), prefix.c_str());
                 errno = unknown_error;
@@ -359,7 +359,7 @@ namespace microsoft_azure {
             {
                 ifs.open(sourcePath, std::ifstream::in);
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 // TODO open failed
                 syslog(LOG_ERR, "Failure to open the input stream in put_blob.  ex.what() = %s, sourcePath = %s.", ex.what(), sourcePath.c_str());
@@ -381,7 +381,7 @@ namespace microsoft_azure {
                     errno = 0;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Failure to upload the blob in put_blob.  ex.what() = %s, container = %s, blob = %s, sourcePath = %s.", ex.what(), container.c_str(), blob.c_str(), sourcePath.c_str());
                 errno = unknown_error;
@@ -391,7 +391,7 @@ namespace microsoft_azure {
             {
                 ifs.close();
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 // TODO close failed
                 syslog(LOG_ERR, "Failure to close the input stream in put_blob.  ex.what() = %s, container = %s, blob = %s, sourcePath = %s.", ex.what(), container.c_str(), blob.c_str(), sourcePath.c_str());
@@ -429,7 +429,7 @@ namespace microsoft_azure {
                     errno = 0;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in upload_block_blob_from_stream.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
                 errno = unknown_error;
@@ -643,7 +643,7 @@ namespace microsoft_azure {
                     errno = 0;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in download_blob_to_stream.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
                 errno = unknown_error;
@@ -750,7 +750,7 @@ namespace microsoft_azure {
                 }
                 errno = errcode;
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in download_blob_to_file.  ex.what() = %s, container = %s, blob = %s, destPath = %s.", ex.what(), container.c_str(), blob.c_str(), destPath.c_str());
                 errno = unknown_error;
@@ -783,7 +783,7 @@ namespace microsoft_azure {
                     return result.response();
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in get_blob_property.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
                 errno = unknown_error;
@@ -809,7 +809,7 @@ namespace microsoft_azure {
                 }
                 return false;
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in blob_exists.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
                 errno = unknown_error;
@@ -845,7 +845,7 @@ namespace microsoft_azure {
                     errno = 0;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in delete_blob.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
                 errno = unknown_error;
@@ -883,7 +883,7 @@ namespace microsoft_azure {
                     errno = 0;
                 }
             }
-            catch(std::exception ex)
+            catch(const std::exception &ex)
             {
                 syslog(LOG_ERR, "Unknown failure in start_copy.  ex.what() = %s, sourceContainer = %s, sourceBlob = %s, destContainer = %s, destBlob = %s.", ex.what(), sourceContainer.c_str(), sourceBlob.c_str(), destContainer.c_str(), destBlob.c_str());
                 errno = unknown_error;


### PR DESCRIPTION
Fix compilation error with GCC 8.2.1 :

> error: catching polymorphic type 'class std::exception' by value [-werror=catch-value=]

Compiled successfully after modification