### PR TITLE
Optimize Read Streaming Map Lookups

### DIFF
--- a/component/stream/stream.go
+++ b/component/stream/stream.go
@@ -300,7 +300,9 @@ func (st *Stream) WriteFile(options internal.WriteFileOptions) (int, error) {
 func (st *Stream) CloseFile(options internal.CloseFileOptions) error {
 	log.Trace("Stream::CloseFile : name=%s, handle=%d", options.Handle.Path, options.Handle.ID)
 	st.NextComponent().CloseFile(options)
-	st.streamCache.removeCachedHandle(options.Handle)
+	if !st.streamOnly {
+		st.streamCache.removeCachedHandle(options.Handle)
+	}
 	return nil
 }
 

--- a/component/stream/stream_cache.go
+++ b/component/stream/stream_cache.go
@@ -179,7 +179,7 @@ func (c *cache) filePurge(key, value interface{}) {
 
 // Using key construct a file name for persisted block
 func (c *cache) getLocalFilePath(key blockKey) string {
-	return filepath.Join(c.diskPath, key.handle.FObj.Name()+"__"+fmt.Sprintf("%d", key.offset)+"__")
+	return filepath.Join(c.diskPath, key.handle.Path+"__"+fmt.Sprintf("%d", key.offset)+"__")
 }
 
 // Persist this block on disk

--- a/component/stream/stream_test.go
+++ b/component/stream/stream_test.go
@@ -157,7 +157,7 @@ func asyncCloseFile(suite *streamTestSuite, closeFileOptions internal.CloseFileO
 //assert that the block is cached
 func assertBlockCached(suite *streamTestSuite, offset int64, handle *handlemap.Handle) {
 	bk := blockKey{offset, handle}
-	_, err := handle.DataBuffer.Get(bk)
+	_, err := handle.CacheObj.DataBuffer.Get(bk)
 	suite.assert.NoError(err)
 	_, err = suite.stream.streamCache.blocks.Get(bk)
 	suite.assert.NoError(err)
@@ -166,7 +166,7 @@ func assertBlockCached(suite *streamTestSuite, offset int64, handle *handlemap.H
 //assert the block is not cached and KeyNotFoundError is thrown
 func assertBlockNotCached(suite *streamTestSuite, offset int64, handle *handlemap.Handle) {
 	bk := blockKey{offset, handle}
-	_, err := handle.DataBuffer.Get(bk)
+	_, err := handle.CacheObj.DataBuffer.Get(bk)
 	suite.assert.EqualError(err, gcache.KeyNotFoundError.Error())
 	_, err = suite.stream.streamCache.blocks.Get(bk)
 	suite.assert.EqualError(err, gcache.KeyNotFoundError.Error())
@@ -177,7 +177,7 @@ func assertNumberOfCachedBlocks(suite *streamTestSuite, numOfBlocks int) {
 }
 
 func assertNumberOfCachedFileBlocks(suite *streamTestSuite, numOfBlocks int, handle *handlemap.Handle) {
-	suite.assert.Equal(numOfBlocks, handle.DataBuffer.Len(false))
+	suite.assert.Equal(numOfBlocks, handle.CacheObj.DataBuffer.Len(false))
 }
 
 // ====================================== End of helper methods =================================

--- a/internal/handlemap/handle_map.go
+++ b/internal/handlemap/handle_map.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/bluele/gcache"
 	"go.uber.org/atomic"
 )
 
@@ -55,12 +56,13 @@ const (
 
 type Handle struct {
 	sync.RWMutex
-	FObj   *os.File
-	ID     HandleID
-	Size   int64 // Size of the file being handled here
-	Flags  common.BitMap16
-	Path   string // always holds path relative to mount dir
-	values map[string]interface{}
+	FObj       *os.File
+	ID         HandleID
+	Size       int64 // Size of the file being handled here
+	Flags      common.BitMap16
+	Path       string // always holds path relative to mount dir
+	values     map[string]interface{}
+	DataBuffer gcache.Cache
 }
 
 func NewHandle(path string) *Handle {

--- a/internal/handlemap/handle_map.go
+++ b/internal/handlemap/handle_map.go
@@ -54,15 +54,19 @@ const (
 	HandleFlagCached
 )
 
+type Cache struct {
+	DataBuffer gcache.Cache
+}
+
 type Handle struct {
 	sync.RWMutex
-	FObj       *os.File
-	ID         HandleID
-	Size       int64 // Size of the file being handled here
-	Flags      common.BitMap16
-	Path       string // always holds path relative to mount dir
-	values     map[string]interface{}
-	DataBuffer gcache.Cache
+	FObj     *os.File
+	ID       HandleID
+	Size     int64 // Size of the file being handled here
+	Flags    common.BitMap16
+	Path     string // always holds path relative to mount dir
+	values   map[string]interface{}
+	CacheObj *Cache
 }
 
 func NewHandle(path string) *Handle {

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -39,7 +39,6 @@ stream:
   blocks-per-file: <maximum number of blocks, per file, that can be cached at any given time. Default - 0>
   cache-size-mb: <total amount of memory that streaming can consume on the system. Default - 0 MB>
   policy: lfu|lru|arc <cache eviction policy for cached blocks. Default - arc>
-  cache-on-file-handle: true|false <cache block per file handle instead of file-name. (better performance but increases memory consumption)>
   disk-persistence: <persist blocks on disk when evicted from memory>
   disk-cache-path: <path to perist evicted blocks>
   disk-size-mb: <maximum disk space to be consumed by disk-persistence>


### PR DESCRIPTION
optimized streaming by storing file buffers on handle level only and avoiding file name lookups on a map