### PR TITLE
Vibhansa/block upload of unchanged file

### DIFF
--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -49,12 +49,9 @@ const struct fuse_opt option_spec[] =
     OPTION("--max-concurrency=%s", concurrency),
     OPTION("--cache-size-mb=%s", cache_size_mb),
     OPTION("--empty-dir-check=%s", empty_dir_check),
-<<<<<<< HEAD
     OPTION("--upload-if-modified=%s", upload_if_modified),
-=======
     OPTION("--high-disk-threshold=%s", high_disk_threshold),
     OPTION("--low-disk-threshold=%s", low_disk_threshold),
->>>>>>> origin/master
     OPTION("--version", version),
     OPTION("-v", version),
     OPTION("--help", help),

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -49,6 +49,7 @@ const struct fuse_opt option_spec[] =
     OPTION("--max-concurrency=%s", concurrency),
     OPTION("--cache-size-mb=%s", cache_size_mb),
     OPTION("--empty-dir-check=%s", empty_dir_check),
+    OPTION("--upload-if-modified=%s", upload_if_modified),
     OPTION("--version", version),
     OPTION("-v", version),
     OPTION("--help", help),
@@ -807,6 +808,15 @@ int read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
         if(val == "true")
         {
             config_options.emptyDirCheck = true;
+        }
+    }
+
+    config_options.uploadIfModified = false;
+    if (cmd_options.upload_if_modified != NULL) {
+        std::string val(cmd_options.upload_if_modified);
+        if(val == "true")
+        {
+            config_options.uploadIfModified = true;
         }
     }
     

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -64,6 +64,7 @@ struct configParams
     int concurrency;
     unsigned long long cacheSize;
     bool emptyDirCheck;
+    bool uploadIfModified;
     std::string mntPath;
 };
 
@@ -85,6 +86,7 @@ struct cmdlineOptions
     const char *concurrency; // Max Concurrency factor for blob client wrapper (default 40)
     const char *cache_size_mb; // MAX Size of cache in MBs
     const char *empty_dir_check;
+    const char *upload_if_modified;
     const char *encode_full_file_name; // Encode the '%' symbol in file name
 };
 
@@ -94,8 +96,9 @@ struct cmdlineOptions
 struct fhwrapper
 {
     int fh; // The handle to the file in the file cache to use for read/write operations.
-    bool upload; // True if the blob should be uploaded when the file is closed.  (False when the file was opened in read-only mode.)
-    fhwrapper(int fh, bool flag) : fh(fh), upload(flag)
+    bool write_mode; // False when the file was opened in read-only mode
+    bool upload_on_close; // False if file is not written or created. Upload only if the flag is true
+    fhwrapper(int fh, bool mode) : fh(fh), write_mode(mode), upload_on_close(false)
     {
 
     }


### PR DESCRIPTION
Do not upload file unless it has been modified.
User can choose this behavior using "--upload-if-modified=true" cli option.