### PR TITLE
Mount directory can be mounted to other filesystem bug fix

### DIFF
--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -679,7 +679,7 @@ void set_up_callbacks()
 }
 
 /*
- *  Check if the given directory is already mounted or not
+ *  Check if the given directory is already mounted for the mounttype fuse or not
  *  If mounted then re-mounting again shall fail.
  */ 
 bool is_directory_mounted(const char* mntDir) {
@@ -690,7 +690,7 @@ bool is_directory_mounted(const char* mntDir) {
      mnt_list = setmntent(_PATH_MOUNTED, "r");
      while ((mnt_ent = getmntent(mnt_list))) 
      {
-         if (!strcmp(mnt_ent->mnt_dir, mntDir)) 
+         if (!strcmp(mnt_ent->mnt_dir, mntDir) && !strcmp(mnt_ent->mnt_type, "fuse")) 
          {
              found = true;
              break;


### PR DESCRIPTION
This bug fix is for allowing non-fuse file systems to and blobfuse mount on the same directory.