### PR TITLE
[BUG] ParseFloat fix for file cache on locales that provide a ","

### DIFF
--- a/component/file_cache/cache_policy.go
+++ b/component/file_cache/cache_policy.go
@@ -37,7 +37,6 @@ import (
 	"blobfuse2/common"
 	"blobfuse2/common/log"
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -101,7 +100,6 @@ func getUsage(path string) float64 {
 	}
 	// some OS's use "," instead of "." that will not work for float parsing - replace it
 	size = strings.Replace(size, ",", ".", 1)
-	fmt.Println(size)
 	parsed, err := strconv.ParseFloat(size[:len(size)-1], 64)
 	if err != nil {
 		log.Err("cachePolicy::getCacheUsage : error parsing folder size [%s]", err.Error())

--- a/component/file_cache/cache_policy.go
+++ b/component/file_cache/cache_policy.go
@@ -37,6 +37,7 @@ import (
 	"blobfuse2/common"
 	"blobfuse2/common/log"
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -98,7 +99,9 @@ func getUsage(path string) float64 {
 	if size == "0" {
 		return 0
 	}
-
+	// some OS's use "," instead of "." that will not work for float parsing - replace it
+	size = strings.Replace(size, ",", ".", 1)
+	fmt.Println(size)
 	parsed, err := strconv.ParseFloat(size[:len(size)-1], 64)
 	if err != nil {
 		log.Err("cachePolicy::getCacheUsage : error parsing folder size [%s]", err.Error())


### PR DESCRIPTION
This resolves https://github.com/Azure/azure-storage-fuse/issues/784
some locales produce sizes of format `X,XM`
Replace `,` to `.`