### PR TITLE
Initial changes for fuse 3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,15 @@ elseif( EXISTS "/etc/os-release")
   set(Boost_USE_STATIC_LIBS OFF)
 endif()
 
+if(AZS_FUSE3)
+  set(FUSE_LIB fuse3)
+  set(FUSE_INCLUDES /usr/include/fuse3)
+  add_definitions(-DAZS_FUSE3)
+else()
+  set(FUSE_LIB fuse)
+  set(FUSE_INCLUDES "")
+endif()
+
 if(UNIX)
   #set( CMAKE_VERBOSE_MAKEFILE on )
   project(blobfuse)
@@ -93,7 +102,7 @@ if(UNIX)
 
   set(CMAKE_CXX_FLAGS "${CMAKE_THREAD_LIBS_INIT} ${WARNING} ${CMAKE_CXX_FLAGS}")
 
-  include_directories(${CMAKE_SOURCE_DIR}/blobfuse ${CMAKE_SOURCE_DIR}/blobfuse/include ${CMAKE_SOURCE_DIR}/cpplite/include ${CMAKE_SOURCE_DIR}/cpplite/adls/include ${CURL_INCLUDE_DIRS} ${GNUTLS_INCLUDE_DIR} ${Boost_INCLUDE_DIR} nlohmann-json)
+  include_directories(${CMAKE_SOURCE_DIR}/blobfuse ${CMAKE_SOURCE_DIR}/blobfuse/include ${CMAKE_SOURCE_DIR}/cpplite/include ${CMAKE_SOURCE_DIR}/cpplite/adls/include ${CURL_INCLUDE_DIRS} ${GNUTLS_INCLUDE_DIR} ${Boost_INCLUDE_DIR} nlohmann-json ${FUSE_INCLUDES})
   set(CMAKE_MACOSX_RPATH ON)
   pkg_search_module(UUID REQUIRED uuid)
   
@@ -102,9 +111,9 @@ if(UNIX)
   add_executable(blobfuse ${BLOBFUSE_HEADER} ${BLOBFUSE_SOURCE} blobfuse/main.cpp)
 
   if(INCLUDE_EXTRALIB)
-    target_link_libraries(blobfuse azure-storage-adls azure-storage-lite ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} fuse gcrypt stdc++ m dl)
+    target_link_libraries(blobfuse azure-storage-adls azure-storage-lite ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${FUSE_LIB} gcrypt stdc++ m dl)
   else()
