### PR TITLE
Fixed bug where remount on empty containers was not throwing error when the mount path has trailing '/'

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -59,6 +59,9 @@ func IsDirectoryMounted(path string) bool {
 		return false
 	}
 
+	// removing trailing / from the path
+	path = strings.TrimRight(path, "/")
+
 	for _, line := range strings.Split(string(mntList), "\n") {
 		if strings.TrimSpace(line) != "" {
 			mntPoint := strings.Split(line, " ")[1]


### PR DESCRIPTION
Let's say we mount an empty container using blobfuse2. Now if we try to remount it again on the same path, it should ideally throw an error. But if the path contains trailing '/', it doesn't. So, added a line where we trim the trailing '/' from the mount path.