### PR TITLE
Gen-2 ACL based blobs not showing correct permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ By default, blobfuse will log to syslog.  The default settings will, in some cas
 - Not optimized for updating an existing file. blobfuse downloads the entire file to local cache to be able to modify and update the file
 - When using enabling the "--use-attr-cache" feature, there may be an issue with overflow and will not clear the attribute cache until blobfuse is unmounted
 - See the list of differences between POSIX and blobfuse [here](https://github.com/Azure/azure-storage-fuse/wiki/4.-Limitations-%7C-Differences-from-POSIX)
+- For Gen-2 account is ACL is set at blob with additional principals and mask, 'chmod' operation done on that blob will remove mask and additional pricipals if any.
 
 ## License
 This project is licensed under MIT.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ By default, blobfuse will log to syslog.  The default settings will, in some cas
 - Not optimized for updating an existing file. blobfuse downloads the entire file to local cache to be able to modify and update the file
 - When using enabling the "--use-attr-cache" feature, there may be an issue with overflow and will not clear the attribute cache until blobfuse is unmounted
 - See the list of differences between POSIX and blobfuse [here](https://github.com/Azure/azure-storage-fuse/wiki/4.-Limitations-%7C-Differences-from-POSIX)
-- For Gen-2 account is ACL is set at blob with additional principals and mask, 'chmod' operation done on that blob will remove mask and additional pricipals if any.
+- For Gen-2 account blobs, a chmod operation will remove mask and additional principals in the ACL even if the prior ACLs included additional principals and mask.
 
 ## License
 This project is licensed under MIT.

--- a/blobfuse/include/StorageBfsClientBase.h
+++ b/blobfuse/include/StorageBfsClientBase.h
@@ -161,13 +161,18 @@ class BfsFileProperty
             
             if (!modestring.empty())
             {
+                if(modestring.size() != blobfuse_constants::acl_size)
+                {
+                    syslog(LOG_DEBUG, "Unexpected amount of permissions from service : %s", modestring.c_str());
+                }
                
-                for (char & c : modestring) {
+                for (uint32_t i = 0; i < blobfuse_constants::acl_size; i++)
+                {
                     // Start by pushing back the mode_t.
                     m_file_mode = m_file_mode << 1; // NOLINT(hicpp-signed-bitwise) (mode_t is signed, apparently. Suppress the inspection.)
                     // Then flip the new bit based on whether the mode is enabled or not.
                     // This works because we can expect a consistent 9 character modestring.
-                    m_file_mode |= (c != '-');
+                    m_file_mode |= (modestring[i] != '-');
                 }
             }
         }


### PR DESCRIPTION
- For Gen-2 accounts if ACL is set with mask and additional pricipals for a blob/container, file permissions are not shown correctly when mounted with blobfuse.