### PR TITLE
Mask out SYNC and DIRECT flags in open call as write operation fails …

### DIFF
--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -63,6 +63,10 @@ int azs_open(const char *path, struct fuse_file_info *fi)
 {
     syslog (LOG_DEBUG, "azs_open called with path = %s, fi->flags = %X.\n", path, fi->flags);
     if (fi->flags & O_SYNC || fi->flags & __O_DIRECT) {
+        // Blobfuse does not support DIRECT and SYNC flags, if user application pass them on to blobfuse and 
+        // it open file with these, follow up write operations will fail with "Invalid argument" error
+        // Just masking them out here in open call itself for write to work fine
+        // Oracle RMAN is one such application which sends these flags during backup
         fi->flags &= ~(O_SYNC | __O_DIRECT);
         syslog (LOG_DEBUG, "azs_open reset flags path = %s, fi->flags = %X.\n", path, fi->flags);
     }

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -62,6 +62,11 @@ int DownloadFileToDisk(std::string pathString, std::string mntPathString, bool i
 int azs_open(const char *path, struct fuse_file_info *fi)
 {
     syslog (LOG_DEBUG, "azs_open called with path = %s, fi->flags = %X.\n", path, fi->flags);
+    if (fi->flags & O_SYNC || fi->flags & __O_DIRECT) {
+        fi->flags &= ~(O_SYNC | __O_DIRECT);
+        syslog (LOG_DEBUG, "azs_open reset flags path = %s, fi->flags = %X.\n", path, fi->flags);
+    }
+
     std::string pathString(path);
     std::replace(pathString.begin(), pathString.end(), '\\', '/');
     


### PR DESCRIPTION
#665 : Mask out SYNC and DIRECT flags in open call as write operation fails if they are given in open call 