### PR TITLE
Fixed bug where blobfuse2 could not be installed in docker container

### DIFF
--- a/blobfuse2-nightly.yaml
+++ b/blobfuse2-nightly.yaml
@@ -888,7 +888,7 @@ jobs:
               sudo rm -rf [0-9]
             displayName: 'Clean Agent Directories'
             condition: always() 
- - job: Set_8
+  - job: Set_8
     timeoutInMinutes: 30
 
     strategy:

--- a/blobfuse2-nightly.yaml
+++ b/blobfuse2-nightly.yaml
@@ -893,7 +893,7 @@ jobs:
 
     strategy:
       matrix:
-        Ubuntu-18:
+        Ubuntu-18-CSI:
           imageName: 'ubuntu-18.04'
           containerName: 'test-cnt-ubn-18'
           adlsSas: $(UBUNTU-18-ADLS-SAS)

--- a/blobfuse2-nightly.yaml
+++ b/blobfuse2-nightly.yaml
@@ -888,4 +888,85 @@ jobs:
               sudo rm -rf [0-9]
             displayName: 'Clean Agent Directories'
             condition: always() 
-  
+ - job: Set_8
+    timeoutInMinutes: 30
+
+    strategy:
+      matrix:
+        Ubuntu-18:
+          imageName: 'ubuntu-18.04'
+          containerName: 'test-cnt-ubn-18'
+          adlsSas: $(UBUNTU-18-ADLS-SAS)
+          hostedAgent: true
+          stressParallel: 3
+          fuselib: 'libfuse-dev'
+          tags: 'fuse2'
+    pool:
+      vmImage: $(imageName)
+
+    variables:
+      - group: NightlyBlobFuse
+      - name: ROOT_DIR
+        value: '$(System.DefaultWorkingDirectory)' 
+      - name: WORK_DIR
+        value: '$(System.DefaultWorkingDirectory)/azure-storage-fuse'
+
+    steps:
+      - checkout: none
+      - script: |
+          git clone https://github.com/Azure/azure-storage-fuse
+        displayName: 'Checkout Code & List commits'
+        workingDirectory: $(root_dir)
+          
+      # list commits from past 12hrs
+      - script: |
+          git checkout `echo $(Build.SourceBranch) | cut -d "/" -f 1,2 --complement`
+          git --no-pager log --since="12 hours ago" --stat
+        displayName: 'List Commits'
+        workingDirectory: $(work_dir)
+      
+      # install dependencies required for compiling blobfuse
+      - script: |
+          sudo apt-get update --fix-missing
+          sudo apt-get install ruby-dev build-essential $(fuselib) -y
+          sudo gem install fpm -V
+        displayName: "Installing Dependencies"
+
+      # build blobfuse2 and generate binary
+      - template: 'azure-pipeline-templates/build-release.yml'
+        parameters:
+          work_dir: $(work_dir)
+          root_dir: $(root_dir)
+          unit_test: false
+          tags: $(tags)
+
+      # place the generated binary files & any additional files in appropriate locations
+      - script: |
+          mkdir -p pkgDir/usr/bin/
+          mkdir -p pkgDir/usr/share/blobfuse2/
+          cp azure-storage-fuse/blobfuse2 pkgDir/usr/bin/blobfuse2
+          cp azure-storage-fuse/setup/baseConfig.yaml pkgDir/usr/share/blobfuse2/
+          cp azure-storage-fuse/sampleFileCacheConfig.yaml pkgDir/usr/share/blobfuse2/
+          cp azure-storage-fuse/sampleStreamingConfig.yaml pkgDir/usr/share/blobfuse2/
+          cp azure-storage-fuse/tools/postinstall.sh pkgDir/usr/share/blobfuse2/
+          mkdir -p pkgDir/etc/rsyslog.d
+          mkdir -p pkgDir/etc/logrotate.d
+          cp azure-storage-fuse/setup/11-blobfuse2.conf pkgDir/etc/rsyslog.d
+          cp azure-storage-fuse/setup/blobfuse2-logrotate pkgDir/etc/logrotate.d/blobfuse2
+        workingDirectory: $(root_dir)
+        displayName: 'Accumulate pkg files'
+      
+      # using fpm tool for packaging of our binary & performing post-install operations
+      # for additional information about fpm refer https://fpm.readthedocs.io/en/v1.13.1/
+      - script: |
+          fpm -s dir -t deb -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
+          --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
+          --description "An user-space filesystem for interacting with Azure Storage" 
+          mv ./blobfuse2*.deb $(work_dir)/test/csi_driver_test/blobfuse2.deb
+        workingDirectory: $(root_dir)
+        displayName: 'Make Package'
+      - script: |
+          docker build --no-cache --output=type=docker -t blobfuse2/blob-csi:test -f ./Dockerfile .
+        workingDirectory: $(work_dir)/test/csi_driver_test
+        displayName: 'Docker Build'
+        continueOnError: false

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -114,7 +114,6 @@ stages:
               fpm -s dir -t deb -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" \
-              --before-install ./azure-storage-fuse/tools/preinstall.sh \
               --after-install ./azure-storage-fuse/tools/postinstall.sh
               mv ./blobfuse2*.deb ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(container_image)-x86-64.deb
               cp ./blobfuse2*.deb $(Build.ArtifactStagingDirectory)
