### PR TITLE
[BUG] Check length of slice rather than capacity

### DIFF
--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -326,15 +326,15 @@ func (az *AzStorage) ReadFile(options internal.ReadFileOptions) (data []byte, er
 	return az.storage.ReadBuffer(options.Handle.Path, 0, 0)
 }
 
-func (az *AzStorage) ReadInBuffer(options internal.ReadInBufferOptions) (len int, err error) {
+func (az *AzStorage) ReadInBuffer(options internal.ReadInBufferOptions) (length int, err error) {
 	//log.Trace("AzStorage::ReadInBuffer : Read %s from %d offset", h.Path, offset)
 
 	if options.Offset > options.Handle.Size {
 		return 0, syscall.ERANGE
 	}
 
-	var dataLen int64 = int64(cap(options.Data))
-	if options.Handle.Size < (options.Offset + int64(cap(options.Data))) {
+	var dataLen int64 = int64(len(options.Data))
+	if options.Handle.Size < (options.Offset + int64(len(options.Data))) {
 		dataLen = options.Handle.Size - options.Offset
 	}
 
@@ -347,7 +347,7 @@ func (az *AzStorage) ReadInBuffer(options internal.ReadInBufferOptions) (len int
 		log.Err("AzStorage::ReadInBuffer : Failed to read %s (%s)", options.Handle.Path, err.Error())
 	}
 
-	len = int(dataLen)
+	length = int(dataLen)
 	return
 }
 


### PR DESCRIPTION
Current we check against the capacity - this is problematic as libfuse create a slice with a capacity of the file size. What we need is the slice length