-    target_link_libraries(blobfuse azure-storage-adls azure-storage-lite ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} fuse gcrypt)
+    target_link_libraries(blobfuse azure-storage-adls azure-storage-lite ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${FUSE_LIB} gcrypt)
   endif()
   install(TARGETS blobfuse
     PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE

--- a/blobfuse/blobfuse.cpp
+++ b/blobfuse/blobfuse.cpp
@@ -375,7 +375,10 @@ void destroyBlobfuseOnAuthError()
     if (n == -1) {
         syslog(LOG_ERR, "Failed to report back failure.");
     }
-    
+#if FUSE_MAJOR_VERSION < 3
+    fuse_unmount(config_options.mntPath.c_str(), NULL);
+#endif
+
     if (is_directory_mounted(config_options.mntPath.c_str())) 
     {
         char errStr[] = "Failed to unmount blobfuse. Manually unmount using fusermount command.\n";
@@ -397,7 +400,11 @@ void destroyBlobfuseOnAuthError()
 }
 
 int configure_tls();
+#if FUSE_MAJOR_VERSION < 3
+void *azs_init(struct fuse_conn_info * conn )
+#else
 void *azs_init(struct fuse_conn_info * conn, struct fuse_config* cfg )
+#endif
 {
     syslog(LOG_DEBUG, "azs_init ran");
 
@@ -407,8 +414,10 @@ void *azs_init(struct fuse_conn_info * conn, struct fuse_config* cfg )
     cfg->entry_timeout = 120;
     cfg->negative_timeout = 120;
     */
+#if FUSE_MAJOR_VERSION >= 3
     cfg->kernel_cache = 1;
     cfg->hard_remove = 1;
+#endif
 
    // even 4.18 does not like this so 5.4 is not enough so 
     if (kernel_version < blobfuse_constants::minKernelVersion) {
@@ -416,10 +425,21 @@ void *azs_init(struct fuse_conn_info * conn, struct fuse_config* cfg )
 	// let fuselib pick 128KB
 	//conn->max_read = 4194304;
     } 
+    else {
+#if FUSE_MAJOR_VERSION < 3
+        conn->want |= FUSE_CAP_BIG_WRITES;
+#else
+        // big writes always enabled in fuse3
+#endif
+    }
     conn->max_readahead = 4194304;
     conn->max_background = 128;
     //  conn->want |= FUSE_CAP_WRITEBACK_CACHE | FUSE_CAP_EXPORT_SUPPORT; // TODO: Investigate putting this back in when we downgrade to fuse 2.9
+
+#if FUSE_MAJOR_VERSION >=3
+    // allows kernel to flush cache on mtime change or file size change
     conn->want |= FUSE_CAP_AUTO_INVAL_DATA;
+#endif
 
     g_gc_cache = std::make_shared<gc_cache>(config_options.tmpPath, config_options.fileCacheTimeoutInSeconds);
     g_gc_cache->run();
@@ -1268,6 +1288,13 @@ void configure_fuse(struct fuse_args *args)
     // FUSE contains a feature where it automatically implements 'soft' delete if one process has a file open when another calls unlink().
     // This feature causes us a bunch of problems, so we use "-ohard_remove" to disable it, and track the needed 'soft delete' functionality on our own.
     fuse_opt_add_arg(args, "-ofsname=blobfuse");
+
+#if FUSE_MAJOR_VERSION < 3
+    fuse_opt_add_arg(args, "-ohard_remove");
+    fuse_opt_add_arg(args, "-obig_writes");
+    fuse_opt_add_arg(args, "-okernel_cache");
+#endif
+
     umask(0);
 }
 

--- a/blobfuse/blobfuse.h
+++ b/blobfuse/blobfuse.h
@@ -96,7 +96,11 @@ bool is_directory_blob(unsigned long long size, std::vector<std::pair<std::strin
  * @param  stbuf The 'stat' struct containing the output information.
  * @return       TODO: Error codes
  */
+#if FUSE_MAJOR_VERSION >=3
 int azs_getattr(const char *path, struct stat *stbuf, struct fuse_file_info*);
+#else
+int azs_getattr(const char *path, struct stat *stbuf);
+#endif
 
 /**
 * statfs gets the file system statistics for the tmpPath/local cache path
@@ -130,8 +134,11 @@ int azs_mkdir(const char *path, mode_t mode);
  * @param  fi     File info about the directory to be read.
  * @return        TODO: error codes.
  */
+#if FUSE_MAJOR_VERSION >= 3
 int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi, fuse_readdir_flags);
-
+#else
+int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+#endif
 
 /**
  * Open an item (a file) for writing or reading.
@@ -233,7 +240,11 @@ int azs_rmdir(const char *path);
  * @param  dst Path to the destination file or directory.
  * @return      TODO: Error codes.
  */
+#if FUSE_MAJOR_VERSION >= 3
 int azs_rename(const char *src, const char *dst, unsigned int);
+#else
+int azs_rename(const char *src, const char *dst);
+#endif
 
 /**
  * Initialize the filesystem.
@@ -244,7 +255,11 @@ int azs_rename(const char *src, const char *dst, unsigned int);
  * @param  conn Configuration info of fuse driver.
  * @return      TODO: Error codes.
  */
+#if FUSE_MAJOR_VERSION >= 3
 void* azs_init(struct fuse_conn_info * conn, struct fuse_config*);
+#else
+void* azs_init(struct fuse_conn_info * conn);
+#endif
 
 /**
  * Un-mount the file system
@@ -261,10 +276,17 @@ void azs_destroy(void *private_data);
 int azs_access(const char *path, int mask);
 int azs_fsync(const char *path, int isdatasync, struct fuse_file_info *fi);
 int azs_fsyncdir(const char *path, int isdatasync, struct fuse_file_info *fi);
+#if FUSE_MAJOR_VERSION >= 3
 int azs_chown(const char *path, uid_t uid, gid_t gid, struct fuse_file_info*);
 int azs_chmod(const char *path, mode_t mode, struct fuse_file_info*);
 int azs_utimens(const char *path, const struct timespec ts[2], struct fuse_file_info*);
 int azs_truncate(const char *path, off_t off, struct fuse_file_info*);
+#else
+int azs_chown(const char *path, uid_t uid, gid_t gid);
+int azs_chmod(const char *path, mode_t mode);
+int azs_utimens(const char *path, const struct timespec ts[2]);
+int azs_truncate(const char *path, off_t off);
+#endif
 int azs_setxattr(const char *path, const char *name, const char *value, size_t size, int flags);
 
 // symlink related handlers

--- a/blobfuse/blobfuse.h
+++ b/blobfuse/blobfuse.h
@@ -21,11 +21,17 @@
 #include <gcrypt.h>
 #include <pthread.h>
 
-
+#ifdef AZS_FUSE3
+// fuse 3.4 is the oldest version used by a supported distro (debian 10)
+// which includes fuse3 at all
+#define FUSE_USE_VERSION 34
+#else
 // Declare that we're using version 2.9 of FUSE
 // 3.0 is not built-in to many distros yet.
 // This line must come before #include <fuse.h>.
 #define FUSE_USE_VERSION 29
+#endif
+
 #include <fuse.h>
 
 #include <stddef.h>
@@ -90,7 +96,7 @@ bool is_directory_blob(unsigned long long size, std::vector<std::pair<std::strin
  * @param  stbuf The 'stat' struct containing the output information.
  * @return       TODO: Error codes
  */
-int azs_getattr(const char *path, struct stat *stbuf);
+int azs_getattr(const char *path, struct stat *stbuf, struct fuse_file_info*);
 
 /**
 * statfs gets the file system statistics for the tmpPath/local cache path
@@ -124,7 +130,7 @@ int azs_mkdir(const char *path, mode_t mode);
  * @param  fi     File info about the directory to be read.
  * @return        TODO: error codes.
  */
-int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi, fuse_readdir_flags);
 
 
 /**
@@ -227,7 +233,7 @@ int azs_rmdir(const char *path);
  * @param  dst Path to the destination file or directory.
  * @return      TODO: Error codes.
  */
