### PR TITLE
Instead of using syscall try reading /etc/mtab to figure out director…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
      * [OPTIONAL] **--ca-cert-file=/etc/ssl/certs/proxy.pem** : If external network is only available through a proxy server, this parameter should specify the proxy pem certificate otherwise blobfuse cannot connect to the storage account. This option is only available from version 1.3.7
      * [OPTIONAL] **--httpsproxy=http://10.1.22.4:8080/** : If external network is only available through a proxy server, this parameter should specify the proxy server along with the port which is 8080 unless there are some deviations from normal port allocation numbers. This option is only available from version 1.3.7
      * [OPTIONAL] **--httpproxy=http://10.1.22.4:8080/** : Only used when https is turned off using --use-https=false, and if external network is only available through a proxy server, this parameter should specify the proxy server along with the port which is 8080 unless there are some deviations from normal port allocation numbers. This option is only available from version 1.3.7
-     
+     * [OPTIONAL] **--basic-remount-check=false** : Try checking for a remount by reading /etc/mtab instead of calling the syscall setmntent
 
 ### Valid authentication setups:
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
      * [OPTIONAL] **--httpsproxy=http://10.1.22.4:8080/** : If external network is only available through a proxy server, this parameter should specify the proxy server along with the port which is 8080 unless there are some deviations from normal port allocation numbers. This option is only available from version 1.3.7
      * [OPTIONAL] **--httpproxy=http://10.1.22.4:8080/** : Only used when https is turned off using --use-https=false, and if external network is only available through a proxy server, this parameter should specify the proxy server along with the port which is 8080 unless there are some deviations from normal port allocation numbers. This option is only available from version 1.3.7
      * [OPTIONAL] **--basic-remount-check=false** : Try checking for a remount by reading /etc/mtab instead of calling the syscall setmntent
+     * [OPTIONAL] **--pre-mount-validate=false** : Skip cURL version check and validate storage connection before mount.
 
 ### Valid authentication setups:
 

--- a/blobfuse-artifacts.yml
+++ b/blobfuse-artifacts.yml
@@ -362,15 +362,15 @@ stages:
           displayName: "Print Agent Info"
 
         # Install all dependencies
-        - script: |
-            #sudo zypper in <>
-            sudo zypper -n update git tar make cmake gcc gcc-c++ curl-devel gnutls-devel libuuid-devel boost-devel libboost*devel libgcrypt-devel rpm-build
-          displayName: "Basic Tools Setup"
+        #- script: |
+        #    #sudo zypper in <>
+        #    sudo zypper -n update git tar make cmake gcc gcc-c++ curl-devel gnutls-devel libuuid-devel boost-devel libboost*devel libgcrypt-devel rpm-build
+        #  displayName: "Basic Tools Setup"
 
         # Install libfuse
-        - script: |
-            sudo zypper -n update fuse-devel
-          displayName: "libFuse Setup"
+        #- script: |
+        #    sudo zypper -n update fuse-devel
+        #  displayName: "libFuse Setup"
 
         # Prebuild cleanup
         - script: |

--- a/blobfuse-nightly.yml
+++ b/blobfuse-nightly.yml
@@ -1252,14 +1252,14 @@ jobs:
           displayName: "Print Agent Info"
 
         # Install all dependencies
-        - script: |
-            sudo zypper -n update git tar make cmake gcc gcc-c++ curl-devel gnutls-devel libuuid-devel boost-devel libboost*devel libgcrypt-devel rpm-build go
-          displayName: "Basic Tools Setup"
+        #- script: |
+        #    sudo zypper -n update git tar make cmake gcc gcc-c++ curl-devel gnutls-devel libuuid-devel boost-devel libboost*devel libgcrypt-devel rpm-build go
+        #  displayName: "Basic Tools Setup"
 
         # Install libfuse
-        - script: |
-            sudo zypper -n update fuse-devel fuse
-          displayName: "libFuse Setup"
+        #- script: |
+        #    sudo zypper -n update fuse-devel fuse
+        #  displayName: "libFuse Setup"
 
         # Prebuild cleanup
         - script: |

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -685,6 +685,7 @@ bool is_directory_mounted(const char* mntDir) {
     bool found = false;
 
     if (!config_options.basicRemountCheck) {
+        syslog(LOG_INFO, "Using syscall to detect directory is already mounted or not");
         struct mntent *mnt_ent;
 
         FILE *mnt_list;
@@ -700,6 +701,7 @@ bool is_directory_mounted(const char* mntDir) {
         }
         endmntent(mnt_list);
     } else {
+        syslog(LOG_INFO, "Reading mtab to detect directory is already mounted or not");
         ssize_t read = 0;
         size_t len = 0;
         char *line = NULL;
@@ -793,6 +795,7 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
             std::string remnt_chk(cmd_options.basic_remount_check);
             if (remnt_chk == "true")
             {
+                syslog(LOG_INFO, "Basic remount check enabled");
                 config_options.basicRemountCheck = true;
             }
         }
@@ -1102,8 +1105,10 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
     if (cmd_options.pre_mount_validate != NULL) 
     {
         std::string val(cmd_options.pre_mount_validate);
-        if (val == "true")
+        if (val == "true") {
+            syslog(LOG_INFO, "Pre mount validation enabled");
             config_options.preMountValidate = true;
+        }
     }
 
     // Azure retry policy config

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -701,7 +701,7 @@ bool is_directory_mounted(const char* mntDir) {
         }
         endmntent(mnt_list);
     } else {
-        syslog(LOG_INFO, "Reading mtab to detect directory is already mounted or not");
+        syslog(LOG_INFO, "Reading /etc/mtab to detect directory is already mounted or not");
         ssize_t read = 0;
         size_t len = 0;
         char *line = NULL;

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -74,6 +74,7 @@ struct configParams
     unsigned long long cachePollTimeout;
     unsigned long long maxEviction;
     bool basicRemountCheck;
+    bool preMountValidate;
 };
 
 // FUSE contains a specific type of command-line option parsing; here we are just following the pattern.
@@ -106,6 +107,7 @@ struct cmdlineOptions
     const char *max_eviction; // Maximum number of files to be deleted from cache to converse cpu
     const char *set_content_type; // Whether to set content type while upload blob
     const char *basic_remount_check; // Check for remount by reading /etc/mtab
+    const char *pre_mount_validate; // Validate storage auth before the mount
 };
 
 

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -73,6 +73,7 @@ struct configParams
     int low_disk_threshold;
     unsigned long long cachePollTimeout;
     unsigned long long maxEviction;
+    bool basicRemountCheck;
 };
 
 // FUSE contains a specific type of command-line option parsing; here we are just following the pattern.
@@ -104,6 +105,7 @@ struct cmdlineOptions
     const char *cache_poll_timeout_msec; // Timeout for cache eviction thread in case queue is empty
     const char *max_eviction; // Maximum number of files to be deleted from cache to converse cpu
     const char *set_content_type; // Whether to set content type while upload blob
+    const char *basic_remount_check; // Check for remount by reading /etc/mtab
 };
 
 


### PR DESCRIPTION
#612 : Instead of using syscall try reading /etc/mtab to figure out directory is already mounted or not. Use cli option "--basic-remount-check=true" to enable this.
#613 : Skip cURL check and validate authentication before the mount to return early failure for invalid authentication. Use cli option "--pre-mount-validate=true" to enable this.