### PR TITLE
Vibhansa/streaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set (BLOBFUSE_HEADER
   blobfuse/include/DataLakeBfsClient.h
   blobfuse/include/AttrCacheBfsClient.h
   blobfuse/include/AttrCacheWrapper.h
+  blobfuse/include/BlobStreamer.h
 
   blobfuse/include/OAuthToken.h
   blobfuse/include/OAuthTokenCredentialManager.h
@@ -45,6 +46,7 @@ set (BLOBFUSE_SOURCE
   blobfuse/src/BlockBlobBfsClient.cpp
   blobfuse/src/DataLakeBfsClient.cpp
   blobfuse/src/AttrCacheBfsClient.cpp
+  blobfuse/src/BlobStreamer.cpp
   
   blobfuse/src/AttrCacheWrapperLogin.cpp
   blobfuse/src/AttrCacheWrapper.cpp

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
      * [OPTIONAL] **--max-retry-interval-in-seconds=60** : Maximum number of seconds between 2 retries, retry interval is exponentially increased but it can never exceed this value. Default naximum interval is 60 seconds.
      * [OPTIONAL] **--basic-remount-check=false** : Try checking for a remount by reading /etc/mtab instead of calling the syscall setmntent
      * [OPTIONAL] **--pre-mount-validate=false** : Skip cURL version check and validate storage connection before mount.
-
+     * [OPTIONAL] **--read-stream=false** : Instead of caching files on disk, stream data directly from container. This option works only with 'read-only' mount. Use "-o ro" option in mount command to enable read-only mount.
+     * [OPTIONAL] **--stream-buffer-size-mb=500** : When read streaming is enabled, cap memory usage for storing block upto this limit.
 ### Valid authentication setups:
 
 - Account Name & Key (`authType Key`)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
      * [OPTIONAL] **--max-retry-interval-in-seconds=60** : Maximum number of seconds between 2 retries, retry interval is exponentially increased but it can never exceed this value. Default naximum interval is 60 seconds.  This option is only available from version 1.3.8
      * [OPTIONAL] **--basic-remount-check=false** : Set this to true if you want to check for an already mounted status using /etc/mtab instead of calling the syscall setmntent. Default is true. It is known that for AKS 1.19, blobfuse will throw a segmentation fault error, so set this to false.  This option is only available from version 1.3.8
      * [OPTIONAL] **--pre-mount-validate=false** : Set this to true to skip the cURL version check and just straight validate storage connection before mount. Default is false, so use this only if you know that you have the recent Curl version, otherwise blobfuse will hang. This option is only available from version 1.3.8
-     * [OPTIONAL] **--read-stream=false** : Instead of caching files on disk, stream data directly from container. This option works only with 'read-only' mount. Use "-o ro" option in mount command to enable read-only mount.
+     * [OPTIONAL] **--streaming=false** : Instead of caching files on disk, stream data directly to/from container. Only the files which are created newly will be dumped to disk.
      * [OPTIONAL] **--stream-buffer-size-mb=500** : When read streaming is enabled, cap memory usage for storing block upto this limit.
      * [OPTIONAL] **--max_block_per_file=3** : Maximum number of blocks to be cached in memory for a file in case of streaming.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
      * [OPTIONAL] **--pre-mount-validate=false** : Set this to true to skip the cURL version check and just straight validate storage connection before mount. Default is false, so use this only if you know that you have the recent Curl version, otherwise blobfuse will hang. This option is only available from version 1.3.8
      * [OPTIONAL] **--streaming=false** : Instead of caching files on disk, stream data directly to/from container. Only the files which are created newly will be dumped to disk.
      * [OPTIONAL] **--stream-buffer-size-mb=500** : When read streaming is enabled, cap memory usage for storing block upto this limit.
-     * [OPTIONAL] **--max_block_per_file=3** : Maximum number of blocks to be cached in memory for a file in case of streaming.
+     * [OPTIONAL] **--max-cache-block-per-file=3** : Maximum number of blocks to be cached in memory for a file in case of streaming.
      * [OPTIONAL] **--background-download=false** : Instead of downloading the file in 'open' system call, download it in background and return 'open' system call. Follow up 'read'/'write' calls will wait for download to complete.
 
 ### Valid authentication setups:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
      * [OPTIONAL] **--pre-mount-validate=false** : Skip cURL version check and validate storage connection before mount.
      * [OPTIONAL] **--read-stream=false** : Instead of caching files on disk, stream data directly from container. This option works only with 'read-only' mount. Use "-o ro" option in mount command to enable read-only mount.
      * [OPTIONAL] **--stream-buffer-size-mb=500** : When read streaming is enabled, cap memory usage for storing block upto this limit.
+     * [OPTIONAL] **--max_block_per_file=3** : Maximum number of blocks to be cached in memory for a file in case of streaming.
+
+
 ### Valid authentication setups:
 
 - Account Name & Key (`authType Key`)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Blobfuse is stable, and is ***supported by Microsoft*** provided that it is used
 - Allows multiple nodes to mount the same container for read-only scenarios.
 - Authenicates using storage key credentials, SaS Key, Managed Identity and SPN
 - Allows ADLS Gen2 features
+- When the file cache timeout is set to a higher value and user wants to evict a file forcefully from disk cache, use 'sync' command with the file name on mounted directory.
 
 ## Installation
 You can install blobfuse from the Linux Software Repository for Microsoft products. The process is explained in the [blobfuse installation](https://github.com/Azure/azure-storage-fuse/wiki/1.-Installation) page. Alternatively, you can clone this repository, install the dependencies (fuse, libcurl, gcrypt and GnuTLS) and build from source code. See details in the [wiki](https://github.com/Azure/azure-storage-fuse/wiki/1.-Installation#build-from-source).
@@ -79,6 +80,7 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
      * [OPTIONAL] **--streaming=false** : Instead of caching files on disk, stream data directly to/from container. Only the files which are created newly will be dumped to disk.
      * [OPTIONAL] **--stream-buffer-size-mb=500** : When read streaming is enabled, cap memory usage for storing block upto this limit.
      * [OPTIONAL] **--max_block_per_file=3** : Maximum number of blocks to be cached in memory for a file in case of streaming.
+     * [OPTIONAL] **--background-download=false** : Instead of downloading the file in 'open' system call, download it in background and return 'open' system call. Follow up 'read'/'write' calls will wait for download to complete.
 
 ### Valid authentication setups:
 

--- a/blobfuse-nightly.yml
+++ b/blobfuse-nightly.yml
@@ -525,6 +525,53 @@ jobs:
           continueOnError: true
           
         # -------------------------------------------------------
+        # Mount a directory for Streaming test
+        - script:  |
+            sudo rm -rf $(MOUNT_DIR)/*
+            sudo rm -rf $(TEMP_DIR)/*
+            ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true --file-cache-timeout-in-seconds=0
+            pidof blobfuse
+
+            for i in {10,50,100,200,500,1024}; do echo $i; done | parallel --will-cite -j 5 'head -c {}M < /dev/urandom > myfile_{}' 
+            cp myfile_* $(MOUNT_DIR)
+          # condition: eq(variables['Build.SourceBranchName'], 'master')
+          displayName: TEST - Streaming Test Preparation
+          timeoutInMinutes: 120
+          continueOnError: true
+
+        - script:  |
+            sudo fusermount -u $(MOUNT_DIR)
+            sudo rm -rf $(TEMP_DIR)/*
+          # condition: eq(variables['Build.SourceBranchName'], 'master')
+          displayName: TEST - Streaming Test Preparation-done
+          timeoutInMinutes: 30
+          continueOnError: true
+        
+        - script:  |
+            ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true --file-cache-timeout-in-seconds=0 --read-stream=true --max_block_per_file=3 --stream-buffer-size-mb=500 -o ro
+            pidof blobfuse
+          # condition: eq(variables['Build.SourceBranchName'], 'master')
+          displayName: TEST - Streaming Test Mount
+          timeoutInMinutes: 120
+          continueOnError: true
+
+        - script:  |
+            for i in {10,50,100,200,500,1024}; do echo $i; done | parallel --will-cite -j 5 'diff myfile_{} $(MOUNT_DIR)/myfile_{}' 
+          # condition: eq(variables['Build.SourceBranchName'], 'master')
+          displayName: TEST - Streaming Test
+          timeoutInMinutes: 120
+          continueOnError: true
+
+        - script:  |
+            rm -rf $(MOUNT_DIR)/*
+            sudo fusermount -u $(MOUNT_DIR)
+            sudo rm -rf $(TEMP_DIR)/*
+          # condition: eq(variables['Build.SourceBranchName'], 'master')
+          displayName: TEST - Streaming Test Cleanup
+          timeoutInMinutes: 30
+          continueOnError: true
+
+        # -------------------------------------------------------
         # Starting pyTest
 
         # Mount a directory for pyTest and run it

--- a/blobfuse-nightly.yml
+++ b/blobfuse-nightly.yml
@@ -548,7 +548,7 @@ jobs:
           continueOnError: true
         
         - script:  |
-            ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true --file-cache-timeout-in-seconds=0 --streaming=true --max_block_per_file=3 --stream-buffer-size-mb=500 -o ro
+            ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true --file-cache-timeout-in-seconds=0 --streaming=true --max-cache-block-per-file=3 --stream-buffer-size-mb=500 -o ro
             pidof blobfuse
           # condition: eq(variables['Build.SourceBranchName'], 'master')
           displayName: TEST - Streaming Test Mount

--- a/blobfuse-nightly.yml
+++ b/blobfuse-nightly.yml
@@ -548,7 +548,7 @@ jobs:
           continueOnError: true
         
         - script:  |
-            ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true --file-cache-timeout-in-seconds=0 --read-stream=true --max_block_per_file=3 --stream-buffer-size-mb=500 -o ro
+            ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true --file-cache-timeout-in-seconds=0 --streaming=true --max_block_per_file=3 --stream-buffer-size-mb=500 -o ro
             pidof blobfuse
           # condition: eq(variables['Build.SourceBranchName'], 'master')
           displayName: TEST - Streaming Test Mount

--- a/blobfuse-nightly.yml
+++ b/blobfuse-nightly.yml
@@ -563,6 +563,16 @@ jobs:
           continueOnError: true
 
         - script:  |
+            sudo fusermount -u $(MOUNT_DIR)
+            ./build/blobfuse $(MOUNT_DIR) --tmp-path=$(TEMP_DIR) --config-file=$(BLOBFUSE_CFG_ADLS) --use-adls=true --file-cache-timeout-in-seconds=0 --background-download=true
+            pidof blobfuse
+            for i in {10,50,100,200,500,1024}; do echo $i; done | parallel --will-cite -j 5 'diff myfile_{} $(MOUNT_DIR)/myfile_{}' 
+          # condition: eq(variables['Build.SourceBranchName'], 'master')
+          displayName: TEST - Delay download test
+          timeoutInMinutes: 120
+          continueOnError: true
+
+        - script:  |
             rm -rf $(MOUNT_DIR)/*
             sudo fusermount -u $(MOUNT_DIR)
             sudo rm -rf $(TEMP_DIR)/*

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -69,7 +69,7 @@ const struct fuse_opt option_spec[] =
     OPTION("--basic-remount-check=%s", basic_remount_check),
     OPTION("--pre-mount-validate=%s", pre_mount_validate),
     
-    OPTION("--read-stream=%s", stream_read),
+    OPTION("--streaming=%s", streaming),
     OPTION("--stream-buffer-size-mb=%s", stream_buffer),
     OPTION("--max-cache-block-per-file=%s", max_block_per_file),
     
@@ -476,7 +476,7 @@ void *azs_init(struct fuse_conn_info * conn)
         tokenManager->StartTokenMonitor();
     }
 
-    if (config_options.streamRead) {
+    if (config_options.streaming) {
         blob_streamer = std::make_shared<BlobStreamer>(storage_client, config_options.readStreamBufferSize, config_options.maxBlockPerFile);
     }
 
@@ -1150,13 +1150,13 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
         config_options.retryDelay = stod(retry_delay, &offset);
     }
 
-    config_options.streamRead = false;
-    if(cmd_options.stream_read != NULL)
+    config_options.streaming = false;
+    if(cmd_options.streaming != NULL)
     {
-        std::string stream_read(cmd_options.stream_read);
-        if(stream_read == "true")
+        std::string streaming(cmd_options.streaming);
+        if(streaming == "true")
         {
-            config_options.streamRead = true;
+            config_options.streaming = true;
         } 
     }
     
@@ -1176,7 +1176,7 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
 
 
     /*
-    if (config_options.streamRead && !config_options.readOnlyMount) {
+    if (config_options.streaming && !config_options.readOnlyMount) {
         syslog(LOG_ERR, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");    
         fprintf(stderr, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");  
         return 1;
@@ -1189,9 +1189,9 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
         config_options.cancel_list_on_mount_secs,
         config_options.maxTryCount, config_options.maxTimeoutSeconds, config_options.retryDelay);
 
-    if (config_options.streamRead) {
-        syslog(LOG_INFO, "Streaming Read : %d, Stream buffer size : %lu, Max Blocks : %d", 
-            config_options.streamRead, config_options.readStreamBufferSize,
+    if (config_options.streaming) {
+        syslog(LOG_INFO, "Streaming : %d, Stream buffer size : %lu, Max Blocks : %d", 
+            config_options.streaming, config_options.readStreamBufferSize,
             config_options.maxBlockPerFile);
     }
 

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -72,6 +72,7 @@ const struct fuse_opt option_spec[] =
     OPTION("--streaming=%s", streaming),
     OPTION("--stream-buffer-size-mb=%s", stream_buffer),
     OPTION("--max-cache-block-per-file=%s", max_block_per_file),
+    OPTION("--background-download=%s", background_download),
     
 
     OPTION("--version", version),
@@ -1174,6 +1175,15 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
         config_options.maxBlockPerFile = stod(max_block, &offset);
     }
 
+    config_options.backgroundDownload = false;
+    if (cmd_options.background_download != NULL) {
+        std::string background_download(cmd_options.background_download);
+        if(background_download == "true")
+        {
+            config_options.backgroundDownload = true;
+        } 
+    }
+
     if (config_options.streaming && !config_options.readOnlyMount) {
         syslog(LOG_ERR, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");    
         fprintf(stderr, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");  
@@ -1191,6 +1201,10 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
         syslog(LOG_INFO, "Streaming : %d, Stream buffer size : %lu, Max Blocks : %d", 
             config_options.streaming, config_options.readStreamBufferSize,
             config_options.maxBlockPerFile);
+    }
+
+    if (config_options.backgroundDownload) {
+        syslog(LOG_INFO, "Background download is turned on");
     }
 
     return 0;

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -1174,14 +1174,12 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
         config_options.maxBlockPerFile = stod(max_block, &offset);
     }
 
-
-    /*
     if (config_options.streaming && !config_options.readOnlyMount) {
         syslog(LOG_ERR, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");    
         fprintf(stderr, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");  
         return 1;
     }
-    */
+    
 
     syslog(LOG_INFO, "Disk Thresholds : %d - %d, Cache Eviction : %llu-%llu, List Cancel time : %d Retry Policy (%d, %f, %f)", 
         config_options.high_disk_threshold, config_options.low_disk_threshold,

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -1175,11 +1175,13 @@ read_and_set_arguments(int argc, char *argv[], struct fuse_args *args)
     }
 
 
+    /*
     if (config_options.streamRead && !config_options.readOnlyMount) {
         syslog(LOG_ERR, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");    
         fprintf(stderr, "Streaming Read is supported only on Readonly Mounts. Use '-o ro' option in mount command");  
         return 1;
     }
+    */
 
     syslog(LOG_INFO, "Disk Thresholds : %d - %d, Cache Eviction : %llu-%llu, List Cancel time : %d Retry Policy (%d, %f, %f)", 
         config_options.high_disk_threshold, config_options.low_disk_threshold,

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -179,7 +179,7 @@ int azs_open(const char *path, struct fuse_file_info *fi)
                 BfsFileProperty blob_property = storage_client->GetProperties(pathString.substr(1));
                 if ((errno == 0) && blob_property.isValid() && blob_property.exists()) {
                     // File exists on the container so create a dummy file of same size here and return back the handle for it
-                    int tempFD = open(mntPath, O_WRONLY|O_CREAT);
+                    int tempFD = open(mntPath, O_WRONLY|O_CREAT, config_options.defaultPermission);
                     if (tempFD == -1)
                     {
                         syslog (LOG_ERR, "Failed to open %s; unable to open file %s in cache directory.  Errno = %d", path, mntPath, errno);

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -290,11 +290,6 @@ int azs_flush(const char *path, struct fuse_file_info *fi)
     // At this point, the shared flock will be held.
     // In some cases, due (I believe) to us using the hard_unlink option, path will be null.  Thus, we need to get the file name from the file descriptor:
 
-    if (config_options.streamRead) {
-        //  As no file handel was created in case of streaming read nothing to be done here.
-        return 0;
-    }
-
     char path_link_buffer[50];
     snprintf(path_link_buffer, 50, "/proc/self/fd/%d", (((struct fhwrapper *)fi->fh)->fh));
 
@@ -518,10 +513,6 @@ int azs_unlink(const char *path)
 int azs_truncate(const char * path, off_t off)
 {
     AZS_DEBUGLOGV("azs_truncate called.  Path = %s, offset = %s\n", path, to_str(off).c_str());
-
-    if (config_options.streamRead) {
-        return ENOSYS;
-    }
 
     std::string pathString(path);
     std::replace(pathString.begin(), pathString.end(), '\\', '/');

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -50,7 +50,7 @@ int DownloadFileToDisk(std::string pathString, std::string mntPathString, BfsFil
     if (is_delayed)
         rename(disk_path.c_str(), mntPathString.c_str());
     */
-   
+
     struct utimbuf new_time;
     new_time.modtime = last_modified;
     new_time.actime = 0;
@@ -187,8 +187,8 @@ int azs_open(const char *path, struct fuse_file_info *fi)
                     }
                     fchmod(tempFD, config_options.defaultPermission);
                     close(tempFD);
-                    truncate64(mntPath, blob_property.size);
-                    if (errno != 0) {
+                    int ret = truncate64(mntPath, blob_property.size);
+                    if (ret !=0 || errno != 0) {
                         syslog(LOG_ERR, "Failed to resize the file %s (%d)", mntPath, errno);
                     }
 

--- a/blobfuse/include/AttrCacheBfsClient.h
+++ b/blobfuse/include/AttrCacheBfsClient.h
@@ -273,6 +273,10 @@ public:
     int UpdateBlobProperty(std::string pathStr, std::string key, std::string value, METADATA *metadata = NULL);
     
     int RefreshSASToken(std::string sas);
+
+    get_block_list_response GetBlockList(const std::string &blob);
+    void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
+
     
     private:
         std::shared_ptr<StorageBfsClientBase> blob_client;

--- a/blobfuse/include/AttrCacheBfsClient.h
+++ b/blobfuse/include/AttrCacheBfsClient.h
@@ -276,7 +276,7 @@ public:
 
     get_block_list_response GetBlockList(const std::string &blob);
     void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
-
+    void UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen);
     
     private:
         std::shared_ptr<StorageBfsClientBase> blob_client;

--- a/blobfuse/include/AttrCacheBfsClient.h
+++ b/blobfuse/include/AttrCacheBfsClient.h
@@ -277,7 +277,8 @@ public:
     get_block_list_response GetBlockList(const std::string &blob);
     void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
     void UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen);
-    
+    void InvalidateFile(const std::string blob);
+
     private:
         std::shared_ptr<StorageBfsClientBase> blob_client;
         AttrCache attr_cache;

--- a/blobfuse/include/BlobStreamer.h
+++ b/blobfuse/include/BlobStreamer.h
@@ -188,8 +188,14 @@ class  BlobStreamer {
         // Read file searches the map gets the object and gets the required block based on offset
         int ReadFile(const char* file_name, uint64_t offset, uint64_t length, char* out);
 
+        // Write file searches the map gets the object and gets the required block based on offset and update+uploads it
+        int WriteFile(const char* file_name, uint64_t offset, uint64_t length, const char* data);
+
         // Close file decrements ref count and cleansup file info if all handles are closed
         int CloseFile(const char* file_name);
+
+        // Delete file removes all the buffers in the memory
+        int DeleteFile(const char* file_name);
 
         // Search and add a new block if it does not exists for the given file
         BlobBlock* GetBlock(const char* file_name, uint64_t offset, StreamObject* obj);

--- a/blobfuse/include/BlobStreamer.h
+++ b/blobfuse/include/BlobStreamer.h
@@ -72,6 +72,7 @@ struct BlobBlock {
         uint64_t            start;  // Start offset of block
         uint64_t            end;    // End offset of block
         std::stringstream   buff;   // Buffer holding the data
+        std::mutex          lck;    // No one shall delete the block when someone is reading it
 };
 
 // StreamObject : Holds all available blocks for a given file

--- a/blobfuse/include/BlobStreamer.h
+++ b/blobfuse/include/BlobStreamer.h
@@ -1,0 +1,134 @@
+#ifndef BLOBSTREAMER_H_
+#define BLOBSTREAMER_H_
+
+#include <blobfuse.h>
+#include <BlobfuseGlobals.h>
+#include<StorageBfsClientBase.h>
+
+#include <FileLockMap.h>
+#include <list>
+
+using namespace std;
+using namespace azure::storage_lite;
+using namespace azure::storage_adls;
+
+// Maximum number of blocks to be stored per file in case caching is enabled
+#define MAX_BLOCKS_PER_FILE 3
+
+// Structure representing one block segment
+struct BlobBlock {
+        bool                valid;  // Block is valid or not
+        bool                last;   // This block is the last block of file
+        uint64_t            start;  // Start offset of block
+        uint64_t            end;    // End offset of block
+        std::stringstream   buff;   // Buffer holding the data
+};
+
+// StreamObject : Holds all available blocks for a given file
+class StreamObject {
+    public:
+        StreamObject() {
+            ref_count = 0;
+        }
+
+        int IncRefCount() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ref_count++;
+            return ref_count;
+        }
+
+        int DecRefCount() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ref_count--;
+
+            if (ref_count == 0) {
+                Cleanup();
+            }
+
+            return ref_count;
+        }
+
+        int GetRefCount() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return ref_count;
+        }
+
+        void Lock() {
+            m_mutex.lock();
+        }
+        
+        void UnLock() {
+            m_mutex.unlock();
+        }
+
+
+        // Add a new block for this file
+        int AddBlock(BlobBlock* block, uint64_t max_blocks);
+
+        // Remove existing block for this file
+        int RemoveBlock();
+
+        // Get the block based on offset and length, if not add it
+        BlobBlock* GetBlock(uint64_t offset);
+
+        // Remove all blocks and wipe out this file info
+        void Cleanup();
+
+    private:
+        int                 ref_count;      // How many open handles are there for this file
+        std::mutex          m_mutex;        // Mutex for safety
+        
+        list<BlobBlock*>    m_block_list;   // List of blocks cached for this file
+};
+
+
+// BlobStreamer : Holds a map holding StreamObject for each file being open
+class  BlobStreamer {
+    public:
+        BlobStreamer(std::shared_ptr<StorageBfsClientBase> client, uint64_t buffer_size, int max_blocks):
+            blob_client(client)
+        {
+            nextHandle = 0;
+            current_usage = 0;
+            max_usage = buffer_size;
+            max_blocks_per_file = max_blocks;
+        }
+
+        // As all data is cached in memory, there is no physical handle we can open so just return back a seq number for handle
+        int GetDummyHandle() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return ++nextHandle;
+        }
+
+        // Update the current usage
+        void UpdateUSage(int size){
+            std::lock_guard<std::mutex> lock(m_mutex);
+            current_usage += size;
+        }
+
+        // Open file causes a new entry in map and caching its first buffer
+        int OpenFile(const char* file_name);
+
+        // Read file searches the map gets the object and gets the required block based on offset
+        int ReadFile(const char* file_name, uint64_t offset, uint64_t length, char* out);
+
+        // Close file decrements ref count and cleansup file info if all handles are closed
+        int CloseFile(const char* file_name);
+
+        // Search and add a new block if it does not exists for the given file
+        BlobBlock* GetBlock(const char* file_name, uint64_t offset, StreamObject* obj);
+
+    private:
+        uint64_t        current_usage;          //  Current memory usage based on how many blocks are cached
+        uint64_t        max_usage;              //  Max memory usage allowed by configuration for caching
+        uint64_t        max_blocks_per_file;    //  Max number of blocks we can cache per file
+        int             nextHandle;             //  Next available handle id
+        std::mutex      m_mutex;                //  Mutex to sync the map
+        
+
+        std::map<std::string, StreamObject*>    m_file_map;  // Map holding stream object per file
+        std::shared_ptr<StorageBfsClientBase>   blob_client; // Storage client object to download new blocks     
+
+};
+
+#endif

--- a/blobfuse/include/BlobfuseGcCache.h
+++ b/blobfuse/include/BlobfuseGcCache.h
@@ -9,6 +9,7 @@ struct file_to_delete
 {
     std::string path;
     time_t closed_time;
+    bool force;
 };
 
 class gc_cache
@@ -20,7 +21,7 @@ public:
         file_cache_timeout_in_seconds(timeout),
         m_current_usage(0){}
     void run();
-    void uncache_file(std::string path);
+    void uncache_file(std::string path, bool force = false);
     void addCacheBytes(std::string path, long int size);
 
 private:

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -85,6 +85,7 @@ struct configParams
     bool streaming;
     uint64_t readStreamBufferSize;
     int maxBlockPerFile;
+    bool backgroundDownload;
 };
 
 // FUSE contains a specific type of command-line option parsing; here we are just following the pattern.
@@ -125,6 +126,7 @@ struct cmdlineOptions
     const char *streaming; // Allow user to stream the read operation
     const char *stream_buffer; // Stream buffer max size
     const char *max_block_per_file; // Number of blocks to be cached per file in case of streaming
+    const char *background_download; // Download the file in background instead of downloading in open call
 };
 
 

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -84,6 +84,7 @@ struct configParams
     bool readOnlyMount;
     bool streamRead;
     uint64_t readStreamBufferSize;
+    int maxBlockPerFile;
 };
 
 // FUSE contains a specific type of command-line option parsing; here we are just following the pattern.