-int azs_rename(const char *src, const char *dst);
+int azs_rename(const char *src, const char *dst, unsigned int);
 
 /**
  * Initialize the filesystem.
@@ -238,7 +244,7 @@ int azs_rename(const char *src, const char *dst);
  * @param  conn Configuration info of fuse driver.
  * @return      TODO: Error codes.
  */
-void* azs_init(struct fuse_conn_info * conn);
+void* azs_init(struct fuse_conn_info * conn, struct fuse_config*);
 
 /**
  * Un-mount the file system
@@ -255,10 +261,10 @@ void azs_destroy(void *private_data);
 int azs_access(const char *path, int mask);
 int azs_fsync(const char *path, int isdatasync, struct fuse_file_info *fi);
 int azs_fsyncdir(const char *path, int isdatasync, struct fuse_file_info *fi);
-int azs_chown(const char *path, uid_t uid, gid_t gid);
-int azs_chmod(const char *path, mode_t mode);
-int azs_utimens(const char *path, const struct timespec ts[2]);
-int azs_truncate(const char *path, off_t off);
+int azs_chown(const char *path, uid_t uid, gid_t gid, struct fuse_file_info*);
+int azs_chmod(const char *path, mode_t mode, struct fuse_file_info*);
+int azs_utimens(const char *path, const struct timespec ts[2], struct fuse_file_info*);
+int azs_truncate(const char *path, off_t off, struct fuse_file_info*);
 int azs_setxattr(const char *path, const char *name, const char *value, size_t size, int flags);
 
 // symlink related handlers

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -1,5 +1,6 @@
 #include "blobfuse.h"
 #include <sys/file.h>
+#include <utime.h>
 #include <FileLockMap.h>
 
 #include <include/StorageBfsClientBase.h>
@@ -594,7 +595,7 @@ int azs_unlink(const char *path)
     return retval;
 }
 
-int azs_truncate(const char * path, off_t off)
+int azs_truncate(const char * path, off_t off, struct fuse_file_info*)
 {
     AZS_DEBUGLOGV("azs_truncate called.  Path = %s, offset = %s\n", path, to_str(off).c_str());
 

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -595,7 +595,11 @@ int azs_unlink(const char *path)
     return retval;
 }
 
+#if FUSE_MAJOR_VERSION >= 3
 int azs_truncate(const char * path, off_t off, struct fuse_file_info*)
+#else
+int azs_truncate(const char * path, off_t off)
+#endif
 {
     AZS_DEBUGLOGV("azs_truncate called.  Path = %s, offset = %s\n", path, to_str(off).c_str());
 

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -115,7 +115,11 @@ int ensure_files_directory_exists_in_cache(const std::string &file_path)
     return status;
 }
 
+#if FUSE_MAJOR_VERSION >= 3
 int azs_getattr(const char *path, struct stat *stbuf, struct fuse_file_info*)
+#else
+int azs_getattr(const char *path, struct stat *stbuf)
+#endif
 {
     AZS_DEBUGLOGV("azs_getattr called with path = %s\n", path);
 
@@ -516,14 +520,22 @@ int azs_fsyncdir(const char *path, int, struct fuse_file_info *)
     return 0; 
 }
 
+#if FUSE_MAJOR_VERSION >= 3
 int azs_chown(const char * /*path*/, uid_t /*uid*/, gid_t /*gid*/, struct fuse_file_info*)
