### PR TITLE
Adding disable version check flag only once when the mount all command is run

### DIFF
--- a/cmd/mount_all.go
+++ b/cmd/mount_all.go
@@ -272,7 +272,6 @@ func mountAllContainers(containerList []string, configFile string, mountPath str
 		// Now that we have mount path and config file for this container fire a mount command for this one
 		cliParams[1] = contMountPath
 		cliParams[2] = "--config-file=" + contConfigFile
-		cliParams = append(cliParams, "--disable-version-check=true")
 
 		fmt.Println("Mounting container :", container, "to path :", contMountPath)
 		cmd := exec.Command(mountAllOpts.blobfuse2BinPath, cliParams...)
@@ -322,6 +321,7 @@ func buildCliParamForMount() []string {
 			cliParam = append(cliParam, opt)
 		}
 	}
+	cliParam = append(cliParam, "--disable-version-check=true")
 
 	return cliParam
 }


### PR DESCRIPTION
When we run mount all command, the --disable-version-check=true flag is added multiple times for subsequent containers. So, added a small fix where it is added only once.