### PR TITLE
Vibhansa/dirrenamebug

### DIFF
--- a/blobfuse-artifacts.yml
+++ b/blobfuse-artifacts.yml
@@ -103,6 +103,10 @@ stages:
             DistroVer: "Debian9.0"
             AgentName : "DEB 9.0"
             Description: "Debian Linux 9.0"
+          Debian-10.0:
+            DistroVer: "Debian10.0"
+            AgentName : "DEB 10.0"
+            Description: "Debian Linux 10.0 Gen 1"
 
       pool:
         name: "Blobfuse Pool"

--- a/blobfuse/src/DataLakeBfsClient.cpp
+++ b/blobfuse/src/DataLakeBfsClient.cpp
@@ -456,13 +456,9 @@ long int DataLakeBfsClient::rename_cached_file(std::string src, std::string dst,
     int statret = stat(src.c_str(), &buf);
     if(statret == 0)
     {
-        //source file/directory exists in cache locally
-        if((buf.st_mode & S_IFMT) == S_IFREG ||
-           ((buf.st_mode & S_IFMT) == S_IFLNK))
-        {
-            //make sure directory path exists in cache
-            ensure_directory_path_exists_cache(dst.c_str());
-        }
+        //make sure directory path exists in cache
+        ensure_directory_path_exists_cache(dst.c_str());
+
         int rename_ret = rename(src.c_str(), dst.c_str());
         if(rename_ret < 0)
         {


### PR DESCRIPTION
- Rename fails if source directory exists in the local cache but destination directory is not in cache. Before rename we need to create the required structure locally.