### PR TITLE
Dont delete directory in case of gen2 account if directory is not empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.6)
 
 # Change this while bumping up the version, needed for RHEL package
-set(VERSION "1.4.4")
+set(VERSION "1.4.5-preview")
 
 # This macro is referred in code to print the current version
 # Change CPACK_DEBIAN_PACKAGE_DESCRIPTION as well in this file while bumping up the version
-add_definitions(-D_BLOBFUSE_VERSION_="1.4.4")
+add_definitions(-D_BLOBFUSE_VERSION_="1.4..5-preview")
 
 set(CPACK_PACKAGE_VERSION_MAJOR 1)
 set(CPACK_PACKAGE_VERSION_MINOR 4)  
-set(CPACK_PACKAGE_VERSION_PATCH 4)
+set(CPACK_PACKAGE_VERSION_PATCH 5)
 set(CPACK_PACKAGE_VERSION_RELEASE 1)
 
 set (BLOBFUSE_HEADER
@@ -127,7 +127,7 @@ if(UNIX)
   set(CPACK_GENERATOR "DEB")
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Microsoft - Azure Storage")
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "fuse")
-  set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "blobfuse 1.4.4 - FUSE adapter for Azure Blob Storage")
+  set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "blobfuse 1.4.5-preview - FUSE adapter for Azure Blob Storage")
   set(CPACK_PACKAGE_NAME "blobfuse")
   set(CPACK_PACKAGE_VENDOR "Microsoft")
   include(CPack)

--- a/blobfuse/directoryapis.cpp
+++ b/blobfuse/directoryapis.cpp
@@ -256,7 +256,11 @@ int azs_rmdir(const char *path)
     mntPath = mntPathString.c_str();
 
     AZS_DEBUGLOGV("Attempting to delete local cache directory %s.\n", mntPath);
-    remove(mntPath); // This will fail if the cache is not empty, which is fine, as in this case it will also fail later, after the server-side check.
+    int ret_code = remove(mntPath); // This will fail if the cache is not empty, which is fine, as in this case it will also fail later, after the server-side check.
+    if (ret_code != 0 && errno == ENOTEMPTY) {
+        AZS_DEBUGLOGV("Local cache directory is not empty %s.\n", mntPath);
+        return -ENOTEMPTY;
+    }
 
     if(!storage_client->DeleteDirectory(pathString.substr(1)))
     {

--- a/blobfuse/src/DataLakeBfsClient.cpp
+++ b/blobfuse/src/DataLakeBfsClient.cpp
@@ -325,6 +325,10 @@ int DataLakeBfsClient::Exists(const std::string directoryPath)
 bool DataLakeBfsClient::DeleteDirectory(const std::string directoryPath)
 {
     errno = 0;
+    if (IsDirectoryEmpty(directoryPath) == D_NOTEMPTY) {
+        return false;
+    }
+
     m_adls_client->delete_directory(configurations.containerName, directoryPath);
     if(errno != 0)
     {

--- a/cpplite/include/constants.dat
+++ b/cpplite/include/constants.dat
@@ -117,7 +117,7 @@ DAT(header_value_payload_format_nometadata, "application/json;odata=nometadata")
 DAT(header_value_payload_format_fullmetadata, "application/json;odata=fullmetadata")
 DAT(header_value_storage_blob_version, "2018-11-09")
 
-DAT(header_value_user_agent, "azure-storage-fuse/1.4.4")
+DAT(header_value_user_agent, "azure-storage-fuse/1.4.5-preview")
 
 DAT(date_format_rfc_1123, "%a, %d %b %Y %H:%M:%S GMT")
 DAT(date_format_iso_8601, "%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Commands like "git stash" try attempting a non-empty directory. On regular filesystem it fails with error "directory on empty"
In case of blobfuse, for block blob account we check for non-empty directory condition but for gen2 account we go ahead and delete the directory recursively on container as well, this results into "git stash" command deleting ".git" directory and resulting into a corrupting git repository.