@@ -123,6 +124,7 @@ struct cmdlineOptions
 
     const char *stream_read; // Allow user to stream the read operation
     const char *stream_buffer; // Stream buffer max size
+    const char *max_block_per_file; // Number of blocks to be cached per file in case of streaming
 };
 
 

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -132,16 +132,33 @@ struct cmdlineOptions
 
 // FUSE gives you one 64-bit pointer to use for communication between API's.
 // An instance of this struct is pointed to by that pointer.
+enum FHW_FLAGS
+{
+    FILE_FLAG_UNKNOWN           = 0,
+    FILE_OPEN_WRITE_MODE        = 1,    // False when the file was opened in read-only mode
+    FILE_UPLOAD_ON_CLOSE,               // False if file is not written or created. Upload only if the flag is true
+    FILE_CREATED,                       // This is a new file being created by user
+    FILE_FORCE_DELETE,                  // False if file is not written or created. Upload only if the flag is true
+    FILE_DONWLOADED_IN_OPEN,            // File was downloaded during open of this handle
+    FILE_FLAG_MAX               = 15
+};
+
+#define SET_FHW_FLAG(val, flag) \
+        (val |= (1 << flag))
+#define CLEAR_FHW_FLAG(val, flag) \
+        (val &= ~(1 << flag))
+#define IS_FHW_FLAG_SET(val, flag) \
+        (val & (1 << flag))
 struct fhwrapper
 {
     int fh; // The handle to the file in the file cache to use for read/write operations.
-    bool write_mode; // False when the file was opened in read-only mode
-    bool upload_on_close; // False if file is not written or created. Upload only if the flag is true
-    bool file_created; // This is a new file being created by user
+    uint16_t flags;
     std::string file_name; // name of the file in case of streaming as we can not convert handle id to file name back
-    fhwrapper(int fh, bool mode) : fh(fh), write_mode(mode), upload_on_close(false)
+    fhwrapper(int fh, bool mode) : fh(fh)
     {
-        file_created = false;
+        flags = 0;
+        if (mode)
+            SET_FHW_FLAG(flags, FILE_OPEN_WRITE_MODE);
     }
 };
 

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -80,6 +80,10 @@ struct configParams
     double retryDelay;
     bool basicRemountCheck;
     bool preMountValidate;