+#else
+int azs_chown(const char * /*path*/, uid_t /*uid*/, gid_t /*gid*/)
+#endif
 {
     //TODO: is it ok to change ownership if it is ADLS. Should blbofuse allow this?
     // Block blob should allow changing ownership.
     return 0;
 }
 
+#if FUSE_MAJOR_VERSION >= 3
 int azs_chmod(const char *path, mode_t mode, struct fuse_file_info*)
+#else
+int azs_chmod(const char *path, mode_t mode)
+#endif
 {
     //This is only functional when --use-adls is enabled as a mount flag
     AZS_DEBUGLOGV("azs_chmod called with path = %s, mode = %o.\n", path, mode);
@@ -543,7 +555,11 @@ int azs_chmod(const char *path, mode_t mode, struct fuse_file_info*)
 }
 
 //#ifdef HAVE_UTIMENSAT
+#if FUSE_MAJOR_VERSION >= 3
 int azs_utimens(const char * /*path*/, const struct timespec[2] /*ts[2]*/, struct fuse_file_info*)
+#else
+int azs_utimens(const char * /*path*/, const struct timespec[2] /*ts[2]*/)
+#endif
 {
     //TODO: Implement
     //    return -ENOSYS;
@@ -555,7 +571,11 @@ int azs_utimens(const char * /*path*/, const struct timespec[2] /*ts[2]*/, struc
 // TODO: Fix bugs where the a file has been created but not yet uploaded.
 // TODO: Fix the bug where this fails for multi-level dirrectories.
 // TODO: If/when we upgrade to FUSE 3.0, we will need to worry about the additional possible flags (RENAME_EXCHANGE and RENAME_NOREPLACE)
+#if FUSE_MAJOR_VERSION >= 3
 int azs_rename(const char *src, const char *dst, unsigned int)
+#else
+int azs_rename(const char *src, const char *dst)
+#endif
 {
     AZS_DEBUGLOGV("azs_rename called with src = %s, dst = %s.\n", src, dst);
 
@@ -566,7 +586,11 @@ int azs_rename(const char *src, const char *dst, unsigned int)
 
     errno = 0;
     struct stat stbuf;
+#if FUSE_MAJOR_VERSION >= 3
     errno = azs_getattr(fromStr.c_str(), &stbuf, NULL);
+#else
+    errno = azs_getattr(fromStr.c_str(), &stbuf);
+#endif
     if (errno != 0)
         return errno;
 

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -115,7 +115,7 @@ int ensure_files_directory_exists_in_cache(const std::string &file_path)
     return status;
 }
 
-int azs_getattr(const char *path, struct stat *stbuf)
+int azs_getattr(const char *path, struct stat *stbuf, struct fuse_file_info*)
 {
     AZS_DEBUGLOGV("azs_getattr called with path = %s\n", path);
 
@@ -516,14 +516,14 @@ int azs_fsyncdir(const char *path, int, struct fuse_file_info *)
     return 0; 
 }
 
-int azs_chown(const char * /*path*/, uid_t /*uid*/, gid_t /*gid*/)
+int azs_chown(const char * /*path*/, uid_t /*uid*/, gid_t /*gid*/, struct fuse_file_info*)
 {
     //TODO: is it ok to change ownership if it is ADLS. Should blbofuse allow this?
     // Block blob should allow changing ownership.
     return 0;
 }
 
-int azs_chmod(const char *path, mode_t mode)
+int azs_chmod(const char *path, mode_t mode, struct fuse_file_info*)
 {
     //This is only functional when --use-adls is enabled as a mount flag
     AZS_DEBUGLOGV("azs_chmod called with path = %s, mode = %o.\n", path, mode);
@@ -543,7 +543,7 @@ int azs_chmod(const char *path, mode_t mode)
 }
 
 //#ifdef HAVE_UTIMENSAT
-int azs_utimens(const char * /*path*/, const struct timespec[2] /*ts[2]*/)
+int azs_utimens(const char * /*path*/, const struct timespec[2] /*ts[2]*/, struct fuse_file_info*)
 {
     //TODO: Implement
     //    return -ENOSYS;
@@ -555,7 +555,7 @@ int azs_utimens(const char * /*path*/, const struct timespec[2] /*ts[2]*/)
 // TODO: Fix bugs where the a file has been created but not yet uploaded.
 // TODO: Fix the bug where this fails for multi-level dirrectories.
 // TODO: If/when we upgrade to FUSE 3.0, we will need to worry about the additional possible flags (RENAME_EXCHANGE and RENAME_NOREPLACE)
-int azs_rename(const char *src, const char *dst)
+int azs_rename(const char *src, const char *dst, unsigned int)
 {
     AZS_DEBUGLOGV("azs_rename called with src = %s, dst = %s.\n", src, dst);
 
@@ -566,7 +566,7 @@ int azs_rename(const char *src, const char *dst)
 
     errno = 0;
     struct stat stbuf;
-    errno = azs_getattr(fromStr.c_str(), &stbuf);
+    errno = azs_getattr(fromStr.c_str(), &stbuf, NULL);
     if (errno != 0)
         return errno;
 

--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,10 @@ then
 	fi
 fi
 
+if [ -n "${AZS_FUSE3}" ]; then
+   cmake_args="-DAZS_FUSE3=1 $cmake_args"
+fi
+
 ## Use cmake3 if it's available.  If not, then fallback to the default "cmake".  Otherwise, fail.
 cmake3 $cmake_args
 if [ $? -ne 0 ]


### PR DESCRIPTION
This makes it possible to conditionally build against fuse3, prinicipally so that FUSE_CAP_AUTO_INVAL_DATA can be used (see #668)

This results in a working file system for me when building against fuse 3, although I havent extensively tested it.

if AZS_FUSE3 environment variable is defined before running build.sh fuse3 will be used.  

I have left in fuse 2 code path because it seems fuse 2 would still need to be used for some of the older supported OS's (I'm using the OS's that are included in the binary build artifacts on the release page as a guide for what is supported 'officially'):

* Debian 9 (EOL June 2022)
* Ubuntu 18.04 (EOL April 2023)

I defined FUSE_USE_VERSION to 34 if using fuse3, as Debian 10 is the oldest supported OS which contains fuse 3, and that uses 3.4.1

There are zero changes to the code when building against fuse 2.