@@ -217,7 +216,6 @@ stages:
               fpm -s dir -t deb -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" \
-              --before-install ./azure-storage-fuse/tools/preinstall.sh \
               --after-install ./azure-storage-fuse/tools/postinstall.sh
               mv ./blobfuse2*.deb ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.deb
               cp ./blobfuse2*.deb $(Build.ArtifactStagingDirectory)
@@ -323,7 +321,6 @@ stages:
               fpm -s dir -t rpm -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" \
-              --before-install ./azure-storage-fuse/tools/preinstall.sh \
               --after-install ./azure-storage-fuse/tools/postinstall.sh
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.rpm
               cp ./blobfuse2*.rpm $(Build.ArtifactStagingDirectory)
@@ -422,7 +419,6 @@ stages:
               fpm -s dir -t rpm -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" \
-              --before-install ./azure-storage-fuse/tools/preinstall.sh \
               --after-install ./azure-storage-fuse/tools/postinstall.sh
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.rpm
               cp ./blobfuse2*.rpm $(Build.ArtifactStagingDirectory)
@@ -605,7 +601,6 @@ stages:
               fpm -s dir -t rpm -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" \
-              --before-install ./azure-storage-fuse/tools/preinstall.sh \
               --after-install ./azure-storage-fuse/tools/postinstall.sh
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.rpm
               cp ./blobfuse2*.rpm $(Build.ArtifactStagingDirectory)

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -101,6 +101,7 @@ stages:
               cp azure-storage-fuse/setup/baseConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleFileCacheConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleStreamingConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/tools/postinstall.sh pkgDir/usr/share/blobfuse2/
               mkdir -p pkgDir/etc/rsyslog.d
               mkdir -p pkgDir/etc/logrotate.d
               cp azure-storage-fuse/setup/11-blobfuse2.conf pkgDir/etc/rsyslog.d
@@ -113,8 +114,7 @@ stages:
           - script: |
               fpm -s dir -t deb -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
-              --description "An user-space filesystem for interacting with Azure Storage" \
-              --after-install ./azure-storage-fuse/tools/postinstall.sh
+              --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.deb ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(container_image)-x86-64.deb
               cp ./blobfuse2*.deb $(Build.ArtifactStagingDirectory)
             workingDirectory: $(root_dir)
@@ -204,6 +204,7 @@ stages:
               cp azure-storage-fuse/setup/baseConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleFileCacheConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleStreamingConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/tools/postinstall.sh pkgDir/usr/share/blobfuse2/
               mkdir -p pkgDir/etc/rsyslog.d
               mkdir -p pkgDir/etc/logrotate.d
               cp azure-storage-fuse/setup/11-blobfuse2.conf pkgDir/etc/rsyslog.d
@@ -215,8 +216,7 @@ stages:
           - script: |
               fpm -s dir -t deb -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
-              --description "An user-space filesystem for interacting with Azure Storage" \
-              --after-install ./azure-storage-fuse/tools/postinstall.sh
+              --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.deb ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.deb
               cp ./blobfuse2*.deb $(Build.ArtifactStagingDirectory)
             workingDirectory: $(root_dir)
@@ -307,6 +307,7 @@ stages:
               cp azure-storage-fuse/setup/baseConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleFileCacheConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleStreamingConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/tools/postinstall.sh pkgDir/usr/share/blobfuse2/
               mkdir -p pkgDir/etc/rsyslog.d
               mkdir -p pkgDir/etc/logrotate.d
               cp azure-storage-fuse/setup/11-blobfuse2.conf pkgDir/etc/rsyslog.d
@@ -320,8 +321,7 @@ stages:
               gem install fpm
               fpm -s dir -t rpm -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
