### PR TITLE
chmod fix to preserve additional principals added to to ACL

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -222,15 +222,11 @@ var mountCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if !config.IsSet("config-file") {
-			options.ConfigFile = "config.yaml"
-		}
-
 		if !config.IsSet("logging.file-path") {
 			options.Logging.LogFilePath = common.DefaultLogFilePath
 		}
 
-		if !config.IsSet("logging.log-level") {
+		if !config.IsSet("logging.level") {
 			options.Logging.LogLevel = "LOG_WARNING"
 		}
 

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -505,8 +505,23 @@ func (dl *Datalake) ChangeMod(name string, mode os.FileMode) error {
 	log.Trace("Datalake::ChangeMod : Change mode of file %s to %s", name, mode)
 	fileURL := dl.Filesystem.NewRootDirectoryURL().NewFileURL(filepath.Join(dl.Config.prefixPath, name))
 
-	accessControlList := getAccessControlList(mode)
-	_, err := fileURL.SetAccessControl(context.Background(), azbfs.BlobFSAccessControl{ACL: accessControlList})
+	/*
+		// If we need to call the ACL set api then we need to get older acl string here
+		// and create new string with the username included in the string
+		// Keeping this code here so in future if its required we can get the string and manipulate
+
+		currPerm, err := fileURL.GetAccessControl(context.Background())
+		e := storeDatalakeErrToErr(err)
+		if e == ErrFileNotFound {
+			return syscall.ENOENT
+		} else if err != nil {
+			log.Err("Datalake::ChangeMod : Failed to get mode of file %s (%s)", name, err.Error())
+			return err
+		}
+	*/
+
+	newPerm := getACLPermissions(mode)
+	_, err := fileURL.SetAccessControl(context.Background(), azbfs.BlobFSAccessControl{Permissions: newPerm})
 	e := storeDatalakeErrToErr(err)
 	if e == ErrFileNotFound {
 		return syscall.ENOENT

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -69,6 +69,10 @@ attr_cache:
   no-cache-on-list: true|false <do not cache attributes during listing, to optimize performance>
   no-symlinks: true|false <to improve performance disable symlink support. symlinks will be treated like regular files.>
   
+# Loopback configuration
+loopbackfs:
+  path: <path to local directory>
+
 # Azure storage configuration
 azstorage:
   type: block|adls <type of storage account to be connected. Default - block>


### PR DESCRIPTION
…t ACL to preserve the existing principals added to the file
context:
In the portal if "Manage ACL" to any file/folder in container there are two things in it. One is regular Linux style triplet of 'rwx' and additionally you can provide specific access to various principals and identities as well. If we call SetACL it just overwrites all of them because we pass only the 'rwx' triplet and not the other principal related info. While we set permissions it just overwrites the triplets and leave the principals as is.