### PR TITLE
Correction with Block Size calculation for upload 

### DIFF
--- a/common/log/base_logger.go
+++ b/common/log/base_logger.go
@@ -56,9 +56,8 @@ type LogFileConfig struct {
 }
 
 type BaseLogger struct {
-	channel     chan (string)
-	workerDone  sync.WaitGroup
-	channelLock sync.RWMutex
+	channel    chan (string)
+	workerDone sync.WaitGroup
 
 	logger        *log.Logger
 	logFileHandle io.WriteCloser
@@ -225,9 +224,7 @@ func (l *BaseLogger) logEvent(lvl string, format string, args ...interface{}) {
 		filepath.Base(fn), ln,
 		msg)
 
-	l.channelLock.Lock()
 	l.channel <- msg
-	l.channelLock.Unlock()
 }
 
 // logDumper : logEvent just enqueues an event in the channel, this thread dumps that log to the file

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -648,7 +648,8 @@ func (bb *BlockBlob) calculateBlockSize(name string, fi *os.File) (blockSize int
 		}
 	}
 
-	return blockSize, err
+	log.Info("BlockBlob::calculateBlockSize : %s size %lu, blockSize %lu", name, fileSize, blockSize)
+	return blockSize, nil
 }
 
 // WriteFromFile : Upload local file to blob

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -618,7 +618,7 @@ func (bb *BlockBlob) calculateBlockSize(name string, fileSize int64) (blockSize 
 
 	// If bufferSize <= BlockBlobMaxUploadBlobBytes, then Upload should be used with just 1 I/O request
 	if fileSize <= azblob.BlockBlobMaxUploadBlobBytes {
-		// Files upto 256MB can be uploaded as a single block
+		// Files up to 256MB can be uploaded as a single block
 		blockSize = azblob.BlockBlobMaxUploadBlobBytes
 	} else {
 		// buffer / max blocks = block size to use all 50,000 blocks

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -629,11 +629,14 @@ func (bb *BlockBlob) calculateBlockSize(name string, fileSize int64) (blockSize 
 			blockSize = azblob.BlobDefaultDownloadBlockSize
 		} else {
 			if (blockSize * azblob.BlockBlobMaxBlocks) < fileSize {
-				// blockSize * 50K leaves some bytes in files as fileSize is not divisble by
+				// If fileSize is not divisble by 50K then there will be some bytes left
+				// as blockSize is rounded to integer value, in that case bump up the blockSize
 				blockSize++
 			}
 
 			if (blockSize & (-8)) != 0 {
+				// EXTRA : round off the block size to next higher multiple of 8.
+				// No reason to do so just the odd numbers in block size will not be good on server end is assumption
 				blockSize = (blockSize + 7) & (-8)
 			}
 

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -628,9 +628,14 @@ func (bb *BlockBlob) calculateBlockSize(name string, fileSize int64) (blockSize 
 			// Block size is smaller then 16MB then consider 16MB as default
 			blockSize = azblob.BlobDefaultDownloadBlockSize
 		} else {
-			// Round it off to next multiple of 8, to avoid round offs
-			// If file size is not divisble by 50K then there will be some data left so expand for that
-			blockSize = (blockSize + 7) & int64(-8)
+			if (blockSize * azblob.BlockBlobMaxBlocks) < fileSize {
+				// blockSize * 50K leaves some bytes in files as fileSize is not divisble by
+				blockSize++
+			}
+
+			if (blockSize & (-8)) != 0 {
+				blockSize = (blockSize + 7) & (-8)
+			}
 
 			if blockSize > azblob.BlockBlobMaxStageBlockBytes {
 				// After rounding off the blockSize has become bigger then max allowed blocks.

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -622,18 +622,12 @@ func (bb *BlockBlob) calculateBlockSize(name string, fileSize int64) (blockSize 
 		blockSize = azblob.BlockBlobMaxUploadBlobBytes
 	} else {
 		// buffer / max blocks = block size to use all 50,000 blocks
-		blockSize = fileSize / azblob.BlockBlobMaxBlocks
+		blockSize = int64(math.Ceil(float64(fileSize) / azblob.BlockBlobMaxBlocks))
 
 		if blockSize < azblob.BlobDefaultDownloadBlockSize {
 			// Block size is smaller then 16MB then consider 16MB as default
 			blockSize = azblob.BlobDefaultDownloadBlockSize
 		} else {
-			if (blockSize * azblob.BlockBlobMaxBlocks) < fileSize {
-				// If fileSize is not divisble by 50K then there will be some bytes left
-				// as blockSize is rounded to integer value, in that case bump up the blockSize
-				blockSize++
-			}
-
 			if (blockSize & (-8)) != 0 {
 				// EXTRA : round off the block size to next higher multiple of 8.
 				// No reason to do so just the odd numbers in block size will not be good on server end is assumption

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -1749,10 +1749,10 @@ func (s *blockBlobTestSuite) TestXBlockSize() {
 	s.assert.Nil(err)
 	s.assert.EqualValues(block, int64(10737424))
 
-	// For filesize 1TB expected blocksize is 21990232  (1TB/50000 ~= rounded off to next multiple of 8)
+	// For filesize 1TB expected blocksize is 21990240  (1TB/50000 ~= rounded off to next multiple of 8)
 	block, err = bb.calculateBlockSize(name, (1 * 1024 * 1024 * 1024 * 1024))
 	s.assert.Nil(err)
-	s.assert.EqualValues(block, int64(21990232))
+	s.assert.EqualValues(block, int64(21990240))
 
 	// For filesize 100TB expected blocksize is 2199023256  (100TB/50000 ~= rounded off to next multiple of 8)
 	block, err = bb.calculateBlockSize(name, (100 * 1024 * 1024 * 1024 * 1024))
@@ -1772,7 +1772,7 @@ func (s *blockBlobTestSuite) TestXBlockSize() {
 	// For Filesize created using dd for 1TB size
 	block, err = bb.calculateBlockSize(name, int64(1099511627776))
 	s.assert.Nil(err)
-	s.assert.EqualValues(block, int64(21990232))
+	s.assert.EqualValues(block, int64(21990240))
 
 	// Boundary condition 5 bytes less then max expected file size
 	block, err = bb.calculateBlockSize(name, (azblob.BlockBlobMaxStageBlockBytes*azblob.BlockBlobMaxBlocks)-5)

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -1769,6 +1769,11 @@ func (s *blockBlobTestSuite) TestXBlockSize() {
 	s.assert.Nil(err)
 	s.assert.EqualValues(block, int64(azblob.BlockBlobMaxStageBlockBytes)) // 4194304000
 
+	// For Filesize created using dd for 1TB size
+	block, err = bb.calculateBlockSize(name, int64(1099511627776))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, int64(21990232))
+
 	// Boundary condition 5 bytes less then max expected file size
 	block, err = bb.calculateBlockSize(name, (azblob.BlockBlobMaxStageBlockBytes*azblob.BlockBlobMaxBlocks)-5)
 	s.assert.Nil(err)

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -1717,6 +1717,89 @@ func (s *blockBlobTestSuite) TestChown() {
 	s.assert.EqualValues(syscall.ENOTSUP, err)
 }
 
+func (s *blockBlobTestSuite) TestXBlockSize() {
+	defer s.cleanupTest()
+	// Setup
+	name := generateFileName()
+
+	bb := BlockBlob{}
+
+	// For filesize 0 expected blocksize is 256MB
+	block, err := bb.calculateBlockSize(name, 0)
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, azblob.BlockBlobMaxUploadBlobBytes)
+
+	// For filesize 100MB expected blocksize is 256MB
+	block, err = bb.calculateBlockSize(name, (100 * 1024 * 1024))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, azblob.BlockBlobMaxUploadBlobBytes)
+
+	// For filesize 500MB expected blocksize is 4MB
+	block, err = bb.calculateBlockSize(name, (500 * 1024 * 1024))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, azblob.BlobDefaultDownloadBlockSize)
+
+	// For filesize 1GB expected blocksize is 4MB
+	block, err = bb.calculateBlockSize(name, (1 * 1024 * 1024 * 1024))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, azblob.BlobDefaultDownloadBlockSize)
+
+	// For filesize 500GB expected blocksize is 10737424
+	block, err = bb.calculateBlockSize(name, (500 * 1024 * 1024 * 1024))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, int64(10737424))
+
+	// For filesize 1TB expected blocksize is 21990232  (1TB/50000 ~= rounded off to next multiple of 8)
+	block, err = bb.calculateBlockSize(name, (1 * 1024 * 1024 * 1024 * 1024))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, int64(21990232))
+
+	// For filesize 100TB expected blocksize is 2199023256  (100TB/50000 ~= rounded off to next multiple of 8)
+	block, err = bb.calculateBlockSize(name, (100 * 1024 * 1024 * 1024 * 1024))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, int64(2199023256))
+
+	// For filesize 190TB expected blocksize is 4178144192  (190TB/50000 ~= rounded off to next multiple of 8)
+	block, err = bb.calculateBlockSize(name, (190 * 1024 * 1024 * 1024 * 1024))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, int64(4178144192))
+
+	// Boundary condition which is exactly max size supported by sdk
+	block, err = bb.calculateBlockSize(name, (azblob.BlockBlobMaxStageBlockBytes * azblob.BlockBlobMaxBlocks))
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, int64(azblob.BlockBlobMaxStageBlockBytes)) // 4194304000
+
+	// Boundary condition 5 bytes less then max expected file size
+	block, err = bb.calculateBlockSize(name, (azblob.BlockBlobMaxStageBlockBytes*azblob.BlockBlobMaxBlocks)-5)
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, int64(azblob.BlockBlobMaxStageBlockBytes))
+
+	// Boundary condition 1 bytes more then max expected file size
+	block, err = bb.calculateBlockSize(name, (azblob.BlockBlobMaxStageBlockBytes*azblob.BlockBlobMaxBlocks)+1)
+	s.assert.NotNil(err)
+	s.assert.EqualValues(block, 0)
+
+	// Boundary condition 5 bytes more then max expected file size
+	block, err = bb.calculateBlockSize(name, (azblob.BlockBlobMaxStageBlockBytes*azblob.BlockBlobMaxBlocks)+5)
+	s.assert.NotNil(err)
+	s.assert.EqualValues(block, 0)
+
+	// Boundary condition file size one block short of file blocks
+	block, err = bb.calculateBlockSize(name, (azblob.BlockBlobMaxStageBlockBytes*azblob.BlockBlobMaxBlocks)-azblob.BlockBlobMaxStageBlockBytes)
+	s.assert.Nil(err)
+	s.assert.EqualValues(block, 4194220120)
+
+	// Boundary condition one byte more then max block size
+	block, err = bb.calculateBlockSize(name, (4194304001 * azblob.BlockBlobMaxBlocks))
+	s.assert.NotNil(err)
+	s.assert.EqualValues(block, 0)
+
+	// For filesize 200TB, error is expected as max 190TB only supported
+	block, err = bb.calculateBlockSize(name, (200 * 1024 * 1024 * 1024 * 1024))
+	s.assert.NotNil(err)
+	s.assert.EqualValues(block, 0)
+}
+
 // func (s *blockBlobTestSuite) TestRAGRS() {
 // 	defer s.cleanupTest()
 // 	// Setup


### PR DESCRIPTION
- While calculating block size we need to round off if blocksize*50K is not able to accommodate entire file.
- Add UT for block size