### PR TITLE
[BUG] Upload after creating does not work if > 256MB

### DIFF
--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -221,14 +221,14 @@ func (dl *Datalake) Exists(name string) bool {
 // CreateFile : Create a new file in the filesystem/directory
 func (dl *Datalake) CreateFile(name string, mode os.FileMode) error {
 	log.Trace("Datalake::CreateFile : name %s", name)
-	accessControlList := getAccessControlList(mode)
-	fileURL := dl.Filesystem.NewRootDirectoryURL().NewFileURL(filepath.Join(dl.Config.prefixPath, name))
-	_, err := fileURL.Create(context.Background(), azbfs.BlobFSHTTPHeaders{
-		ContentType: getContentType(name),
-	}, azbfs.BlobFSAccessControl{ACL: accessControlList})
-
+	err := dl.BlockBlob.CreateFile(name, mode)
 	if err != nil {
 		log.Err("Datalake::CreateFile : Failed to create file %s (%s)", name, err.Error())
+		return err
+	}
+	err = dl.ChangeMod(name, mode)
+	if err != nil {
+		log.Err("Datalake::CreateFile : Failed to set permissions on file %s (%s)", name, err.Error())
 		return err
 	}
 


### PR DESCRIPTION
Currently when a file is created it uses the dfs endpoint - this means we cannot use the blob endpoint for staging and committing. Now we create using block endpoint and just do a second call for ACLs.