+
+    bool readOnlyMount;
+    bool streamRead;
+    uint64_t readStreamBufferSize;
 };
 
 // FUSE contains a specific type of command-line option parsing; here we are just following the pattern.
@@ -116,6 +120,9 @@ struct cmdlineOptions
     const char *retry_delay; // Exponential factor for each retry
     const char *basic_remount_check; // Check for remount by reading /etc/mtab
     const char *pre_mount_validate; // Validate storage auth before the mount
+
+    const char *stream_read; // Allow user to stream the read operation
+    const char *stream_buffer; // Stream buffer max size
 };
 
 

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -82,7 +82,7 @@ struct configParams
     bool preMountValidate;
 
     bool readOnlyMount;
-    bool streamRead;
+    bool streaming;
     uint64_t readStreamBufferSize;
     int maxBlockPerFile;
 };
@@ -122,7 +122,7 @@ struct cmdlineOptions
     const char *basic_remount_check; // Check for remount by reading /etc/mtab
     const char *pre_mount_validate; // Validate storage auth before the mount
 
-    const char *stream_read; // Allow user to stream the read operation
+    const char *streaming; // Allow user to stream the read operation
     const char *stream_buffer; // Stream buffer max size
     const char *max_block_per_file; // Number of blocks to be cached per file in case of streaming
 };
