### PR TITLE
V2 : Dont delete directory based on local cache status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug in append file flow resolving data corruption
 - Fixed a bug in MSI auth to send correct resource string
 - Fixed a bug in OAuth token parsing when expires_on denotes numbers of seconds
+- Fixed a bug in rmdir flow. Dont allow directory deletion if local cache says its empty. On container it might still have files.
 ## 2.0.0-preview.2 (2022-05-31)
 **Performance Improvements**
 - fio: Outperforms blobfuse by 10% in sequential reads

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -512,29 +512,33 @@ func (fc *FileCache) IsDirEmpty(options internal.IsDirEmptyOptions) bool {
 	// If the directory does not exist locally then call the next component
 	localPath := filepath.Join(fc.tmpPath, options.Name)
 	f, err := os.Open(localPath)
-	if os.IsNotExist(err) {
+	if err == nil {
+		log.Debug("FileCache::IsDirEmpty : %s found in local cache", options.Name)
+
+		// Check local cache directory is empty or not
+		path, err := f.Readdirnames(1)
+
+		// If the local directory has a path in it, it is likely due to !createEmptyFile.
+		if err == nil && !fc.createEmptyFile && len(path) > 0 {
+			log.Debug("FileCache::IsDirEmpty : %s had a subpath in the local cache", options.Name)
+			return false
+		}
+
+		// If there are files in local cache then dont allow deletion of directory
+		if err != io.EOF {
+			// Local directory is not empty fail the call
+			log.Debug("FileCache::IsDirEmpty : %s was not empty in local cache", options.Name)
+			return false
+		}
+	} else if os.IsNotExist(err) {
+		// Not found in local cache so check with container
 		log.Debug("FileCache::IsDirEmpty : %s not found in local cache", options.Name)
-		return fc.NextComponent().IsDirEmpty(options)
+	} else {
+		// Unknown error, check with container
+		log.Err("FileCache::IsDirEmpty : %s failed while checking local cache (%s)", options.Name, err.Error())
 	}
 
-	if err != nil {
-		log.Err("FileCache::IsDirEmpty : error opening directory %s [%s]", options.Name, err.Error())
-		return false
-	}
-
-	// The file cache policy handles deleting locally empty directories in the cache
-	// If the directory exists locally and is empty, it was probably recently emptied and we can trust this result.
-	path, err := f.Readdirnames(1)
-	if err == io.EOF {
-		log.Debug("FileCache::IsDirEmpty : %s was empty in local cache", options.Name)
-		return true
-	}
-	// If the local directory has a path in it, it is likely due to !createEmptyFile.
-	if err == nil && !fc.createEmptyFile && len(path) > 0 {
-		log.Debug("FileCache::IsDirEmpty : %s had a subpath in the local cache", options.Name)
-		return false
-	}
-
+	log.Debug("FileCache::IsDirEmpty : %s checking with container", options.Name)
 	return fc.NextComponent().IsDirEmpty(options)
 }
 


### PR DESCRIPTION
Commands like "git stash" try attempting a non-empty directory. On regular filesystem it fails with error "directory on empty"
In case of blobfuse, for block blob account we check for non-empty directory condition but for gen2 account we go ahead and delete the directory recursively on container as well, this results into "git stash" command deleting ".git" directory and resulting into a corrupting git repository.
In V2 we take decision based on local directory status. If local directory is empty then we allow deletion of directory. This is a wrong decision as local directory might be empty due to file-cache-eviction as well.