### PR TITLE
[BUG] Fixed block size max blocks exceeded bug when blocksize not set

### DIFF
--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -447,7 +447,7 @@ func NewazstorageComponent() internal.Component {
 	// Init the component with default config
 	az := &AzStorage{
 		stConfig: AzStorageConfig{
-			blockSize:      (16 * 1024 * 1024),
+			blockSize:      0,
 			maxConcurrency: 32,
 			defaultTier:    getAccessTierType("none"),
 			authConfig: azAuthConfig{

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -612,7 +612,6 @@ func (bb *BlockBlob) WriteFromFile(name string, metadata map[string]string, fi *
 	blockSize := bb.Config.blockSize
 	// if the block size is not set then we configure it based on file size
 	if !config.IsSet(compName + ".block-size-mb") {
-		fmt.Println("not here")
 		// get the size of the file
 		stat, err := fi.Stat()
 		if err != nil {

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -72,6 +72,10 @@ type BlockBlob struct {
 // Verify that BlockBlob implements AzConnection interface
 var _ AzConnection = &BlockBlob{}
 
+const (
+	MaxBlocks = azblob.BlockBlobMaxStageBlockBytes * azblob.BlockBlobMaxBlocks
+)
+
 func (bb *BlockBlob) Configure(cfg AzStorageConfig) error {
 	bb.Config = cfg
 
@@ -619,7 +623,7 @@ func (bb *BlockBlob) WriteFromFile(name string, metadata map[string]string, fi *
 		}
 		fileSize := stat.Size()
 		// If bufferSize > (BlockBlobMaxStageBlockBytes * BlockBlobMaxBlocks), then error
-		if fileSize > azblob.BlockBlobMaxStageBlockBytes*azblob.BlockBlobMaxBlocks {
+		if fileSize > MaxBlocks {
 			err = errors.New("buffer is too large to upload to a block blob")
 			log.Err("BlockBlob::WriteFromFile : buffer is too large to upload to a block blob %s", name)
 			return err

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -42,7 +42,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"math"
 	"net/url"
 	"os"
@@ -635,7 +634,6 @@ func (bb *BlockBlob) WriteFromFile(name string, metadata map[string]string, fi *
 			}
 		}
 	}
-	fmt.Println(blockSize)
 	_, err = azblob.UploadFileToBlockBlob(context.Background(), fi, blobURL, azblob.UploadToBlockBlobOptions{
 		BlockSize:      blockSize,
 		Parallelism:    bb.Config.maxConcurrency,

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -263,7 +263,7 @@ func (s *blockBlobTestSuite) TestDefault() {
 	s.assert.Equal(EAuthType.KEY(), s.az.stConfig.authConfig.AuthMode)
 	s.assert.Equal(s.container, s.az.stConfig.container)
 	s.assert.Empty(s.az.stConfig.prefixPath)
-	s.assert.EqualValues(16*1024*1024, s.az.stConfig.blockSize)
+	s.assert.EqualValues(0, s.az.stConfig.blockSize)
 	s.assert.EqualValues(32, s.az.stConfig.maxConcurrency)
 	s.assert.EqualValues(AccessTiers["none"], s.az.stConfig.defaultTier)
 	s.assert.EqualValues(0, s.az.stConfig.cancelListForSeconds)

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -170,12 +170,12 @@ type blockBlobTestSuite struct {
 	container    string
 }
 
-func newTestAzStorage(configuration string) *AzStorage {
+func newTestAzStorage(configuration string) (*AzStorage, error) {
 	config.ReadConfigFromReader(strings.NewReader(configuration))
 	az := NewazstorageComponent()
-	az.Configure()
+	err := az.Configure()
 
-	return az.(*AzStorage)
+	return az.(*AzStorage), err
 }
 
 func (s *blockBlobTestSuite) SetupTest() {
@@ -223,7 +223,7 @@ func (s *blockBlobTestSuite) setupTestHelper(configuration string, container str
 
 	s.assert = assert.New(s.T())
 
-	s.az = newTestAzStorage(configuration)
+	s.az, _ = newTestAzStorage(configuration)
 	s.az.Start(ctx) // Note: Start->TestValidation will fail but it doesn't matter. We are creating the container a few lines below anyway.
 	// We could create the container before but that requires rewriting the code to new up a service client.
 
@@ -244,6 +244,13 @@ func (s *blockBlobTestSuite) tearDownTestHelper(delete bool) {
 func (s *blockBlobTestSuite) cleanupTest() {
 	s.tearDownTestHelper(true)
 	log.Destroy()
+}
+
+func (s *blockBlobTestSuite) TestInvalidBlockSize() {
+	configuration := fmt.Sprintf("azstorage:\n  account-name: %s\n  endpoint: https://%s.blob.core.windows.net/\n  type: block\n  block-size-mb: 5000\n account-key: %s\n  mode: key\n  container: %s\n  fail-unsupported-op: true",
+		storageTestConfigurationParameters.BlockAccount, storageTestConfigurationParameters.BlockAccount, storageTestConfigurationParameters.BlockKey, s.container)
+	_, err := newTestAzStorage(configuration)
+	s.assert.NotNil(err)
 }
 
 func (s *blockBlobTestSuite) TestDefault() {

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -380,6 +380,9 @@ func ParseAndReadDynamicConfig(az *AzStorage, opt AzStorageOptions, reload bool)
 
 	// If block size and max concurrency is configured use those
 	// A user provided value of 0 doesn't make sense for BlockSize, or MaxConcurrency.
+	if opt.BlockSize != 0 {
+		az.stConfig.blockSize = opt.BlockSize * 1024 * 1024
+	}
 
 	if opt.MaxConcurrency != 0 {
 		az.stConfig.maxConcurrency = opt.MaxConcurrency

--- a/component/azstorage/datalake_test.go
+++ b/component/azstorage/datalake_test.go
@@ -151,7 +151,7 @@ func (s *datalakeTestSuite) TestDefault() {
 	s.assert.Equal(EAuthType.KEY(), s.az.stConfig.authConfig.AuthMode)
 	s.assert.Equal(s.container, s.az.stConfig.container)
 	s.assert.Empty(s.az.stConfig.prefixPath)
-	s.assert.EqualValues(16*1024*1024, s.az.stConfig.blockSize)
+	s.assert.EqualValues(0, s.az.stConfig.blockSize)
 	s.assert.EqualValues(32, s.az.stConfig.maxConcurrency)
 	s.assert.EqualValues(AccessTiers["none"], s.az.stConfig.defaultTier)
 	s.assert.EqualValues(0, s.az.stConfig.cancelListForSeconds)

--- a/component/azstorage/datalake_test.go
+++ b/component/azstorage/datalake_test.go
@@ -111,7 +111,7 @@ func (s *datalakeTestSuite) setupTestHelper(configuration string, container stri
 
 	s.assert = assert.New(s.T())
 
-	s.az = newTestAzStorage(configuration)
+	s.az, _ = newTestAzStorage(configuration)
 	s.az.Start(ctx) // Note: Start->TestValidation will fail but it doesn't matter. We are creating the container a few lines below anyway.
 	// We could create the container before but that requires rewriting the code to new up a service client.
 


### PR DESCRIPTION
If the blocksize is not set - let's set it dynamically based on file size to avoid max blocks exceeded errors. 
changed default block size to 0.