@@ -135,9 +135,10 @@ struct fhwrapper
     int fh; // The handle to the file in the file cache to use for read/write operations.
     bool write_mode; // False when the file was opened in read-only mode
     bool upload_on_close; // False if file is not written or created. Upload only if the flag is true
+    bool file_created; // This is a new file being created by user
     fhwrapper(int fh, bool mode) : fh(fh), write_mode(mode), upload_on_close(false)
     {
-
+        file_created = false;
     }
 };
 

--- a/blobfuse/include/BlobfuseGlobals.h
+++ b/blobfuse/include/BlobfuseGlobals.h
@@ -136,6 +136,7 @@ struct fhwrapper
     bool write_mode; // False when the file was opened in read-only mode
     bool upload_on_close; // False if file is not written or created. Upload only if the flag is true
     bool file_created; // This is a new file being created by user
+    std::string file_name; // name of the file in case of streaming as we can not convert handle id to file name back
     fhwrapper(int fh, bool mode) : fh(fh), write_mode(mode), upload_on_close(false)
     {
         file_created = false;

--- a/blobfuse/include/BlockBlobBfsClient.h
+++ b/blobfuse/include/BlockBlobBfsClient.h
@@ -108,7 +108,7 @@ public:
 
     get_block_list_response GetBlockList(const std::string &blob);
     void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
-    
+    void UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen);
 protected:
     ///<summary>
     /// Blob Client to make blob storage calls

