### PR TITLE
fix bug: delete or rename directory

### DIFF
--- a/blobfuse/include/BlockBlobBfsClient.h
+++ b/blobfuse/include/BlockBlobBfsClient.h
@@ -132,6 +132,10 @@ protected:
     /// Helper function - Authenticates with spn
     ///</summary>
     std::shared_ptr<blob_client_wrapper> authenticate_blob_spn();
+    ///< summary>
+    /// Helper function - Copy directory.
+    ///</summary>
+    bool copy_directory(const std::string sourcePath, const std::string destinationPath);
 private:
     ///<summary>
     /// Helper function - Renames single file

--- a/cpplite/adls/src/adls_client.cpp
+++ b/cpplite/adls/src/adls_client.cpp
@@ -317,7 +317,7 @@ namespace azure { namespace storage_adls {
 
     void adls_client::delete_file(const std::string& filesystem, const std::string& file)
     {
-        return blob_client_adaptor<void>(std::bind(&azure::storage_lite::blob_client::delete_blob, m_blob_client, filesystem, file, false));
+        return blob_client_adaptor<void>(std::bind(&azure::storage_lite::blob_client::delete_blob, m_blob_client, filesystem, file, false, false));
     }
 
     bool adls_client::file_exists(const std::string& filesystem, const std::string& file)

--- a/cpplite/include/blob/blob_client.h
+++ b/cpplite/include/blob/blob_client.h
@@ -160,7 +160,7 @@ namespace azure { namespace storage_lite {
         /// <param name="blob">The blob name.</param>
         /// <param name="delete_snapshots">A bool value, delete snapshots if it is true.</param>
         /// <returns>A <see cref="std::future" /> object that represents the current operation.</returns>
-        AZURE_STORAGE_API std::future<storage_outcome<void>> delete_blob(const std::string &container, const std::string &blob, bool delete_snapshots = false);
+        AZURE_STORAGE_API std::future<storage_outcome<void>> delete_blob(const std::string &container, const std::string &blob, bool delete_snapshots = false, bool is_directory = false);
 
         /// <summary>
         /// Intitiates an asynchronous operation  to create a container.
@@ -553,6 +553,13 @@ namespace azure { namespace storage_lite {
         /// <param name="destBlob">The destination blob name.</param>
         AZURE_STORAGE_API virtual void start_copy(const std::string &sourceContainer, const std::string &sourceBlob, const std::string &destContainer, const std::string &destBlob);
         
+        /// <summary>
+        /// Deletes a blob which is empty directory.
+        /// </summary>
+        /// <param name="container">The container name.</param>
+        /// <param name="blob">The blob name.</param>
+        AZURE_STORAGE_API virtual void delete_empty_directory(const std::string &container, const std::string &blob);
+
         AZURE_STORAGE_API void set_retry_policy(std::shared_ptr<retry_policy_base> retry_policy)
         {
             if (m_blobClient)

--- a/cpplite/include/blob/delete_blob_request.h
+++ b/cpplite/include/blob/delete_blob_request.h
@@ -7,10 +7,11 @@ namespace azure { namespace storage_lite {
     class delete_blob_request final : public delete_blob_request_base
     {
     public:
-        delete_blob_request(const std::string &container, const std::string &blob, bool delete_snapshots_only = false)
+        delete_blob_request(const std::string &container, const std::string &blob, bool delete_snapshots_only = false, bool is_directory = false)
             : m_container(container),
             m_blob(blob),
-            m_delete_snapshots_only(delete_snapshots_only) {}
+            m_delete_snapshots_only(delete_snapshots_only),
+            m_is_directory(is_directory) {}
 
         std::string container() const override
         {
@@ -24,6 +25,9 @@ namespace azure { namespace storage_lite {
 
         delete_snapshots ms_delete_snapshots() const override
         {
+            if (m_is_directory) {
+                return delete_snapshots::unspecified;
+            }
             if (m_delete_snapshots_only) {
                 return delete_snapshots::only;
             }
@@ -36,6 +40,7 @@ namespace azure { namespace storage_lite {
         std::string m_container;
         std::string m_blob;
         bool m_delete_snapshots_only;
+        bool m_is_directory;
     };
 
 }}  // azure::storage_lite

--- a/cpplite/src/blob/blob_client.cpp
+++ b/cpplite/src/blob/blob_client.cpp
@@ -388,11 +388,11 @@ std::future<storage_outcome<void>> blob_client::upload_block_from_buffer(const s
     return async_executor<void>::submit(m_account, request, http, m_context);
 }
 
-std::future<storage_outcome<void>> blob_client::delete_blob(const std::string &container, const std::string &blob, bool delete_snapshots)
+std::future<storage_outcome<void>> blob_client::delete_blob(const std::string &container, const std::string &blob, bool delete_snapshots, bool is_directory)
 {
     auto http = m_client->get_handle();
 
-    auto request = std::make_shared<delete_blob_request>(container, blob, delete_snapshots);
+    auto request = std::make_shared<delete_blob_request>(container, blob, delete_snapshots, is_directory);
 
     return async_executor<void>::submit(m_account, request, http, m_context);
 }


### PR DESCRIPTION
**There are 2 bugs: cannot delete or rename directory**

Demo:
![image](https://user-images.githubusercontent.com/13145082/186123284-9b837b46-5470-4826-8405-34b72fa601ab.png)

**Bug Reason:**

1. delete bug:
    When delete directory, http request headers cannot have `x-ms-delete-snapshots`, see: https://docs.microsoft.com/en-us/rest/api/storageservices/delete-blob 
![image](https://user-images.githubusercontent.com/13145082/186123484-d24765ca-7945-407b-9498-f602b18cdbed.png)

2. rename bug:
    When using blob mount to rename directory, `m_blob_client->start_copy` cannot copy directory, so I add `copy_directory` function to copy recursively.

**Result:**
![image](https://user-images.githubusercontent.com/13145082/186124094-f4947d50-fa29-49d3-97d0-58c99c599b68.png)
![image](https://user-images.githubusercontent.com/13145082/186124111-b564dd5c-0ede-4dbe-94db-72a832c78078.png)
