### PR TITLE
File-cache open-file complexity with respect to file locks removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,9 @@ venv/
 *.backup
 __debug_bin
 .env
+*.prof
+cpplite/
+build/
+tools/
 test/manual_scripts/create1000.go
 test/manual_scripts/cachetest.go

--- a/component/file_cache/cache_policy.go
+++ b/component/file_cache/cache_policy.go
@@ -135,6 +135,8 @@ func getUsagePercentage(path string, maxSize float64) float64 {
 
 // Delete a given file
 func deleteFile(name string) error {
+	log.Debug("cachePolicy::deleteFile : attempting to delete %s", name)
+
 	err := os.Remove(name)
 	if err != nil && os.IsPermission(err) {
 		// File is not having delete permissions so change the mode and retry deletion

--- a/component/file_cache/cache_policy.go
+++ b/component/file_cache/cache_policy.go
@@ -140,7 +140,7 @@ func deleteFile(name string) error {
 		// File is not having delete permissions so change the mode and retry deletion
 		log.Warn("cachePolicy::deleteFile : failed to delete %s due to permission", name)
 
-		os.Chmod(name, os.FileMode(0666))
+		err = os.Chmod(name, os.FileMode(0666))
 		if err != nil {
 			log.Err("cachePolicy::deleteFile : %s failed to reset permissions", name)
 			return err

--- a/component/file_cache/cache_policy.go
+++ b/component/file_cache/cache_policy.go
@@ -37,6 +37,7 @@ import (
 	"blobfuse2/common"
 	"blobfuse2/common/log"
 	"bytes"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -130,4 +131,31 @@ func getUsagePercentage(path string, maxSize float64) float64 {
 	log.Debug("cachePolicy::getUsagePercentage : current cache usage : %f%", usagePercent)
 
 	return usagePercent
+}
+
+// Delete a given file
+func deleteFile(name string) error {
+	err := os.Remove(name)
+	if err != nil && os.IsPermission(err) {
+		// File is not having delete permissions so change the mode and retry deletion
+		log.Warn("cachePolicy::deleteFile : failed to delete %s due to permission", name)
+
+		os.Chmod(name, os.FileMode(0666))
+		if err != nil {
+			log.Err("cachePolicy::deleteFile : %s failed to reset permissions", name)
+			return err
+		}
+
+		err = os.Remove(name)
+	} else if err != nil && os.IsNotExist(err) {
+		log.Debug("cachePolicy::deleteFile : %s does not exist in local cache", name)
+		return nil
+	}
+
+	if err != nil {
+		log.Err("lruPolicy::DeleteItem : Failed to delete local file %s", name)
+		return err
+	}
+
+	return nil
 }

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -181,9 +181,9 @@ func (c *FileCache) Configure() error {
 
 	c.createEmptyFile = conf.CreateEmptyFile
 	if config.IsSet(compName + ".timeout-sec") {
-    c.cacheTimeout = float64(conf.Timeout)
+		c.cacheTimeout = float64(conf.Timeout)
 	} else {
-    c.cacheTimeout = float64(defaultFileCacheTimeout)
+		c.cacheTimeout = float64(defaultFileCacheTimeout)
 	}
 	c.allowNonEmpty = conf.AllowNonEmpty
 	c.cleanupOnStart = conf.CleanupOnStart
@@ -529,8 +529,9 @@ func (fc *FileCache) CreateFile(options internal.CreateFileOptions) (*handlemap.
 	//defer exectime.StatTimeCurrentBlock("FileCache::CreateFile")()
 	log.Trace("FileCache::CreateFile : name=%s, mode=%d", options.Name, options.Mode)
 
-	fc.fileLocks.Lock(options.Name)
-	defer fc.fileLocks.Unlock(options.Name)
+	flock := fc.fileLocks.Get(options.Name)
+	flock.Lock()
+	defer flock.Unlock()
 
 	// createEmptyFile was added to optionally support immutable containers. If customers do not care about immutability they can set this to true.
 	if fc.createEmptyFile {
@@ -565,11 +566,8 @@ func (fc *FileCache) CreateFile(options internal.CreateFileOptions) (*handlemap.
 		fc.missedChmodList.LoadOrStore(options.Name, true)
 	}
 
-	err = syscall.Flock(int(f.Fd()), syscall.LOCK_SH|syscall.LOCK_NB)
-	if err != nil {
-		log.Err("FileCache::CreateFile : error flocking %s [%s]", options.Name, err.Error())
-		return nil, err
-	}
+	// Increment the handle count in this lock item as there is one handle open for this now
+	flock.Inc()
 
 	handle := handlemap.NewHandle(options.Name)
 	handle.SetFileObject(f)
@@ -626,8 +624,9 @@ func (fc *FileCache) validateStorageError(path string, err error, method string,
 func (fc *FileCache) DeleteFile(options internal.DeleteFileOptions) error {
 	log.Trace("FileCache::DeleteFile : name=%s", options.Name)
 
-	fc.fileLocks.Lock(options.Name)
-	defer fc.fileLocks.Unlock(options.Name)
+	flock := fc.fileLocks.Get(options.Name)
+	flock.Lock()
+	defer flock.Unlock()
 
 	err := fc.NextComponent().DeleteFile(options)
 	err = fc.validateStorageError(options.Name, err, "DeleteFile", false)
@@ -693,88 +692,25 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 	var f *os.File
 	var err error
 
-	fc.fileLocks.Lock(options.Name)
-	defer fc.fileLocks.Unlock(options.Name)
+	flock := fc.fileLocks.Get(options.Name)
+	flock.Lock()
+	defer flock.Unlock()
 
 	fc.policy.CacheValid(localPath)
 
 	downloadRequired, fileExists := fc.isDownloadRequired(localPath)
-
-	if fileExists && downloadRequired {
-		// If the file exists, check whether the file is free to be overwritten or not
-		// If the lock is held then we cannot update the file
-		f, err = os.OpenFile(localPath, os.O_WRONLY, options.Mode)
-		if err != nil {
-			if os.IsPermission(err) {
-				// File is not having write permission, for re-download we need that permissions
-				log.Err("FileCache::OpenFile : %s failed to open in write mode", localPath)
-				f, err = os.OpenFile(localPath, os.O_RDONLY, os.FileMode(0666))
-				if err == nil {
-					// Able to open file in readonly mode then reset the permissions
-					err = f.Chmod(os.FileMode(0666))
-					if err != nil {
-						log.Err("FileCache::OpenFile : Failed to reset permissions for %s", localPath)
-						return nil, err
-					}
-					f.Close()
-
-					// Retry open in write mode now
-					f, err = os.OpenFile(localPath, os.O_WRONLY, options.Mode)
-					if err != nil {
-						log.Err("FileCache::OpenFile : Failed to re-open file in write mode %s", localPath)
-						return nil, err
-					}
-				} else {
-					log.Err("FileCache::OpenFile : Failed to open file in read mode %s", localPath)
-					return nil, err
-				}
-			} else {
-				log.Err("FileCache::OpenFile : Failed to open file %s in WR mode", localPath)
-				return nil, err
-			}
-		}
-
-		// Grab an exclusive lock to prevent anyone from touching the file while we write to it
-		exLocked := false
-		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-		if err != nil {
-			if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
-				log.Err("FileCache::OpenFile : error flocking %s(%d) [%s]", localPath, int(f.Fd()), err.Error())
-				return nil, err
-			} else {
-				// This indicates that the file is already open, so we can skip the re-download here.
-				// This may happen if we decided to download based on cache timeouts but someone may be accessing the file.
-				log.Err("FileCache::OpenFile : error flocking %s(%d) [%s], proceeding with existing cached copy", localPath, int(f.Fd()), err.Error())
-				downloadRequired = false
-			}
-		} else {
-			exLocked = true
-		}
-
-		if exLocked {
-			// To prepare for re-download, delete the existing file.
-			if downloadRequired {
-				err = os.Remove(localPath)
-				if err != nil {
-					log.Err("FileCache::OpenFile : error removing %s [%s]", localPath, err.Error())
-				}
-			}
-
-			err = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) // Unlock the exclusive lock
-			if err != nil {
-				log.Err("FileCache::OpenFile : error unlocking fd %s(%d) [%s]", localPath, int(f.Fd()), err.Error())
-				return nil, err
-			}
-		}
-		exLocked = false
-		f.Close()
-	}
-
 	if downloadRequired {
 		log.Debug("FileCache::OpenFile : Need to re-download %s", options.Name)
 
-		// Create the file if if doesn't already exist.
-		if !fileExists {
+		if fileExists {
+			log.Debug("FileCache::OpenFile : Delete cached file %s", options.Name)
+
+			err := deleteFile(localPath)
+			if err != nil {
+				log.Err("FileCache::OpenFile : Failed to delete old file %s", options.Name)
+			}
+		} else {
+			// Create the file if if doesn't already exist.
 			err := os.MkdirAll(filepath.Dir(localPath), fc.defaultPermission)
 			if err != nil {
 				log.Err("FileCache::OpenFile : error creating directory structure for file %s [%s]", options.Name, err.Error())
@@ -791,6 +727,7 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 
 		attrReceived := false
 		fileSize := int64(0)
+
 		attr, err := fc.NextComponent().GetAttr(internal.GetAttrOptions{Name: options.Name})
 		if err != nil {
 			log.Err("FileCache::OpenFile : Failed to get attr of %s [%s]", options.Name, err.Error())
@@ -816,9 +753,6 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 
 		log.Debug("FileCache::OpenFile : Download of %s is complete", options.Name)
 		f.Close()
-
-		// TODO: GO SDK should have some way to return attr on download to file since they do that call anyway, this will save us an extra call.
-		// However this can only be done once ADLS accounts have migrated the Download API to the blob endpoint so we can get mode.
 
 		// After downloading the file, update the modified times and mode of the file.
 		fileMode := fc.defaultPermission
@@ -849,17 +783,15 @@ func (fc *FileCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Hand
 		return nil, err
 	}
 
-	err = syscall.Flock(int(f.Fd()), syscall.LOCK_SH|syscall.LOCK_NB)
-	if err != nil {
-		log.Err("FileCache::OpenFile : error flocking %s [%s]", options.Name, err.Error())
-		return nil, err
-	}
+	// Increment the handle count in this lock item as there is one handle open for this now
+	flock.Inc()
 
 	handle := handlemap.NewHandle(options.Name)
 	inf, err := f.Stat()
 	if err == nil {
 		handle.Size = inf.Size()
 	}
+
 	handle.SetFileObject(f)
 
 	if fc.directRead {
@@ -892,13 +824,13 @@ func (fc *FileCache) CloseFile(options internal.CloseFileOptions) error {
 		return syscall.EBADF
 	}
 
-	err := syscall.Flock(int(f.Fd()), syscall.LOCK_UN) // Unlock any locks held
-	if err != nil {
-		log.Err("FileCache::CloseFile : error unlocking fd %s(%d) [%s]", options.Handle.Path, int(f.Fd()), err.Error())
-		return err
-	}
+	// Reduce the open handle counter here as file is being closed now
+	flock := fc.fileLocks.Get(options.Handle.Path)
+	flock.Lock()
+	defer flock.Unlock()
+	flock.Dec()
 
-	err = f.Close()
+	err := f.Close()
 	if err != nil {
 		log.Err("FileCache::CloseFile : error closing file %s(%d) [%s]", options.Handle.Path, int(f.Fd()), err.Error())
 		return err
@@ -907,10 +839,6 @@ func (fc *FileCache) CloseFile(options internal.CloseFileOptions) error {
 	// If it is an fsync op then purge the file
 	if options.Handle.Fsynced() {
 		log.Trace("FileCache::CloseFile : fsync/sync op, purging %s", options.Handle.Path)
-
-		fc.fileLocks.Lock(options.Handle.Path)
-		defer fc.fileLocks.Unlock(options.Handle.Path)
-
 		localPath := filepath.Join(fc.tmpPath, options.Handle.Path)
 		os.Remove(localPath)
 		fc.policy.CachePurge(localPath)
@@ -1046,8 +974,9 @@ func (fc *FileCache) FlushFile(options internal.FlushFileOptions) error {
 		// Write to storage
 		// Create a new handle for the SDK to use to upload (read local file)
 		// The local handle can still be used for read and write.
-		fc.fileLocks.Lock(options.Handle.Path)
-		defer fc.fileLocks.Unlock(options.Handle.Path)
+		flock := fc.fileLocks.Get(options.Handle.Path)
+		flock.Lock()
+		defer flock.Unlock()
 
 		uploadHandle, err := os.Open(localPath)
 		if err != nil {
@@ -1157,11 +1086,13 @@ func (fc *FileCache) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr
 func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 	log.Trace("FileCache::RenameFile : src=%s, dst=%s", options.Src, options.Dst)
 
-	fc.fileLocks.Lock(options.Src)
-	defer fc.fileLocks.Unlock(options.Src)
+	sflock := fc.fileLocks.Get(options.Src)
+	sflock.Lock()
+	defer sflock.Unlock()
 
-	fc.fileLocks.Lock(options.Dst)
-	defer fc.fileLocks.Unlock(options.Dst)
+	dflock := fc.fileLocks.Get(options.Dst)
+	dflock.Lock()
+	defer dflock.Unlock()
 
 	err := fc.NextComponent().RenameFile(options)
 	err = fc.validateStorageError(options.Src, err, "RenameFile", false)
@@ -1194,8 +1125,9 @@ func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 func (fc *FileCache) TruncateFile(options internal.TruncateFileOptions) error {
 	log.Trace("FileCache::TruncateFile : name=%s, size=%d", options.Name, options.Size)
 
-	fc.fileLocks.Lock(options.Name)
-	defer fc.fileLocks.Unlock(options.Name)
+	flock := fc.fileLocks.Get(options.Name)
+	flock.Lock()
+	defer flock.Unlock()
 
 	err := fc.NextComponent().TruncateFile(options)
 	err = fc.validateStorageError(options.Name, err, "TruncateFile", true)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -688,7 +688,7 @@ func (suite *fileCacheTestSuite) TestCloseFile() {
 func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	defer suite.cleanupTest()
 	suite.cleanupTest() // teardown the default file cache generated
-	cacheTimeout := 1
+	cacheTimeout := 5
 	config := fmt.Sprintf("file_cache:\n  path: %s\n  timeout: %d\n\nloopbackfs:\n  path: %s",
 		suite.cache_path, cacheTimeout, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
@@ -711,7 +711,7 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 	suite.assert.True(err == nil || os.IsExist(err))
 
 	// Wait cacheTimeout
-	time.Sleep(time.Second * time.Duration(cacheTimeout*3))
+	time.Sleep(time.Second * time.Duration(cacheTimeout*2))
 
 	// File should not be in cache
 	_, err = os.Stat(suite.cache_path + "/" + path)

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -39,7 +39,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -423,60 +422,24 @@ func (p *lruPolicy) deleteItem(name string) error {
 		azPath = azPath[1:]
 	}
 
-	p.fileLocks.Lock(azPath)
-	defer p.fileLocks.Unlock(azPath)
+	flock := p.fileLocks.Get(azPath)
+	flock.Lock()
+	defer flock.Unlock()
 
-	// opening a file in WRONLY mode means we are wiping out the contnets from cache
-	// this may lead to some corner case where files contents are wiped out while being served from cache
-	f, err := os.OpenFile(name, os.O_RDWR, os.FileMode(0666))
-	if err != nil {
-		if os.IsPermission(err) {
-			// File is not having write permission, for deletion we need that permissions
-			log.Err("lruPolicy::DeleteItem : %s failed to open in write mode", name)
+	// Check if there are any open handles to this file or not
+	if flock.Count() > 0 {
+		log.Err("lruPolicy::DeleteItem : File in use %s", name)
+		p.CacheValid(name)
+		return nil
+	}
 
-			f, err = os.OpenFile(name, os.O_RDONLY, os.FileMode(0666))
-			if err != nil {
-				log.Err("lruPolicy::DeleteItem : %s failed to open in read mode as well", name)
-				return nil
-			} else {
-				err = f.Chmod(os.FileMode(0666))
-				f.Close()
-				if err != nil {
-					log.Err("lruPolicy::DeleteItem : %s failed to reset permissions", name)
-					return nil
-				}
-				// Deadlock here: At entry of this method file level lock is already acquired
-				// recursively calling same method again means in next iteration we will try to acquire the same
-				// lock again and it will result into deadlock. Hence instead of calling p.deleteItem() just post then
-				// name back to cleanup channel so that this function unlocks and returns gracefully and next call to
-				// this method handles the cleanup part.
-
-				//p.deleteItem(name)
-				p.deleteEvent <- name
-			}
-		} else if !os.IsNotExist(err) {
-			log.Err("lruPolicy::DeleteItem : error opening cached file %s [%s]", name, err)
-		}
-	} else {
-		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-		if err == syscall.EWOULDBLOCK {
-			f.Close()
-			log.Err("lruPolicy::DeleteItem : File in use %s, re-add", name)
-			p.CacheValid(name)
-			return err
-		} else {
-			err = os.Remove(name)
-			if err != nil {
-				log.Err("lruPolicy::DeleteItem : Failed to delete local file %s", name)
-			}
-			syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-			f.Close()
-			log.Debug("lruPolicy::DeleteItem : File %s deleted successfully", name)
-
-			dirPath := filepath.Dir(name)
-			if dirPath != p.tmpPath {
-				os.Remove(dirPath)
-			}
+	// There are no open handles for this file so its safe to remove this
+	err := deleteFile(name)
+	if err == nil {
+		// File was deleted so try clearing its parent directory
+		dirPath := filepath.Dir(name)
+		if dirPath != p.tmpPath {
+			os.Remove(dirPath)
 		}
 	}
 

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -428,7 +428,7 @@ func (p *lruPolicy) deleteItem(name string) error {
 
 	// Check if there are any open handles to this file or not
 	if flock.Count() > 0 {
-		log.Err("lruPolicy::DeleteItem : File in use %s", name)
+		log.Warn("lruPolicy::DeleteItem : File in use %s", name)
 		p.CacheValid(name)
 		return nil
 	}

--- a/component/stream/stream.go
+++ b/component/stream/stream.go
@@ -250,13 +250,15 @@ func (st *Stream) OpenFile(options internal.OpenFileOptions) (*handlemap.Handle,
 			handle.ID = handlemap.HandleID(nextHandleID.Inc())
 			fileKey = strconv.FormatUint((uint64(handle.ID)), 10)
 		}
-		st.fileKeyLocks.Lock(fileKey)
+
+		flock := st.fileKeyLocks.Get(fileKey)
+		flock.Lock()
 		st.streamCache.addFileKey(fileKey)
 		block, exists, _ := st.fetchBlock(fileKey, handle, 0)
 		// if it exists then we can just RUnlock since we didn't manipulate its data buffer
 		st.unlockBlock(block, exists)
 		st.streamCache.incrementHandles(fileKey)
-		st.fileKeyLocks.Unlock(fileKey)
+		flock.Unlock()
 	}
 	return handle, err
 }


### PR DESCRIPTION
- file-cache needed ex-locks on files before download or deletion
- these ex-locks works only when file has write permission
- to handle ex-lock and permission combination there was a lot of locks and complex logic involved in openFile. createFile and cache eviction logic
- Moving to a solution where open handle counter is maintained inside the file level locks and using those we take the ex locks.