--- a/blobfuse/include/BlockBlobBfsClient.h
+++ b/blobfuse/include/BlockBlobBfsClient.h
@@ -109,6 +109,8 @@ public:
     get_block_list_response GetBlockList(const std::string &blob);
     void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
     void UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen);
+    void InvalidateFile(const std::string blob);
+
 protected:
     ///<summary>
     /// Blob Client to make blob storage calls

--- a/blobfuse/include/BlockBlobBfsClient.h
+++ b/blobfuse/include/BlockBlobBfsClient.h
@@ -105,6 +105,10 @@ public:
 
     int UpdateBlobProperty(std::string pathStr, std::string key, std::string value, METADATA *metadata = NULL);
     virtual int RefreshSASToken(std::string sas);
+
+    get_block_list_response GetBlockList(const std::string &blob);
+    void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
+    
 protected:
     ///<summary>
     /// Blob Client to make blob storage calls

--- a/blobfuse/include/FileLockMap.h
+++ b/blobfuse/include/FileLockMap.h
@@ -20,6 +20,7 @@ class file_lock_map
 public:
     static file_lock_map* get_instance();
     std::shared_ptr<std::mutex> get_mutex(const std::string& path);
+    std::shared_ptr<std::mutex> get_delay_mutex(const std::string& path);
 
 private:
     file_lock_map()