-              --description "An user-space filesystem for interacting with Azure Storage" \
-              --after-install ./azure-storage-fuse/tools/postinstall.sh
+              --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.rpm
               cp ./blobfuse2*.rpm $(Build.ArtifactStagingDirectory)
             workingDirectory: $(root_dir)
@@ -407,6 +407,7 @@ stages:
               cp azure-storage-fuse/setup/baseConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleFileCacheConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleStreamingConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/tools/postinstall.sh pkgDir/usr/share/blobfuse2/
               mkdir -p pkgDir/etc/rsyslog.d
               mkdir -p pkgDir/etc/logrotate.d
               cp azure-storage-fuse/setup/11-blobfuse2.conf pkgDir/etc/rsyslog.d
@@ -418,8 +419,7 @@ stages:
           - script: |
               fpm -s dir -t rpm -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
-              --description "An user-space filesystem for interacting with Azure Storage" \
-              --after-install ./azure-storage-fuse/tools/postinstall.sh
+              --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.rpm
               cp ./blobfuse2*.rpm $(Build.ArtifactStagingDirectory)
             workingDirectory: $(root_dir)
@@ -490,7 +490,16 @@ stages:
           
           - script: |
               mkdir -p pkgDir/usr/bin/
+              mkdir -p pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/blobfuse2 pkgDir/usr/bin/blobfuse2
+              cp azure-storage-fuse/setup/baseConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/sampleFileCacheConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/sampleStreamingConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/tools/postinstall.sh pkgDir/usr/share/blobfuse2/
+              mkdir -p pkgDir/etc/rsyslog.d
+              mkdir -p pkgDir/etc/logrotate.d
+              cp azure-storage-fuse/setup/11-blobfuse2.conf pkgDir/etc/rsyslog.d
+              cp azure-storage-fuse/setup/blobfuse2-logrotate pkgDir/etc/logrotate.d/blobfuse2
             workingDirectory: $(root_dir)
             displayName: 'Accumulate pkg files'
           
@@ -500,8 +509,7 @@ stages:
               export PATH=$PATH:/usr/lib64/ruby/gems/2.5.0/gems/fpm-1.14.1/bin
               fpm -s dir -t rpm -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
-              --description "An user-space filesystem for interacting with Azure Storage" \
-              --after-install ./azure-storage-fuse/tools/postinstall.sh
+              --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.rpm
               cp ./blobfuse2*.rpm $(Build.ArtifactStagingDirectory)
             workingDirectory: $(root_dir)
@@ -587,6 +595,7 @@ stages:
               cp azure-storage-fuse/setup/baseConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleFileCacheConfig.yaml pkgDir/usr/share/blobfuse2/
               cp azure-storage-fuse/sampleStreamingConfig.yaml pkgDir/usr/share/blobfuse2/
+              cp azure-storage-fuse/tools/postinstall.sh pkgDir/usr/share/blobfuse2/
               mkdir -p pkgDir/etc/rsyslog.d
               mkdir -p pkgDir/etc/logrotate.d
               cp azure-storage-fuse/setup/11-blobfuse2.conf pkgDir/etc/rsyslog.d
@@ -600,8 +609,7 @@ stages:
               export PATH=$PATH:/usr/lib64/ruby/gems/2.6.0/gems/fpm-1.14.1/bin
               fpm -s dir -t rpm -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d fuse \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
-              --description "An user-space filesystem for interacting with Azure Storage" \
-              --after-install ./azure-storage-fuse/tools/postinstall.sh
+              --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(DistroVer)-x86-64.rpm
               cp ./blobfuse2*.rpm $(Build.ArtifactStagingDirectory)
             workingDirectory: $(root_dir)

--- a/test/csi_driver_test/Dockerfile
+++ b/test/csi_driver_test/Dockerfile
@@ -1,0 +1,8 @@
+FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+
+RUN apt update && apt-mark unhold libcap2
+RUN clean-install ca-certificates uuid-dev util-linux mount udev wget fuse
+
+# Before building this Dockerfile ensure blobfuse2.deb is in the current directory.
+COPY blobfuse2.deb /tmp/blobfuse2.deb
+RUN dpkg -i /tmp/blobfuse2.deb

--- a/tools/postinstall.sh
+++ b/tools/postinstall.sh
@@ -28,10 +28,3 @@ then
   sudo service rsyslog restart
   echo "Finished syslog configuration!"
 fi
-
-
-
-
-
-
-


### PR DESCRIPTION
The postinstall script was generating various problems so we now default to ship the postinstall script in /usr/share/blobfuse2/
Fixes : #733 