### PR TITLE
Temporarily fixed fio error caused due to race condition between OpenFile and CloseFile

### DIFF
--- a/component/file_cache/lfu_policy.go
+++ b/component/file_cache/lfu_policy.go
@@ -36,7 +36,6 @@ package file_cache
 import (
 	"blobfuse2/common/log"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -153,15 +152,11 @@ func (l *lfuPolicy) clearItemFromCache(path string) {
 	}
 
 	// There are no open handles for this file so its safe to remove this
-	err := deleteFile(path)
-	if err == nil {
-		// File was deleted so try clearing its parent directory
-		dirPath := filepath.Dir(path)
-		if dirPath != l.tmpPath {
-			// TODO: Delete directories up the path recursively that are "safe to delete". Ensure there is no race between this code and code that creates directories (like OpenFile)
-			// This might require something like hierarchical locking.
-		}
-	}
+	deleteFile(path)
+
+	// File was deleted so try clearing its parent directory
+	// TODO: Delete directories up the path recursively that are "safe to delete". Ensure there is no race between this code and code that creates directories (like OpenFile)
+	// This might require something like hierarchical locking.
 }
 
 func (l *lfuPolicy) clearCache() {

--- a/component/file_cache/lfu_policy.go
+++ b/component/file_cache/lfu_policy.go
@@ -158,7 +158,8 @@ func (l *lfuPolicy) clearItemFromCache(path string) {
 		// File was deleted so try clearing its parent directory
 		dirPath := filepath.Dir(path)
 		if dirPath != l.tmpPath {
-			os.Remove(dirPath)
+			// TODO: Delete directories up the path recursively that are "safe to delete". Ensure there is no race between this code and code that creates directories (like OpenFile)
+			// This might require something like hierarchical locking.
 		}
 	}
 }

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -35,7 +35,6 @@ package file_cache
 
 import (
 	"blobfuse2/common/log"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -439,7 +438,8 @@ func (p *lruPolicy) deleteItem(name string) error {
 		// File was deleted so try clearing its parent directory
 		dirPath := filepath.Dir(name)
 		if dirPath != p.tmpPath {
-			os.Remove(dirPath)
+			// TODO: Delete directories up the path recursively that are "safe to delete". Ensure there is no race between this code and code that creates directories (like OpenFile)
+			// This might require something like hierarchical locking.
 		}
 	}
 

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -35,7 +35,6 @@ package file_cache
 
 import (
 	"blobfuse2/common/log"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -433,15 +432,10 @@ func (p *lruPolicy) deleteItem(name string) error {
 	}
 
 	// There are no open handles for this file so its safe to remove this
-	err := deleteFile(name)
-	if err == nil {
-		// File was deleted so try clearing its parent directory
-		dirPath := filepath.Dir(name)
-		if dirPath != p.tmpPath {
-			// TODO: Delete directories up the path recursively that are "safe to delete". Ensure there is no race between this code and code that creates directories (like OpenFile)
-			// This might require something like hierarchical locking.
-		}
-	}
+	deleteFile(name)
+	// File was deleted so try clearing its parent directory
+	// TODO: Delete directories up the path recursively that are "safe to delete". Ensure there is no race between this code and code that creates directories (like OpenFile)
+	// This might require something like hierarchical locking.
 
 	return nil
 }


### PR DESCRIPTION
This will require some more thought into how to implement directory deletion properly. 

Note: This is fine to do temporarily for now since we already have a flaw in our logic where if we cache a file a/b/c/d/file.txt, then on close we will only delete directory d, leaving a/b/c still in the path. 

There is a race condition between https://github.com/Azure/azure-storage-fuse/blob/main/component/file_cache/lru_policy.go#L442 and https://github.com/Azure/azure-storage-fuse/blob/main/component/file_cache/file_cache.go#L728

OpenFile expects the directories to be present so we call MkDirAll. In between those two calls another CloseFile can come and cause that dir to be deleted