@@ -30,5 +31,9 @@ private:
     static std::mutex s_mutex;
     std::mutex m_mutex;
     std::map<std::string, std::shared_ptr<std::mutex>> m_lock_map;
+
+    std::mutex d_mutex;
+    std::map<std::string, std::shared_ptr<std::mutex>> m_delay_map;
+
 };
 #endif //FILE_LOCK_MAP_H

--- a/blobfuse/include/StorageBfsClientBase.h
+++ b/blobfuse/include/StorageBfsClientBase.h
@@ -367,6 +367,10 @@ public:
     virtual int UpdateBlobProperty(std::string pathStr, std::string key, std::string value, METADATA *metadata = NULL) = 0;
 
     virtual int RefreshSASToken(std::string sas) = 0;
+
+
+    virtual get_block_list_response GetBlockList(const std::string &blob) = 0;
+    virtual void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata) = 0;
     
 protected:
     configParams configurations;

--- a/blobfuse/include/StorageBfsClientBase.h
+++ b/blobfuse/include/StorageBfsClientBase.h
@@ -371,7 +371,8 @@ public:
 
     virtual get_block_list_response GetBlockList(const std::string &blob) = 0;
     virtual void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata) = 0;
-    
+    virtual void UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen) = 0;
+
 protected:
     configParams configurations;
     ///<summary>

--- a/blobfuse/include/StorageBfsClientBase.h
+++ b/blobfuse/include/StorageBfsClientBase.h
@@ -372,6 +372,7 @@ public:
     virtual get_block_list_response GetBlockList(const std::string &blob) = 0;
     virtual void PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata) = 0;
     virtual void UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen) = 0;
+    virtual void InvalidateFile(const std::string blob) = 0;
 
 protected:
     configParams configurations;

--- a/blobfuse/src/AttrCacheBfsClient.cpp
+++ b/blobfuse/src/AttrCacheBfsClient.cpp
@@ -529,3 +529,15 @@ int AttrCacheBfsClient::RefreshSASToken(std::string sas)
 {
     return blob_client->RefreshSASToken(sas);
 }
+
+
+
+get_block_list_response AttrCacheBfsClient::GetBlockList(const std::string &blob)
+{
+    return blob_client->GetBlockList(blob);
+}
+
+void AttrCacheBfsClient::PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata)
+{
+    return blob_client->PutBlockList(blob, block_list, metadata);
+}

--- a/blobfuse/src/AttrCacheBfsClient.cpp
+++ b/blobfuse/src/AttrCacheBfsClient.cpp
@@ -231,6 +231,20 @@ void AttrCacheBfsClient::DeleteFile(const std::string pathToDelete)
     }
 }
 
