### PR TITLE
List blob retrying for 20 times even on 403 errors

### DIFF
--- a/blobfuse-artifacts.yml
+++ b/blobfuse-artifacts.yml
@@ -622,7 +622,10 @@ stages:
   jobs:
   - job: ReleaseBlobfuse
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
+
+    variables:
+      - group: NightlyBlobFuse
 
     steps:
       - checkout: none

--- a/blobfuse-artifacts.yml
+++ b/blobfuse-artifacts.yml
@@ -639,14 +639,53 @@ stages:
       
       - script: |
           sudo ls -lRt $(Build.ArtifactStagingDirectory)
-        displayName: "List the artifacts"      
-      
+          md5sum $(Build.ArtifactStagingDirectory)/blobfuse/*.deb
+          md5sum $(Build.ArtifactStagingDirectory)/blobfuse/*.rpm
+        displayName: 'List Artifacts'      
       
       - ${{ if eq(parameters.post_release, true) }}:
+        # Send images for signing
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+          displayName: 'ESRP CodeSigning blobfuse'
+          inputs:
+            ConnectedServiceName: 'ESRP Code signing blobfuse'
+            FolderPath: '$(Build.ArtifactStagingDirectory)/blobfuse'
+            Pattern: '*.rpm, *.deb'
+            signConfigType: inlineSignParams
+            VerboseLogin: true
+            inlineOperation: |
+              [
+                {
+                  "KeyCode" : $(ESRP_BLOBFUSE_KEY_CODE),
+                  "OperationCode" : "LinuxSign",
+                  "Parameters" : {},
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+                }
+              ]
+
+        # Validate signed images have md5sum changed
+        - script: |
+            chmod 755 $(Build.ArtifactStagingDirectory)/blobfuse/*.rpm
+            chmod 755 $(Build.ArtifactStagingDirectory)/blobfuse/*.deb
+            rm -rf $(Build.ArtifactStagingDirectory)/blobfuse/*.md
+            mv $(Build.ArtifactStagingDirectory)/blobfuse/* $(Build.ArtifactStagingDirectory)/
+            rm -rf $(Build.ArtifactStagingDirectory)/blobfuse/
+          displayName: 'Make Artifacts executable'
+
+        - script: |
+            sudo ls -lRt $(Build.ArtifactStagingDirectory)
+            md5sum $(Build.ArtifactStagingDirectory)/*.deb
+            md5sum $(Build.ArtifactStagingDirectory)/*.rpm
+          displayName: 'List Signed Artifacts'
+
+        - task: PublishBuildArtifacts@1
+          inputs:
+            artifactName: 'blobfuse-signed'
+          displayName: 'Publish Signed Artifacts'
+
         - task: GitHubRelease@1
           inputs:
-            #gitHubConnection: 'vibhansa-msft-git'
-            #repositoryName: 'vibhansa-msft/azure-storage-fuse'
             gitHubConnection: 'blobfuse-git-rel'
             repositoryName: 'Azure/azure-storage-fuse'
             action: 'edit'

--- a/blobfuse/directoryapis.cpp
+++ b/blobfuse/directoryapis.cpp
@@ -221,11 +221,12 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
                 AZS_DEBUGLOGV("#### So far %u items retreived in %u iterations.\n", total_count, iteration);
             
             }
-        }
-        else if (errno == 404)
-        {
+        } else if (errno == 404) {
             success = true;
             syslog(LOG_WARNING, "list_blobs indicates blob not found");
+        } else if (errno == 403) {
+            success = true;
+            syslog(LOG_WARNING, "list_blobs indicates permission error");
         }
         else
         {

--- a/blobfuse/directoryapis.cpp
+++ b/blobfuse/directoryapis.cpp
@@ -234,7 +234,7 @@ int azs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t, stru
             success = false;
             syslog(LOG_WARNING, "list_blobs failed for the %d time with errno = %d.\n", failcount, errno);
         }
-    } while (((!continuation.empty()) || !success) && (failcount < 20));
+    } while (((!continuation.empty()) || !success) && (failcount < maxFailCount));
 
     local_list_results.clear();
     local_list_results.shrink_to_fit();

--- a/blobfuse/src/BlockBlobBfsClient.cpp
+++ b/blobfuse/src/BlockBlobBfsClient.cpp
@@ -1007,7 +1007,7 @@ int BlockBlobBfsClient::ListAllItemsSegmented(
                 results.emplace_back(response.m_items, skip_first);
             }
         }
-        else if (errno == 404)
+        else if (errno == 404 || errno == 403)
         {
             success = true;
             syslog(LOG_WARNING, "list_blobs_segmented indicates blob not found");

--- a/blobfuse/src/BlockBlobBfsClient.cpp
+++ b/blobfuse/src/BlockBlobBfsClient.cpp
@@ -1016,7 +1016,7 @@ int BlockBlobBfsClient::ListAllItemsSegmented(
         else if (errno == 400 || errno == 404 || errno == 403)
         {
             success = true;
-            syslog(LOG_WARNING, "list_blobs_segmented indicates blob not found");
+            syslog(LOG_WARNING, "list_blobs_segmented failed to list blobs");
         }
         else
         {

--- a/blobfuse/src/DataLakeBfsClient.cpp
+++ b/blobfuse/src/DataLakeBfsClient.cpp
@@ -381,7 +381,7 @@ D_RETURN_CODE DataLakeBfsClient::IsDirectoryEmpty(std::string path)
         else if (errno == 400 || errno == 404 || errno == 403)
         {
             success = true;
-            syslog(LOG_WARNING, "adls list list_blobs_segmented indicates blob not found errno: %u", errno);
+            syslog(LOG_WARNING, "adls list list_blobs_segmented failed to list blobfs errno: %u", errno);
         }
         else
         {

--- a/blobfuse/src/DataLakeBfsClient.cpp
+++ b/blobfuse/src/DataLakeBfsClient.cpp
@@ -378,7 +378,7 @@ D_RETURN_CODE DataLakeBfsClient::IsDirectoryEmpty(std::string path)
                 }
             }
         }
-        else if (errno ==400 || errno == 404)
+        else if (errno == 400 || errno == 404 || errno == 403)
         {
             success = true;
             syslog(LOG_WARNING, "adls list list_blobs_segmented indicates blob not found errno: %u", errno);

--- a/blobfuse/src/DataLakeBfsClient.cpp
+++ b/blobfuse/src/DataLakeBfsClient.cpp
@@ -381,7 +381,7 @@ D_RETURN_CODE DataLakeBfsClient::IsDirectoryEmpty(std::string path)
         else if (errno == 400 || errno == 404 || errno == 403)
         {
             success = true;
-            syslog(LOG_WARNING, "adls list list_blobs_segmented failed to list blobfs errno: %u", errno);
+            syslog(LOG_WARNING, "adls list list_blobs_segmented failed to list blobs errno: %u", errno);
         }
         else
         {

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -276,7 +276,7 @@ int azs_getattr(const char *path, struct stat *stbuf)
                 syslog(LOG_WARNING, "File does not currently exist on the storage or cache, errno : %d", errno);
                 response.reset();
                 return -(ENOENT);
-            } else if (errno == 404) {
+            } else if (errno == 403) {
                 syslog(LOG_WARNING, "User does not have permission to access this resource, errno : %d", errno);
                 response.reset();
                 return -(EPERM);


### PR DESCRIPTION
In list-blob, get-attr and is-directory-empty checks blobfuse considers 404 as error while 403 status codes are retried. In most listing cases max retry of 20 is hard coded so if user does not have permission on a folder/file REST call will fail with 403 and blobfuse will always go in a loop of 20 retries affecting the performance of overall operation. As a fix to this it will now condifer 403 as non-retryable error and stop after first attempt.