### PR TITLE
Remount on same path is not failing

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -83,15 +83,15 @@ var pipelineStarted bool
 
 func (opt *mountOptions) validate(skipEmptyMount bool) error {
 	if opt.MountPath == "" {
-		return fmt.Errorf("argument error: Mount path not provided")
+		return fmt.Errorf("argument error: mount path not provided")
 	}
 
 	if _, err := os.Stat(opt.MountPath); os.IsNotExist(err) {
-		return fmt.Errorf("argument error: Mount Directory does not exists")
+		return fmt.Errorf("argument error: mount directory does not exists")
 	} else if common.IsDirectoryMounted(opt.MountPath) {
-		return fmt.Errorf("argument error: Directory is already mounted")
+		return fmt.Errorf("argument error: directory is already mounted")
 	} else if !skipEmptyMount && !common.IsDirectoryEmpty(opt.MountPath) {
-		return fmt.Errorf("argument error: Mount directory is not empty")
+		return fmt.Errorf("argument error: mount directory is not empty")
 	}
 
 	if err := common.ELogLevel.Parse(opt.Logging.LogLevel); err != nil {

--- a/common/util.go
+++ b/common/util.go
@@ -63,7 +63,10 @@ func IsDirectoryMounted(path string) bool {
 		if strings.TrimSpace(line) != "" {
 			mntPoint := strings.Split(line, " ")[1]
 			if path == mntPoint {
-				if strings.Index(line, " fuse.") > -1 {
+				// with earlier fuse driver ' fuse.' was searched in /etc/mtab
+				// however with libfuse entry does not have that signature
+				// if this path is already mounted using fuse then fail
+				if strings.Contains(line, "fuse") {
 					//fmt.Println(path, " is already mounted.")
 					return true
 				}

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -131,7 +131,7 @@ func (c *FileCache) Start(ctx context.Context) error {
 	}
 
 	if c.policy == nil {
-		return fmt.Errorf("FileCache::Start : No cache policy created")
+		return fmt.Errorf("config error in %s error [cache policy missing]", c.Name())
 	}
 
 	c.policy.StartPolicy()

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -199,7 +199,7 @@ func (lf *Libfuse) Configure() error {
 	err := config.UnmarshalKey(lf.Name(), &conf)
 	if err != nil {
 		log.Err("Libfuse::Configure : config error [invalid config attributes]")
-		return fmt.Errorf("Libfuse: config error [invalid config attributes]")
+		return fmt.Errorf("config error in %s [invalid config attributes]", lf.Name())
 	}
 	// Extract values from 'conf' and store them as you wish here
 
@@ -223,7 +223,7 @@ func (lf *Libfuse) Configure() error {
 	err = lf.Validate(&conf)
 	if err != nil {
 		log.Err("Libfuse::Configure : config error [invalid config settings]")
-		return fmt.Errorf("libfuse config error: invalid config settings")
+		return fmt.Errorf("config error in %s [invalid config settings]", lf.Name())
 	}
 
 	log.Info("Libfuse::Configure : read-only %t, allow-other %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d",

--- a/component/loopback/loopback_fs.go
+++ b/component/loopback/loopback_fs.go
@@ -73,13 +73,13 @@ func (lfs *LoopbackFS) Configure() error {
 	err := config.UnmarshalKey(compName, &conf)
 	if err != nil {
 		log.Err("LoopbackFS: config error [invalid config attributes]")
-		return fmt.Errorf("LoopbackFS: config error [invalid config attributes]")
+		return fmt.Errorf("config error in %s [%s]", lfs.Name(), err)
 	}
 	if _, err := os.Stat(conf.Path); os.IsNotExist(err) {
 		err = os.MkdirAll(conf.Path, os.FileMode(0777))
 		if err != nil {
 			log.Err("LoopbackFS: config error [%s]", err)
-			return fmt.Errorf("LoopbackFS: config error [%s]", err)
+			return fmt.Errorf("config error in %s [%s]", lfs.Name(), err)
 		}
 		lfs.path = conf.Path
 	} else {
@@ -317,8 +317,7 @@ func (lfs *LoopbackFS) ReleaseFile(options internal.ReleaseFileOptions) error {
 	f := options.Handle.GetFileObject()
 	if f == nil {
 		log.Err("LoopbackFS: ReleaseFile error [file not open]")
-		return fmt.Errorf("LoopbackFS: %s file not open", options.Handle.Path)
-
+		return fmt.Errorf("LoopbackFS::ReleaseFile : %s file not open", options.Handle.Path)
 	}
 	return nil
 }

--- a/component/stream/stream.go
+++ b/component/stream/stream.go
@@ -179,7 +179,7 @@ func (st *Stream) Configure() error {
 
 			if conf.DiskPath == "" {
 				log.Err("Stream::Configure : Config error [disk-cache-path not set]")
-				return fmt.Errorf("config error in %s error [disk-cache-path not set]", st.Name())
+				return fmt.Errorf("config error in %s [disk-cache-path not set]", st.Name())
 			}
 
 			_, err = os.Stat(conf.DiskPath)
@@ -188,7 +188,7 @@ func (st *Stream) Configure() error {
 				err := os.Mkdir(conf.DiskPath, os.FileMode(0755))
 				if err != nil {
 					log.Err("Stream::Configure : Config error creating temp directory failed [%s]", err.Error())
-					return fmt.Errorf("failed to create temp directory for stream persistence[%s]", err.Error())
+					return fmt.Errorf("failed to create temp directory for stream persistence [%s]", err.Error())
 				}
 			}
 		}

--- a/internal/pipeline.go
+++ b/internal/pipeline.go
@@ -71,7 +71,7 @@ func NewPipeline(components []string) (*Pipeline, error) {
 
 			if !(comp.Priority() <= lastPriority) {
 				log.Err("Pipeline::NewPipeline : Invalid Component order [priority of %s higher than above components]", comp.Name())
-				return nil, fmt.Errorf("Pipeline::NewPipeline : Invalid component order")
+				return nil, fmt.Errorf("config error in Pipeline [component %s is out of order]", name)
 			} else {
 				lastPriority = comp.Priority()
 			}
@@ -80,7 +80,7 @@ func NewPipeline(components []string) (*Pipeline, error) {
 			comps = append(comps, comp)
 		} else {
 			log.Err("Pipeline: error [component %s not registered]", name)
-			return nil, fmt.Errorf("pipeline: error [component %s not registered]", name)
+			return nil, fmt.Errorf("config error in Pipeline [component %s not registered]", name)
 		}
 
 	}


### PR DESCRIPTION
- With libfuse the signature in /etc/mtab has changed and code tuned for previous fuse driver is no more working now. So correcting the signature match for libfuse
- Some errors were not in the common format which are used across different components.