+void AttrCacheBfsClient::InvalidateFile(const std::string blob)
+{
+    std::shared_ptr<boost::shared_mutex> dir_mutex = attr_cache.get_dir_item(get_parent_str(blob));
+    std::shared_ptr<AttrCacheItem> cache_item = attr_cache.get_blob_item(blob);
+    boost::shared_lock<boost::shared_mutex> dirlock(*dir_mutex);
+
+    if (cache_item != NULL && 
+        IS_PROP_FLAG_SET(cache_item->flags, PROP_FLAG_VALID))
+    {
+        CLEAR_PROP_FLAG(cache_item->flags, PROP_FLAG_CONFIRMED);
+    }
+}
+
+
 BfsFileProperty AttrCacheBfsClient::GetProperties(std::string pathName, bool type_known)
 {
     std::shared_ptr<boost::shared_mutex> dir_mutex = attr_cache.get_dir_item(get_parent_str(pathName));

--- a/blobfuse/src/AttrCacheBfsClient.cpp
+++ b/blobfuse/src/AttrCacheBfsClient.cpp
@@ -541,3 +541,8 @@ void AttrCacheBfsClient::PutBlockList(const std::string &blob, const std::vector
 {
     return blob_client->PutBlockList(blob, block_list, metadata);
 }
+
+void AttrCacheBfsClient::UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen)
+{
+    return blob_client->UploadBlockWithID(blob, blockid, buffer, bufferlen);
+}

--- a/blobfuse/src/BlobStreamer.cpp
+++ b/blobfuse/src/BlobStreamer.cpp
@@ -1,0 +1,209 @@
+
+#include <BlobStreamer.h>
+
+const unsigned long long DOWNLOAD_CHUNK_SIZE = 16 * 1024 * 1024;
+
+// Add a new block to this stream object
+int StreamObject::AddBlock(BlobBlock* block, uint64_t max_blocks_per_file)
+{
+    if (m_block_list.size() >= max_blocks_per_file) {
+        // We have exceeeded max number of blocks allowed so delete the end of the queue
+        RemoveBlock();
+    }
+
+    // Add the new block to front of the list (LRU)
+    m_block_list.push_front(block);
+
+    return 0;
+}
+
+// Remove a unused block from the list
+int StreamObject::RemoveBlock()
+{
+    BlobBlock* last_block = m_block_list.back();
+    m_block_list.pop_back();
+
+    if (last_block) {
+        // Release memory used by this block
+        last_block->buff.clear();
+        delete last_block;
+    }
+
+    return 0;
+}
+
+// Search for a block based on offset
+BlobBlock* StreamObject::GetBlock(uint64_t offset)
+{
+    // Start offsets are rounded off to 16MB multiples so just match the start offset
+    for(auto it = m_block_list.begin(); it != m_block_list.end(); ++it) {
+        if ((*it)->valid && (*it)->start == offset) {
+            return (*it);
+        }
+    }
+
+    return NULL;
+}
+
+// Cleanup the file info for this object as its no more nee
+void StreamObject::Cleanup()
+{
+    while(m_block_list.size() > 0)
+        RemoveBlock();
+}
+
+
+
+//  Get block of a given file based on give offset
+BlobBlock* BlobStreamer::GetBlock(const char* file_name, uint64_t offset, StreamObject* obj)
+{
+    uint64_t start_offset = offset - (offset % DOWNLOAD_CHUNK_SIZE);
+
+    obj->Lock();
+    BlobBlock *block = obj->GetBlock(start_offset);
+
+    if (block == NULL || block->valid == false) {
+        // Either block was not found or its not valid so download a new block
+        BlobBlock *block = new BlobBlock;
+        block->start = start_offset;
+        block->valid = true;
+        block->last = false;
+        
+        blob_client->DownloadToStream(file_name, block->buff, start_offset, DOWNLOAD_CHUNK_SIZE);
+        uint32_t read_len = block->buff.str().size();
+        block->end = block->start + read_len;
+
+        if (read_len < DOWNLOAD_CHUNK_SIZE) {
+            // We asked to read 16MB but got less data then assume its the end of file
+            block->last = true;
+        }
+
+        UpdateUSage(block->buff.str().size());
+        obj->AddBlock(block, max_blocks_per_file);
+    }
+    obj->UnLock();
+
+    return block;
+}
+
+// When file open is hit, just download the first block of file and cache it if caching is allowed
+int BlobStreamer::OpenFile(const char* file_name)
+{
+    // If caching of block is not allowed then there is nothing to be done here.
+    if (max_blocks_per_file > 0) {
+        m_mutex.lock();
+
+        StreamObject* obj = NULL;
+        auto iter = m_file_map.find(file_name);
+        
+        if(iter == m_file_map.end()) {
+            // File is not found in the map so create a new entry and cache the first block
+            obj =  new StreamObject;
+            m_file_map[file_name] = obj;
+        } else {
+            // File object exists in our map
+            obj = iter->second;
+        }
+
+        m_mutex.unlock();
+
+        // Mark one more open handle exists for this file
+        obj->IncRefCount();
+
+        // Download and save the first block of this file for future read.
+        GetBlock(file_name, 0, obj);
+    }
+
+    return 0;
+}
+
+// Close file checks all handles are closed or not, if so wipe out the file info
+int BlobStreamer::CloseFile(const char* file_name)
+{
+    // If caching is not allowed as per config then nothing to be cleaned up here
+    if (max_blocks_per_file > 0) {
+
+        m_mutex.lock();
+        auto iter = m_file_map.find(file_name);
+        if(iter == m_file_map.end()) {
+            m_mutex.unlock();
+            return -1;
+        }
+
+        StreamObject* obj = iter->second;
+        m_mutex.unlock();
+
+        if (0 == obj->DecRefCount()) {
+            // All open handles are closed so file info has been cleanedup
+            // We can remove the entry from the map now. Next open will cause a new entry.
+            m_mutex.lock();
+            m_file_map.erase(file_name);
+            delete obj;
+            m_mutex.unlock();
+        }
+    }
+
+    return 0;
+}
+
+// Read file retreives the data from cache and sends it back to the caller
+int BlobStreamer::ReadFile(const char* file_name, uint64_t offset, uint64_t length, char* out)
+{
+    int len = 0;
+    
+    // If block caching is not allowed as per config then stream data directly from container.
+    if (max_blocks_per_file <= 0) {
+        // Get data in form of a stream and fill the output buffer with data retreived
+        std::stringstream os;
+        blob_client->DownloadToStream(file_name, os, offset, length);
+        len = os.str().size();
+        os.read(out, len);
+        out[len]= '\0';
+
+    } else {
+        // Caching of block is allowed so we need to check block exists or not
+        m_mutex.lock();
+        auto iter = m_file_map.find(file_name);
+        if(iter == m_file_map.end()) {
+            m_mutex.unlock();
+            return 0;
+        }
+        StreamObject* obj = iter->second;
+        m_mutex.unlock();
+
+        BlobBlock* block = GetBlock(file_name, offset, obj);
+        if (block == NULL){
+            // For some reason we failed to get the block object
+            return 0;
+        }
+        
+        // Based on offset and block being used calculate the start offset inside the block
+        int start_offset = offset - block->start;
+
+        // As cached buffer is a stream seek to intended offset and read data from there
+        block->buff.seekg(start_offset, std::ios::beg);
+        block->buff.read(out, length);
+
+        // Based on offset and length and available data calculate length of data being read
+        len = block->buff.tellg();
+        if (len < 0) {
+            // we have hit end of the buffer
+            len = block->buff.str().size() - start_offset;
+        } else {
+            len = (len - start_offset);
+        }
+
+        if (len < 0) {
+            // Should not happen but just in case shit happens
+            len = 0;
+        }
+
+        out[len] = '\0';
+
+    } 
+
+    return len;
+}
+
+
+

--- a/blobfuse/src/BlobfuseGcCache.cpp
+++ b/blobfuse/src/BlobfuseGcCache.cpp
@@ -225,7 +225,8 @@ void gc_cache::run_gc_cache()
                         evicted++;
                         unlink(mntPath);
                         flock(fd, LOCK_UN);
-                        
+                        AZS_DEBUGLOGV("File %s being deleted successfully by file cache GC.\n", file.path.c_str());
+
                         if (m_current_usage > (unsigned long long)buf.st_size)
                             m_current_usage -= buf.st_size;
                         else

--- a/blobfuse/src/BlockBlobBfsClient.cpp
+++ b/blobfuse/src/BlockBlobBfsClient.cpp
@@ -1079,3 +1079,8 @@ void BlockBlobBfsClient::UploadBlockWithID(const std::string &blob, const std::s
 {
     return m_blob_client->upload_block_from_buffer(configurations.containerName, blob, blockid, buffer, bufferlen);
 }
+
+void BlockBlobBfsClient::InvalidateFile(const std::string)
+{
+    return;
+}

--- a/blobfuse/src/BlockBlobBfsClient.cpp
+++ b/blobfuse/src/BlockBlobBfsClient.cpp
@@ -1074,3 +1074,8 @@ void BlockBlobBfsClient::PutBlockList(const std::string &blob, const std::vector
 {
     return m_blob_client->put_block_list(configurations.containerName, blob, block_list, metadata);
 }
+
+void BlockBlobBfsClient::UploadBlockWithID(const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen)
+{
+    return m_blob_client->upload_block_from_buffer(configurations.containerName, blob, blockid, buffer, bufferlen);
+}

--- a/blobfuse/src/BlockBlobBfsClient.cpp
+++ b/blobfuse/src/BlockBlobBfsClient.cpp
@@ -1063,3 +1063,14 @@ int BlockBlobBfsClient::RefreshSASToken(std::string sas)
     }
     return 0;
 }
+
+
+get_block_list_response BlockBlobBfsClient::GetBlockList(const std::string &blob)
+{
+    return m_blob_client->get_block_list(configurations.containerName, blob);
+}
+
+void BlockBlobBfsClient::PutBlockList(const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata)
+{
+    return m_blob_client->put_block_list(configurations.containerName, blob, block_list, metadata);
+}

--- a/blobfuse/src/FileLockMap.cpp
+++ b/blobfuse/src/FileLockMap.cpp
@@ -28,3 +28,19 @@ std::shared_ptr<std::mutex> file_lock_map::get_mutex(const std::string& path)
         return iter->second;
     }
 }
