### PR TITLE
Update README.md with authType SPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
             - Client ID (Use this if you are using a custom MSI endpoint)
             - Object ID
             - Resource ID
+- Service Principal Name (`authType SPN`)
+    - Client ID
+    - Tenant ID
+    - Client Secret
 
 ### Environment variables
 
@@ -110,7 +114,7 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
 - General options
     * `accountName`: Specifies the storage account blobfuse targets.
     * `blobEndpoint`: Specifies the blob endpoint to use. Defaults to *.blob.core.windows.net, but is useful for targeting storage emulators.
-    * `authType`: Overrides the currently specified auth type. Options: Key, SAS, MSI (Using this option is only available for 1.2.0 or above)
+    * `authType`: Overrides the currently specified auth type. Options: Key, SAS, MSI, SPN (Using this option is only available for 1.2.0 or above)
     * `logLevel`: Specifies the logging level. Use to change the logging level dynamically. Read `Logging` section for details. For allowed values refer to `--log-level` command line option.
     * `accountType`: Specifies the type of account. Either `block` or `adls` can be specified, `block` is the default value. Same can also be controlled through the command line option `--use-adls=true`. If wrong account type is supplied, certain features may not work as expected. To learn more about ADLS follow the link `(https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction)`
 


### PR DESCRIPTION
I am proposing this change as the content didn't had any information on authType 'SPN' that we can use for Service Principal Authentication. The connection.cfg has details where it is mentioned that SPN should be used as authType. However, since README.md had no information provided on it, I have added those changes.