### PR TITLE
Fix missing [Unit] section name

### DIFF
--- a/systemd/without-config-file/blobfuse.service
+++ b/systemd/without-config-file/blobfuse.service
@@ -1,3 +1,4 @@
+[Unit]
 Description=A virtual file system adapter for Azure Blob storage.
 After=network.target
 


### PR DESCRIPTION
According to [systemd docs](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options), `Description=` and `After=` settings should appear in the \[Unit\] section. Omitting section name leads to these log messages:
```
systemd[1]: /etc/systemd/system/blobfuse.service:1: Assignment outside of section. Ignoring.
systemd[1]: /etc/systemd/system/blobfuse.service:2: Assignment outside of section. Ignoring.
```