### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Please take careful note of the following points, before using blobfuse:
 	- to go back to your default logging level (provided in command line options) 
 		- remove the `logLevel` entry from config file 
 		- after saving config file send `SIGUSR1` to running instance of blobfuse.
-- By default logs are directed to system-configured syslog file e.g. /var/log/syslog
+- By default logs are directed to system-configured syslog file e.g. /var/log/syslog or var/log/message (Depending Upon the Linux OS Family)
 - If user wishes to redirect blobfuse logs to a different file, follow the below procedure
 	- copy 10-blobfuse.conf to `/etc/rsyslog.d/`
 	- copy blobfuse-logrotate to `/etc/logrotate.d/`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Please take careful note of the following points, before using blobfuse:
 	- to go back to your default logging level (provided in command line options) 
 		- remove the `logLevel` entry from config file 
 		- after saving config file send `SIGUSR1` to running instance of blobfuse.
-- By default logs are directed to system-configured syslog file e.g. /var/log/syslog or var/log/message (Depending Upon the Linux OS Family)
+- By default logs are directed to system-configured log file e.g. /var/log/syslog or var/log/message (Depending Upon the Linux OS Family)
 - If user wishes to redirect blobfuse logs to a different file, follow the below procedure
 	- copy 10-blobfuse.conf to `/etc/rsyslog.d/`
 	- copy blobfuse-logrotate to `/etc/logrotate.d/`


### PR DESCRIPTION
The logs may also get logged under var/log/message and not be var/log/syslog everytime. This depends on the Linux OS Family type as well.

Hence, proposing the changes so that Customers can check for both the of them in case they are not able to find syslog one.