### PR TITLE
Vibhansa/read stream parallel download block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 2.8)
 
 # Change this while bumping up the version, needed for RHEL package
-set(VERSION "1.4.0")
+set(VERSION "1.4.1")
 
 # This macro is referred in code to print the current version
 # Change CPACK_DEBIAN_PACKAGE_DESCRIPTION as well in this file while bumping up the version
-add_definitions(-D_BLOBFUSE_VERSION_="1.4.0")
+add_definitions(-D_BLOBFUSE_VERSION_="1.4.1")
 
 set(CPACK_PACKAGE_VERSION_MAJOR 1)
 set(CPACK_PACKAGE_VERSION_MINOR 4)  
-set(CPACK_PACKAGE_VERSION_PATCH 0)
+set(CPACK_PACKAGE_VERSION_PATCH 1)
 set(CPACK_PACKAGE_VERSION_RELEASE 1)
 
 set (BLOBFUSE_HEADER
@@ -127,7 +127,7 @@ if(UNIX)
   set(CPACK_GENERATOR "DEB")
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Microsoft - Azure Storage")
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "fuse")
-  set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "blobfuse 1.4.0 - FUSE adapter for Azure Blob Storage")
+  set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "blobfuse 1.4.1 - FUSE adapter for Azure Blob Storage")
   set(CPACK_PACKAGE_NAME "blobfuse")
   set(CPACK_PACKAGE_VENDOR "Microsoft")
   include(CPack)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For more information, see the [wiki](https://github.com/Azure/azure-storage-fuse
     * [OPTIONAL] **--streaming=false** : Enable read streaming of files instead of disk-caching. This option works only with read-only mount. This option is only available from version 1.4.0
     * [OPTIONAL] **--stream-cache-mb=500** : Limit total amount of data being cached in memory to conserve memory footprint of blobfuse.
     * [OPTIONAL] **--max-blocks-per-file=3** : Maximum number of blocks to be cached in memory for a read streaming.
-    * [OPTIONAL] **--block-size-mb=16** : Size (in MB) of a block to be downloaded during streaming.
+    * [OPTIONAL] **--block-size-mb=16** : Size (in MB) of a block to be downloaded during streaming. If configured block-size is <= 64MB then block will be downloaded in a single thread. For higher block size parts of it will be downloaded in parallel. "--max-concurrency" parameter can be used to control parallelism factor. When higher block size is configured, memory usage of blobfuse will be high as these blocks are cached in memory only.
     
 ### Valid authentication setups:
 

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -284,13 +284,13 @@ int read_config(const std::string configFile)
         {
             std::string httpsProxyStr(value);
             config_options.httpsProxy = httpsProxyStr;
-            syslog(LOG_DEBUG, "Https Proxy server %s will be used to connect to storage account", config_options.httpsProxy.c_str());
+            syslog(LOG_INFO, "Https Proxy server %s will be used to connect to storage account", config_options.httpsProxy.c_str());
         }
         else if(line.find("httpProxy") != std::string::npos)
         {
             std::string httpProxyStr(value);
             config_options.httpProxy = httpProxyStr;
-            syslog(LOG_DEBUG, "Http Proxy server %s will be used to connect to storage account", config_options.httpsProxy.c_str());
+            syslog(LOG_INFO, "Http Proxy server %s will be used to connect to storage account", config_options.httpProxy.c_str());
         }
         else if(line.find("authType") != std::string::npos)
         {

--- a/blobfuse/include/AttrCacheBfsClient.h
+++ b/blobfuse/include/AttrCacheBfsClient.h
@@ -208,6 +208,9 @@ public:
     long int DownloadToFile(const std::string blobName, const std::string filePath, time_t& last_modified) override;
     long int DownloadToStream(const std::string blobName, std::ostream & destStream,
                 unsigned long long offset, unsigned long long size) override;
+    long int DownloadToBuffer(const std::string blobName, char* destBuff,
+                unsigned long long offset, unsigned long long size, int parallel) override;
+
     ///<summary>
     /// Creates a Directory
     ///</summary>

--- a/blobfuse/include/BlobStreamer.h
+++ b/blobfuse/include/BlobStreamer.h
@@ -83,6 +83,7 @@ class StreamObject {
     public:
         StreamObject() {
             ref_count = 0;
+            file_size = 0;
         }
 
         int IncRefCount() {
@@ -105,6 +106,14 @@ class StreamObject {
         int GetRefCount() {
             std::lock_guard<std::mutex> lock(m_mutex);
             return ref_count;
+        }
+
+        void SetSize(uint64_t size) {
+            file_size = size;
+        }
+
+        uint64_t GetSize() {
+            return file_size;
         }
 
         void Lock() {
@@ -134,6 +143,7 @@ class StreamObject {
 
     private:
         int                 ref_count;      // How many open handles are there for this file
+        uint64_t            file_size;      // Total size of the file
         std::mutex          m_mutex;        // Mutex for safety
 
         list<BlobBlock*>    m_block_cache_list;   // List of blocks cached for this file

--- a/blobfuse/include/BlockBlobBfsClient.h
+++ b/blobfuse/include/BlockBlobBfsClient.h
@@ -41,6 +41,9 @@ public:
     long int DownloadToFile(const std::string blobName, const std::string filePath, time_t& last_modified) override;
     long int DownloadToStream(const std::string blobName, std::ostream & destStream,
                 unsigned long long offset, unsigned long long size) override;
+    long int DownloadToBuffer(const std::string blobName, char* destBuff,
+                unsigned long long offset, unsigned long long size, int parallel) override;
+
     ///<summary>
     /// Creates a Directory
     ///</summary>

--- a/blobfuse/include/StorageBfsClientBase.h
+++ b/blobfuse/include/StorageBfsClientBase.h
@@ -306,6 +306,8 @@ public:
     virtual long int DownloadToFile(const std::string blobName, const std::string filePath, time_t& last_modified) = 0;
     virtual long int DownloadToStream(const std::string blobName, std::ostream & destStream,
                         unsigned long long offset, unsigned long long size) = 0;
+    virtual long int DownloadToBuffer(const std::string blobName, char* destBuff,
+                        unsigned long long offset, unsigned long long size, int parallel) = 0;
     ///<summary>
     /// Creates a Directory
     ///</summary>

--- a/blobfuse/src/AttrCacheBfsClient.cpp
+++ b/blobfuse/src/AttrCacheBfsClient.cpp
@@ -196,6 +196,12 @@ long int AttrCacheBfsClient::DownloadToStream(const std::string blobName, std::o
     return blob_client->DownloadToStream(blobName, destStream, offset, size);
 }
 
+long int AttrCacheBfsClient::DownloadToBuffer(const std::string blobName, char* destBuff,
+                                                unsigned long long offset, unsigned long long size, int parallel)
+{
+    return blob_client->DownloadToBuffer(blobName, destBuff, offset, size, parallel);
+}
+
 bool AttrCacheBfsClient::CreateDirectory(const std::string directoryPath)
 {
     std::shared_ptr<boost::shared_mutex> dir_mutex = attr_cache.get_dir_item(get_parent_str(directoryPath));

--- a/blobfuse/src/BlobStreamer.cpp
+++ b/blobfuse/src/BlobStreamer.cpp
@@ -115,9 +115,9 @@ BlobBlock* BlobStreamer::GetBlock(const char* file_name, uint64_t offset, Stream
         if (download_size < MAX_BLOCK_SIZE_FOR_SINGLE_READ) {
             azclient->DownloadToStream(file_name, block->buff, start_offset, download_size);
         } else {
-            char *buff = (char*)malloc(block_size);
+            char *buff = (char*)malloc(download_size);
             azclient->DownloadToBuffer(file_name, buff, start_offset, download_size, config_options.concurrency);
-            block->buff.write(buff, block_size);
+            block->buff.write(buff, download_size);
             free(buff);
         }
 

--- a/blobfuse/src/BlobStreamer.cpp
+++ b/blobfuse/src/BlobStreamer.cpp
@@ -184,9 +184,11 @@ int BlobStreamer::OpenFile(const char* file_name)
         // Mark one more open handle exists for this file
         obj->IncRefCount();
 
-        // Download and save the first block of this file for future read.
-        BlobBlock* block = GetBlock(file_name, 0, obj);
-        block->lck.unlock();
+        if (block_size <= MAX_BLOCK_SIZE_FOR_SINGLE_READ) {
+            // Download and save the first block of this file for future read.
+            BlobBlock* block = GetBlock(file_name, 0, obj);
+            block->lck.unlock();
+        }
     }
 
     return 0;

--- a/blobfuse/src/BlockBlobBfsClient.cpp
+++ b/blobfuse/src/BlockBlobBfsClient.cpp
@@ -329,6 +329,13 @@ long int BlockBlobBfsClient::DownloadToStream(const std::string blobName, std::o
     return 0;
 }
 
+long int BlockBlobBfsClient::DownloadToBuffer(const std::string blobName, char* destBuff,
+                                                unsigned long long offset, unsigned long long size, int parallel)
+{
+    m_blob_client->download_blob_to_buffer(configurations.containerName, blobName, offset, size, destBuff, parallel);
+    return 0;
+}
+
 ///<summary>
 /// Creates a Directory
 ///</summary>

--- a/cpplite/include/blob/blob_client.h
+++ b/cpplite/include/blob/blob_client.h
@@ -508,7 +508,8 @@ namespace azure { namespace storage_lite {
         /// <param name="size">The size of the data to download from the blob, in bytes.</param>
         /// <param name="os">The target stream.</param>
         AZURE_STORAGE_API virtual void download_blob_to_stream(const std::string &container, const std::string &blob, unsigned long long offset, unsigned long long size, std::ostream &os);
-
+        AZURE_STORAGE_API virtual void download_blob_to_buffer(const std::string &container, const std::string &blob, unsigned long long offset, unsigned long long size, char* buffer, int parallelism);
+        
         /// <summary>
         /// Downloads the contents of a blob to a local file.
         /// </summary>

--- a/cpplite/include/constants.dat
+++ b/cpplite/include/constants.dat
@@ -117,7 +117,7 @@ DAT(header_value_payload_format_nometadata, "application/json;odata=nometadata")
 DAT(header_value_payload_format_fullmetadata, "application/json;odata=fullmetadata")
 DAT(header_value_storage_blob_version, "2018-11-09")
 
-DAT(header_value_user_agent, "azure-storage-fuse/1.4.0")
+DAT(header_value_user_agent, "azure-storage-fuse/1.4.1")
 
 DAT(date_format_rfc_1123, "%a, %d %b %Y %H:%M:%S GMT")
 DAT(date_format_iso_8601, "%Y-%m-%dT%H:%M:%SZ")

--- a/cpplite/src/blob/blob_client_wrapper.cpp
+++ b/cpplite/src/blob/blob_client_wrapper.cpp
@@ -583,6 +583,38 @@ namespace azure {  namespace storage_lite {
             }
         }
 
+        void blob_client_wrapper::download_blob_to_buffer(const std::string &container, const std::string &blob, unsigned long long offset, unsigned long long size, char* buffer, int parallelism)
+        {
+            if(!is_valid())
+            {
+                errno = client_not_init;
+                return;
+            }
+
+            try
+            {
+                auto task = m_blobClient->download_blob_to_buffer(container, blob, offset, size, buffer, parallelism);
+                task.wait();
+                auto result = task.get();
+
+                if(!result.success())
+                {
+                    errno = std::stoi(result.error().code);
+                }
+                else
+                {
+                    errno = 0;
+                }
+            }
+            catch(std::exception& ex)
+            {
+                logger::log(log_level::error, "Unknown failure in download_blob_to_buffer.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
+                errno = unknown_error;
+                return;
+            }
+        }
+
+
         void blob_client_wrapper::download_blob_to_file(const std::string &container, const std::string &blob, const std::string &destPath, time_t &returned_last_modified, size_t parallel)
         {
             if(!is_valid())


### PR DESCRIPTION
If the block size if bigger then 64MB, instead of downloading in single thread, download in parallel for better performance.