### PR TITLE
Rename in adls failing even after operation being sucessful

### DIFF
--- a/blobfuse-artifacts.yml
+++ b/blobfuse-artifacts.yml
@@ -480,16 +480,16 @@ stages:
           sudo ls -lRt $(Build.ArtifactStagingDirectory)
         displayName: "List the artifacts"
       
-      #- task: EsrpCodeSigning@1
-      #  inputs:
-      #    ConnectedServiceName: 'microsoft'
-      #    FolderPath: '$(Build.ArtifactStagingDirectory)/blobfuse/'
-      #    Pattern: '*.rpm'
-      #    CertificateId: '450779001'
-      #    OpusName: 'blobfuse'
-      #    SessionTimeout: '60'
-      #    MaxConcurrency: '50'
-      #    MaxRetryAttempts: '5'
+      - task: EsrpCodeSigning@1
+        inputs:
+          ConnectedServiceName: 'ESRP Code signing blobfuse'
+          FolderPath: '$(Build.ArtifactStagingDirectory)/blobfuse/*/'
+          Pattern: '*.rpm,*.deb'
+          signConfigType: 'inlineSignParams'
+          SessionTimeout: '60'
+          MaxConcurrency: '50'
+          MaxRetryAttempts: '5'
+          VerboseLogin: true'
 
       - task: GitHubRelease@1
         inputs:

--- a/blobfuse-artifacts.yml
+++ b/blobfuse-artifacts.yml
@@ -170,6 +170,11 @@ stages:
   - job: Set_3
     strategy:
       matrix:
+        RHEL-7.5:
+          DistroVer: "RHEL-7.5"
+          AgentName : "RHEL 7.5"
+          Description: "Red Hat Enterprise Linux 7.5"
+          SignRequired: 1
         RHEL-7.8:
           DistroVer: "RHEL-7.8"
           AgentName : "RHEL 7.8"

--- a/blobfuse-nightly.yml
+++ b/blobfuse-nightly.yml
@@ -361,7 +361,7 @@ jobs:
         sudo rm -rf $(TEMP_DIR)/*
         ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_GTEST)
         cd test
-        go test -v feature_test.go -args -mnt-path=$(MOUNT_DIR)
+        set -e && go test -v feature_test.go -args -mnt-path=$(MOUNT_DIR)
         cd -
       # condition: eq(variables['Build.SourceBranchName'], 'master')
       displayName: TEST - BLOCK FeatureTest
@@ -458,7 +458,7 @@ jobs:
         ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true
         pidof blobfuse
         cd test
-        go test -v feature_test.go -args -mnt-path=$(MOUNT_DIR) -adls=true
+        set -e && go test -v feature_test.go -args -mnt-path=$(MOUNT_DIR) -adls=true
         cd -
       # condition: eq(variables['Build.SourceBranchName'], 'master')
       displayName: TEST - ADLS FeatureTest

--- a/blobfuse/include/DataLakeBfsClient.h
+++ b/blobfuse/include/DataLakeBfsClient.h
@@ -89,7 +89,7 @@ private:
     /// Helper function - Renames cached files
     ///</summary>
     ///<returns>Error value</return>
-    long int rename_cached_file(std::string src, std::string dest);
+    long int rename_cached_file(std::string src, std::string dest, bool &cache_cleared);
     ///<summary>
     /// ADLS Client to make dfs storage calls
     ///</summary>

--- a/blobfuse/src/DataLakeBfsClient.cpp
+++ b/blobfuse/src/DataLakeBfsClient.cpp
@@ -341,13 +341,10 @@ std::vector<std::string> DataLakeBfsClient::Rename(std::string sourcePath, std::
         std::string dstMntPathString = prepend_mnt_path_string(destinationPath);
 
         long int rename_ret = rename_cached_file(srcMntPathString.c_str(), dstMntPathString.c_str());
-
         if(rename_ret != 0) {
             syslog(LOG_ERR, "Failure to rename source file %s in the local cache.  Errno = %d.\n", sourcePath.c_str(), errno);
-        }
-        
+        } 
         file_paths_to_remove.push_back(sourcePath);
-        errno = 0;
     }
     return file_paths_to_remove;
 }
@@ -462,7 +459,6 @@ long int DataLakeBfsClient::rename_cached_file(std::string src, std::string dst)
             //make sure directory path exists in cache
             ensure_directory_path_exists_cache(dst.c_str());
         }
-        errno = 0;
         int rename_ret = rename(src.c_str(), dst.c_str());
         if(rename_ret < 0)
         {
@@ -474,13 +470,9 @@ long int DataLakeBfsClient::rename_cached_file(std::string src, std::string dst)
             AZS_DEBUGLOGV("Successfully to renamed file %s to %s in the local cache.\n", src.c_str(), dst.c_str());
         }
     }
-    else
-    {
-        AZS_DEBUGLOGV("Failure to find source %s in the local cache. errno = %d\n", src.c_str(), errno);
-        //we don't have to rename if the file or directory does not exist in the cache
-        return 0;
-    }
-    return buf.st_size;
+
+    errno = 0;
+    return 0;
 }
 
 #if 0


### PR DESCRIPTION
- if file/dir does not exists in local cache then even when rename is successful, on cli we return failure "Input/Output error"