### PR TITLE
Added content-type as a header on put request.

### DIFF
--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -342,6 +342,7 @@ void destroyBlobfuseOnAuthError()
 int configure_tls();
 void *azs_init(struct fuse_conn_info * conn)
 {
+    syslog(LOG_DEBUG, "ELIAS CUSTOMIZATIONS 2021-02-09 2036 EST");
     syslog(LOG_DEBUG, "azs_init ran");
 
     /*

--- a/cpplite/include/blob/create_block_blob_request.h
+++ b/cpplite/include/blob/create_block_blob_request.h
@@ -32,6 +32,18 @@ namespace azure { namespace storage_lite {
             return m_content_length;
         }
 
+        std::string content_type() const override 
+        {
+            return m_content_type;
+        }
+
+        create_block_blob_request &set_content_type(const std::string &content_type)
+        {
+            syslog(LOG_DEBUG, "SETTING CONTENT TYPE.");
+            m_content_type = content_type;
+            return *this;
+        }
+
         create_block_blob_request &set_content_length(unsigned int content_length)
         {
             m_content_length = content_length;
@@ -53,6 +65,7 @@ namespace azure { namespace storage_lite {
     private:
         std::string m_container;
         std::string m_blob;
+        std::string m_content_type;
 
         unsigned int m_content_length;
         std::vector<std::pair<std::string, std::string>> m_metadata;

--- a/cpplite/src/put_blob_request_base.cpp
+++ b/cpplite/src/put_blob_request_base.cpp
@@ -2,6 +2,7 @@
 
 #include "constants.h"
 #include "utility.h"
+#include <syslog.h>
 
 namespace azure {  namespace storage_lite {
 
@@ -25,6 +26,7 @@ void put_blob_request_base::build_request(const storage_account &a, http_base &h
     add_content_length(h, headers, r.content_length());
     add_optional_content_md5(h, headers, r.content_md5());
     add_optional_content_type(h, headers, r.content_type());
+
     add_access_condition_headers(h, headers, r);
 
     add_optional_header(h, constants::header_cache_control, r.cache_control());


### PR DESCRIPTION
Added a proof-of-concept extension to create_block_blob_request. We needed the ability to add content-type at time of upload. We didn't see a way to do this, so added it into the base class.