### PR TITLE
Fixing large download in single request issue

### DIFF
--- a/cpplite/src/blob/blob_client_wrapper.cpp
+++ b/cpplite/src/blob/blob_client_wrapper.cpp
@@ -668,7 +668,7 @@ namespace azure {  namespace storage_lite {
                     const auto range = std::min(chunk_size, length - offset);
                     auto single_download = std::async(std::launch::async, [originalEtag, offset, range, this, &destPath, &container, &blob](){
                             // Note, keep std::ios_base::in to prevent truncating of the file.
-                            std::ofstream output(destPath.c_str(), std::ofstream::binary | std::ofstream::out);
+                            std::ofstream output(destPath.c_str(), std::ofstream::binary | std::ofstream::out | std::ofstream::in);
                             
                             #if 0
                             output.seekp(offset);
@@ -721,8 +721,8 @@ namespace azure {  namespace storage_lite {
                                     ret_code = unknown_error;
                                     goto return_retcode;
                                 }
-                                current_offset += bytes_to_read;
-                                remaining -= bytes_to_read;
+                                current_offset += chunk.response().size;
+                                remaining -= chunk.response().size;
                             }
 
                             return_retcode:


### PR DESCRIPTION
- In case of download flow, blobfuse divides file-size by number of parallel threads (default 12). In case file is very huge, for e.g. 120GB, then each thread is suppose to download 10GB data. 
- Once this work load division is done each thread just try to download this data in single request. As here data size is very huge server may timeout resulting into download failure
- Once work is distributed across parallel threads, each thread shall download one chunk at a time (~16MB) and continue untill designated workload is not complete.