+
+std::shared_ptr<std::mutex> file_lock_map::get_delay_mutex(const std::string& path)
+{
+    std::lock_guard<std::mutex> lock(d_mutex);
+    auto iter = m_delay_map.find(path);
+    if(iter == m_delay_map.end())
+    {
+        auto file_mutex = std::make_shared<std::mutex>();
+        m_delay_map[path] = file_mutex;
+        return file_mutex;
+    }
+    else
+    {
+        return iter->second;
+    }
+}

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -481,14 +481,10 @@ int azs_access(const char * /*path*/, int /*mask*/)
     return 0; // permit all access
 }
 
-int azs_fsync(const char * path, int /*isdatasync*/, struct fuse_file_info * /*fi*/)
+int azs_fsync(const char * path, int /*isdatasync*/, struct fuse_file_info *fi)
 {
     syslog(LOG_INFO, "FSYNC : Request for forceful eviction of file : %s", path);
-    std::string pathString(path);
-    std::replace(pathString.begin(), pathString.end(), '\\', '/');
-    
-    g_gc_cache->uncache_file(pathString, true);
-
+    SET_FHW_FLAG(((struct fhwrapper *)fi->fh)->flags, FILE_FORCE_DELETE);
     return 0; 
 }
 

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -481,9 +481,15 @@ int azs_access(const char * /*path*/, int /*mask*/)
     return 0; // permit all access
 }
 
-int azs_fsync(const char * /*path*/, int /*isdatasync*/, struct fuse_file_info * /*fi*/)
+int azs_fsync(const char * path, int /*isdatasync*/, struct fuse_file_info * /*fi*/)
 {
-    return 0; // Skip for now
+    syslog(LOG_INFO, "FSYNC : Request for forceful eviction of file : %s", path);
+    std::string pathString(path);
+    std::replace(pathString.begin(), pathString.end(), '\\', '/');
+    
+    g_gc_cache->uncache_file(pathString, true);
+
+    return 0; 
 }
 
 int azs_chown(const char * /*path*/, uid_t /*uid*/, gid_t /*gid*/)

--- a/cpplite/include/blob/blob_client.h
+++ b/cpplite/include/blob/blob_client.h
@@ -548,7 +548,8 @@ namespace azure { namespace storage_lite {
         // Get the list of blocks from blob client
         AZURE_STORAGE_API virtual get_block_list_response get_block_list(const std::string &container, const std::string &blob);
         AZURE_STORAGE_API virtual void put_block_list(const std::string &container, const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
-       
+        AZURE_STORAGE_API virtual void upload_block_from_buffer(const std::string &container, const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen);
+
         /// <summary>
         /// Copy a blob to another.
         /// </summary>

--- a/cpplite/include/blob/blob_client.h
+++ b/cpplite/include/blob/blob_client.h
@@ -543,6 +543,12 @@ namespace azure { namespace storage_lite {
         /// <param name="blob">The blob name.</param>
         AZURE_STORAGE_API virtual void delete_blob(const std::string &container, const std::string &blob);
 
+
+
+        // Get the list of blocks from blob client
+        AZURE_STORAGE_API virtual get_block_list_response get_block_list(const std::string &container, const std::string &blob);
+        AZURE_STORAGE_API virtual void put_block_list(const std::string &container, const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata);
+       
         /// <summary>
         /// Copy a blob to another.
         /// </summary>

--- a/cpplite/src/blob/blob_client_wrapper.cpp
+++ b/cpplite/src/blob/blob_client_wrapper.cpp
@@ -846,6 +846,31 @@ namespace azure {  namespace storage_lite {
         }
 
 
+        void blob_client_wrapper::upload_block_from_buffer(const std::string &container, const std::string &blob, const std::string &blockid, const char* buffer, uint64_t bufferlen)
+        {
+            try
+            {
+                auto result = m_blobClient->upload_block_from_buffer(container, blob, blockid, buffer, bufferlen).get();
+                if(!result.success())
+                {
+                    errno = std::stoi(result.error().code);
+                    return;
+                }
+                else
+                {
+                    errno = 0;
+                    return;
+                }
+            }
+            catch(std::exception& ex)
+            {
+                syslog(LOG_ERR,"Unknown failure in put_block.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
+                errno = unknown_error;
+                return;
+            }
+        }
+
+
 
 }} // azure::storage_lite
 

--- a/cpplite/src/blob/blob_client_wrapper.cpp
+++ b/cpplite/src/blob/blob_client_wrapper.cpp
@@ -815,4 +815,38 @@ namespace azure {  namespace storage_lite {
             }
         }
 
+
+        get_block_list_response blob_client_wrapper::get_block_list(const std::string &container, const std::string &blob) 
+        {
+            try
+            {
+                auto result = m_blobClient->get_block_list(container, blob).get();
+                if(!result.success())
+                {
+                    errno = std::stoi(result.error().code);
+                    return get_block_list_response();
+                }
+                else
+                {
+                    errno = 0;
+                    return result.response();
+                }
+            }
+            catch(std::exception& ex)
+            {
+                syslog(LOG_ERR,"Unknown failure in get_block_list.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
+                errno = unknown_error;
+                return get_block_list_response();
+            }
+        }
+
+        void blob_client_wrapper::put_block_list(const std::string &container, const std::string &blob, const std::vector<put_block_list_request_base::block_item> &block_list, const std::vector<std::pair<std::string, std::string>> &metadata)
+        {
+            m_blobClient->put_block_list(container, blob, block_list, metadata);
+        }
+
+
+
 }} // azure::storage_lite
+
+


### PR DESCRIPTION
- Delayed download Support
    - Do not block open call for download completion
    - Open and Flush will return while file download happens in background
    - Block Read/Write calls until the file download is complete
- Read Streaming Support
    - Support streaming of files for read operation
    - Works only when mount is done in RO mode
    - User can configure number of blocks to be cached per file
- Explicit cache eviction of file using sync command 
    - When file cache timeout is set to a higher value and user wants to clear certain file from cache 'sync' command can be used
    - Sync first opens a file and then calls fsync system call
    - If file is already present in the cache, this will invalidate the attribute cache and remove the file from cache 
    - If the file does not exists, as open is called first by sync it will download the latest file from container to cache
