### PR TITLE
Expand path

### DIFF
--- a/azure-pipeline-templates/mount-test.yml
+++ b/azure-pipeline-templates/mount-test.yml
@@ -24,7 +24,7 @@ steps:
   - task: Go@0
     inputs:
       command: 'test'
-      arguments: '-timeout=120m -v test/mount_test/mount_test.go -args -working-dir=${{ parameters.working_dir }} -mnt-path=${{ parameters.mount_dir }} -config-file=${{parameters.config}}'
+      arguments: '-timeout=120m -p 1 -v test/mount_test/mount_test.go -args -working-dir=${{ parameters.working_dir }} -mnt-path=${{ parameters.mount_dir }} -config-file=${{parameters.config}}'
       workingDirectory: ${{ parameters.working_dir }}
     displayName: 'MountTest: ${{ parameters.idstring }}'
     timeoutInMinutes: 120

--- a/cmd/health-monitor.go
+++ b/cmd/health-monitor.go
@@ -151,7 +151,7 @@ func buildCliParamForMonitor() []string {
 		cliParams = append(cliParams, fmt.Sprintf("--output-path=%v", options.MonitorOpt.OutputPath))
 	}
 
-	cliParams = append(cliParams, "--cache-path="+cacheMonitorOptions.TmpPath)
+	cliParams = append(cliParams, "--cache-path="+common.ExpandPath(cacheMonitorOptions.TmpPath))
 	cliParams = append(cliParams, fmt.Sprintf("--max-size-mb=%v", cacheMonitorOptions.MaxSizeMB))
 
 	for _, v := range options.MonitorOpt.DisableList {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -168,6 +168,8 @@ func OnConfigChange() {
 
 // parseConfig : Based on config file or encrypted data parse the provided config
 func parseConfig() {
+	options.ConfigFile = common.ExpandPath(options.ConfigFile)
+
 	// Based on extension decide file is encrypted or not
 	if options.SecureConfig ||
 		filepath.Ext(options.ConfigFile) == SecureConfigExtension {
@@ -223,7 +225,7 @@ var mountCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Parent().Run(cmd.Parent(), args)
 
-		options.MountPath = args[0]
+		options.MountPath = common.ExpandPath(args[0])
 		configFileExists := true
 
 		if options.ConfigFile == "" {

--- a/cmd/mountgen1.go
+++ b/cmd/mountgen1.go
@@ -208,7 +208,7 @@ func generateAdlsGenOneJson() error {
 	}
 
 	if fileCacheOpt.TmpPath != "" {
-		rustFuseMap["cachedir"] = fileCacheOpt.TmpPath
+		rustFuseMap["cachedir"] = common.ExpandPath(fileCacheOpt.TmpPath)
 	}
 
 	if azStorageOpt.Container != "" {

--- a/cmd/mountgen1_test.go
+++ b/cmd/mountgen1_test.go
@@ -138,7 +138,7 @@ func (suite *genOneConfigTestSuite) TestConfigCreation() {
 
 	suite.assert.EqualValues("myClientId", clientId)
 	suite.assert.EqualValues("myTenantId", tenantId)
-	suite.assert.EqualValues("fileCachePath", cacheDir)
+	suite.assert.Contains(cacheDir, "fileCachePath")
 	suite.assert.EqualValues(mntDir, mountDirTest)
 }
 

--- a/cmd/mountv1.go
+++ b/cmd/mountv1.go
@@ -152,29 +152,32 @@ var generateConfigCmd = &cobra.Command{
 		if len(args) == 1 {
 			mountPath = args[0]
 		}
-		file, _ := os.Open(bfConfCliOptions.configFile)
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			// some users may have a commented out config
-			linePieces := strings.SplitN(scanner.Text(), "#", 2)
-			line := linePieces[0]
-			configParam := strings.Fields(line)
-			if len(configParam) == 0 {
-				continue
-			}
-			if len(configParam) != 2 {
-				return fmt.Errorf("failed to read configuration file. the configuration %s is incorrect. please make sure your configuration file parameters are of the format `key value`", configParam)
-			}
-			// get corresponding Blobfuse2 configurations from the config file parameters
-			err := convertBfConfigParameter(cmd.Flags(), configParam[0], configParam[1])
-			if err != nil {
-				return err
-			}
+		file, err := os.Open(bfConfCliOptions.configFile)
+		if err == nil {
+			defer file.Close()
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				// some users may have a commented out config
+				linePieces := strings.SplitN(scanner.Text(), "#", 2)
+				line := linePieces[0]
+				configParam := strings.Fields(line)
+				if len(configParam) == 0 {
+					continue
+				}
+				if len(configParam) != 2 {
+					return fmt.Errorf("failed to read configuration file. the configuration %s is incorrect. please make sure your configuration file parameters are of the format `key value`", configParam)
+				}
+				// get corresponding Blobfuse2 configurations from the config file parameters
+				err := convertBfConfigParameter(cmd.Flags(), configParam[0], configParam[1])
+				if err != nil {
+					return err
+				}
 
+			}
 		}
 		bfv2ComponentsConfigOptions = append(bfv2ComponentsConfigOptions, "libfuse")
 		// get corresponding Blobfuse2 configurations from the cli parameters - these supersede the config options
-		err := convertBfCliParameters(cmd.Flags())
+		err = convertBfCliParameters(cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/common/util.go
+++ b/common/util.go
@@ -262,10 +262,5 @@ func ExpandPath(path string) string {
 		path = filepath.Join(homeDir, path[2:])
 	}
 
-	// convert relative path to absolute path
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return path
-	}
-	return absPath
+	return path
 }

--- a/common/util.go
+++ b/common/util.go
@@ -43,6 +43,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -249,4 +250,22 @@ func (m *KeyedMutex) GetLock(key string) *sync.Mutex {
 // check if health-monitor is enabled and blofuse stats monitor is not disabled
 func MonitorBfs() bool {
 	return EnableMonitoring && !BfsDisabled
+}
+
+// convert ~ to $HOME in path
+func ExpandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		path = filepath.Join(homeDir, path[2:])
+	}
+
+	// convert relative path to absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return absPath
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -124,3 +124,14 @@ func (suite *typesTestSuite) TestEncryptDecrypt() {
 	suite.assert.Nil(err)
 	suite.assert.EqualValues(data, d)
 }
+
+func (suite *utilTestSuite) TestMonitorBfs() {
+	monitor := MonitorBfs()
+	suite.assert.False(monitor)
+}
+
+func (suite *utilTestSuite) TestExpandPath() {
+	path := "~/a/b/c/d"
+	expandedPath := ExpandPath(path)
+	suite.assert.Contains(expandedPath, path[2:])
+}

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -211,7 +211,7 @@ func (c *FileCache) Configure(_ bool) error {
 	c.offloadIO = conf.OffloadIO
 	c.maxCacheSize = conf.MaxSizeMB
 
-	c.tmpPath = conf.TmpPath
+	c.tmpPath = common.ExpandPath(conf.TmpPath)
 	if c.tmpPath == "" {
 		log.Err("FileCache: config error [tmp-path not set]")
 		return fmt.Errorf("config error in %s error [tmp-path not set]", c.Name())
@@ -224,18 +224,18 @@ func (c *FileCache) Configure(_ bool) error {
 	}
 
 	// Extract values from 'conf' and store them as you wish here
-	_, err = os.Stat(conf.TmpPath)
+	_, err = os.Stat(c.tmpPath)
 	if os.IsNotExist(err) {
 		log.Err("FileCache: config error [tmp-path does not exist. attempting to create tmp-path.]")
-		err := os.Mkdir(conf.TmpPath, os.FileMode(0755))
+		err := os.Mkdir(c.tmpPath, os.FileMode(0755))
 		if err != nil {
 			log.Err("FileCache: config error creating directory after clean [%s]", err.Error())
 			return fmt.Errorf("config error in %s [%s]", c.Name(), err.Error())
 		}
 	}
 
-	if !isLocalDirEmpty(conf.TmpPath) && !c.allowNonEmpty {
-		log.Err("FileCache: config error %s directory is not empty", conf.TmpPath)
+	if !isLocalDirEmpty(c.tmpPath) && !c.allowNonEmpty {
+		log.Err("FileCache: config error %s directory is not empty", c.tmpPath)
 		return fmt.Errorf("config error in %s [%s]", c.Name(), "temp directory not empty")
 	}
 
@@ -327,7 +327,7 @@ func (c *FileCache) GetPolicyConfig(conf FileCacheOptions) cachePolicyConfig {
 	}
 
 	cacheConfig := cachePolicyConfig{
-		tmpPath:       conf.TmpPath,
+		tmpPath:       c.tmpPath,
 		maxEviction:   conf.MaxEviction,
 		highThreshold: float64(conf.HighThreshold),
 		lowThreshold:  float64(conf.LowThreshold),

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -260,93 +260,93 @@ func (suite *mountSuite) TestEnvVarMount() {
 }
 
 // mount test using environment variables for mounting with cli options
-// func (suite *mountSuite) TestEnvVarMountCliParams() {
-// 	// read config file
-// 	configData, err := os.ReadFile(configFile)
-// 	suite.Equal(nil, err)
+func (suite *mountSuite) TestEnvVarMountCliParams() {
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	suite.Equal(nil, err)
 
-// 	viper.SetConfigType("yaml")
-// 	viper.ReadConfig(bytes.NewBuffer(configData))
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
 
-// 	// create environment variables
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+	// create environment variables
+	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-// 	tempFile := viper.GetString("file_cache.path")
+	tempFile := viper.GetString("file_cache.path")
 
-// 	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
-// 		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
-// 		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
-// 	cliOut, err := mountCmd.Output()
-// 	fmt.Println(string(cliOut))
-// 	suite.Equal(0, len(cliOut))
-// 	suite.Equal(nil, err)
+	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
+		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
+		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
+	cliOut, err := mountCmd.Output()
+	fmt.Println(string(cliOut))
+	suite.Equal(0, len(cliOut))
+	suite.Equal(nil, err)
 
-// 	// wait for mount
-// 	time.Sleep(10 * time.Second)
+	// wait for mount
+	time.Sleep(10 * time.Second)
 
-// 	// list blobfuse mounted directories
-// 	cliOut = listBlobfuseMounts(suite)
-// 	suite.NotEqual(0, len(cliOut))
-// 	suite.Contains(string(cliOut), mntDir)
+	// list blobfuse mounted directories
+	cliOut = listBlobfuseMounts(suite)
+	suite.NotEqual(0, len(cliOut))
+	suite.Contains(string(cliOut), mntDir)
 
-// 	// unmount
-// 	blobfuseUnmount(suite, mntDir)
+	// unmount
+	blobfuseUnmount(suite, mntDir)
 
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-// }
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+}
 
-// // mountv1 test using CSI driver cli options
-// func (suite *mountSuite) TestEnvVarMountCSIParams() {
-// 	// read config file
-// 	configData, err := os.ReadFile(configFile)
-// 	suite.Equal(nil, err)
+// mountv1 test using CSI driver cli options
+func (suite *mountSuite) TestEnvVarMountCSIParams() {
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	suite.Equal(nil, err)
 
-// 	viper.SetConfigType("yaml")
-// 	viper.ReadConfig(bytes.NewBuffer(configData))
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
 
-// 	// create environment variables
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+	// create environment variables
+	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-// 	tempFile := viper.GetString("file_cache.path")
+	tempFile := viper.GetString("file_cache.path")
 
-// 	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
-// 		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
-// 		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
-// 		"--log-level=LOG_WARNING", "--cache-size-mb=1000", "--output-file=configV1.yaml")
-// 	cliOut, err := mountCmd.Output()
-// 	fmt.Println(string(cliOut))
-// 	suite.Equal(0, len(cliOut))
-// 	suite.Equal(nil, err)
+	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
+		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
+		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
+		"--log-level=LOG_WARNING", "--cache-size-mb=1000", "--output-file=configV1.yaml")
+	cliOut, err := mountCmd.Output()
+	fmt.Println(string(cliOut))
+	suite.Equal(0, len(cliOut))
+	suite.Equal(nil, err)
 
-// 	// wait for mount
-// 	time.Sleep(10 * time.Second)
+	// wait for mount
+	time.Sleep(10 * time.Second)
 
-// 	// list blobfuse mounted directories
-// 	cliOut = listBlobfuseMounts(suite)
-// 	suite.NotEqual(0, len(cliOut))
-// 	suite.Contains(string(cliOut), mntDir)
+	// list blobfuse mounted directories
+	cliOut = listBlobfuseMounts(suite)
+	suite.NotEqual(0, len(cliOut))
+	suite.Contains(string(cliOut), mntDir)
 
-// 	// unmount
-// 	blobfuseUnmount(suite, mntDir)
+	// unmount
+	blobfuseUnmount(suite, mntDir)
 
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-// }
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+}
 
 func TestMountSuite(t *testing.T) {
 	suite.Run(t, new(mountSuite))

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -363,10 +363,6 @@ func TestMain(m *testing.M) {
 	mntDir = filepath.Join(*pathPtr, mntDir)
 	configFile = *configPtr
 
-	blobfuseBinary = "/home/sourav/go/src/azure-storage-fuse/blobfuse2"
-	mntDir = "/home/sourav/testmntdir/mntdir"
-	configFile = "/home/sourav/config/v2/config.yaml"
-
 	err := os.RemoveAll(mntDir)
 	if err != nil {
 		fmt.Println("Could not cleanup mount directory before testing")

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -85,7 +85,7 @@ func blobfuseUnmount(suite *mountSuite, unmountOutput string) {
 	suite.Contains(string(cliOut), unmountOutput)
 
 	// wait after unmount
-	time.Sleep(4 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// validate unmount
 	cliOut = listBlobfuseMounts(suite)
@@ -102,7 +102,7 @@ func (suite *mountSuite) TestMountCmd() {
 	suite.Equal(nil, err)
 
 	// wait for mount
-	time.Sleep(4 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	// validate mount
 	cliOut = listBlobfuseMounts(suite)
@@ -233,8 +233,6 @@ func (suite *mountSuite) TestEnvVarMount() {
 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-	printEnvVar()
-
 	tempFile := viper.GetString("file_cache.path")
 
 	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile)
@@ -244,7 +242,7 @@ func (suite *mountSuite) TestEnvVarMount() {
 	suite.Equal(nil, err)
 
 	// wait for mount
-	time.Sleep(4 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	// list blobfuse mounted directories
 	cliOut = listBlobfuseMounts(suite)
@@ -259,114 +257,96 @@ func (suite *mountSuite) TestEnvVarMount() {
 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-
-	printEnvVar()
-}
-
-func printEnvVar() {
-	acc := os.Getenv("AZURE_STORAGE_ACCOUNT")
-	ep := os.Getenv("AZURE_STORAGE_BLOB_ENDPOINT")
-	con := os.Getenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-	typ := os.Getenv("AZURE_STORAGE_ACCOUNT_TYPE")
-	fmt.Printf("%v, %v, %v, %v\n", acc, ep, con, typ)
 }
 
 // mount test using environment variables for mounting with cli options
-func (suite *mountSuite) TestEnvVarMountCliParams() {
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	suite.Equal(nil, err)
+// func (suite *mountSuite) TestEnvVarMountCliParams() {
+// 	// read config file
+// 	configData, err := os.ReadFile(configFile)
+// 	suite.Equal(nil, err)
 
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
+// 	viper.SetConfigType("yaml")
+// 	viper.ReadConfig(bytes.NewBuffer(configData))
 
-	// create environment variables
-	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+// 	// create environment variables
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-	printEnvVar()
+// 	tempFile := viper.GetString("file_cache.path")
 
-	tempFile := viper.GetString("file_cache.path")
+// 	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
+// 		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
+// 		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
+// 	cliOut, err := mountCmd.Output()
+// 	fmt.Println(string(cliOut))
+// 	suite.Equal(0, len(cliOut))
+// 	suite.Equal(nil, err)
 
-	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
-		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
-		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
-	cliOut, err := mountCmd.Output()
-	fmt.Println(string(cliOut))
-	suite.Equal(0, len(cliOut))
-	suite.Equal(nil, err)
+// 	// wait for mount
+// 	time.Sleep(10 * time.Second)
 
-	// wait for mount
-	time.Sleep(4 * time.Second)
+// 	// list blobfuse mounted directories
+// 	cliOut = listBlobfuseMounts(suite)
+// 	suite.NotEqual(0, len(cliOut))
+// 	suite.Contains(string(cliOut), mntDir)
 
-	// list blobfuse mounted directories
-	cliOut = listBlobfuseMounts(suite)
-	suite.NotEqual(0, len(cliOut))
-	suite.Contains(string(cliOut), mntDir)
+// 	// unmount
+// 	blobfuseUnmount(suite, mntDir)
 
-	// unmount
-	blobfuseUnmount(suite, mntDir)
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+// }
 
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+// // mountv1 test using CSI driver cli options
+// func (suite *mountSuite) TestEnvVarMountCSIParams() {
+// 	// read config file
+// 	configData, err := os.ReadFile(configFile)
+// 	suite.Equal(nil, err)
 
-	printEnvVar()
-}
+// 	viper.SetConfigType("yaml")
+// 	viper.ReadConfig(bytes.NewBuffer(configData))
 
-// mountv1 test using CSI driver cli options
-func (suite *mountSuite) TestEnvVarMountCSIParams() {
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	suite.Equal(nil, err)
+// 	// create environment variables
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
+// 	tempFile := viper.GetString("file_cache.path")
 
-	// create environment variables
-	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+// 	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
+// 		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
+// 		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
+// 		"--log-level=LOG_WARNING", "--cache-size-mb=1000", "--output-file=configV1.yaml")
+// 	cliOut, err := mountCmd.Output()
+// 	fmt.Println(string(cliOut))
+// 	suite.Equal(0, len(cliOut))
+// 	suite.Equal(nil, err)
 
-	printEnvVar()
+// 	// wait for mount
+// 	time.Sleep(10 * time.Second)
 
-	tempFile := viper.GetString("file_cache.path")
+// 	// list blobfuse mounted directories
+// 	cliOut = listBlobfuseMounts(suite)
+// 	suite.NotEqual(0, len(cliOut))
+// 	suite.Contains(string(cliOut), mntDir)
 
-	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
-		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
-		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
-		"--log-level=LOG_WARNING", "--cache-size-mb=1000")
-	cliOut, err := mountCmd.Output()
-	fmt.Println(string(cliOut))
-	suite.Equal(0, len(cliOut))
-	suite.Equal(nil, err)
+// 	// unmount
+// 	blobfuseUnmount(suite, mntDir)
 
-	// wait for mount
-	time.Sleep(4 * time.Second)
-
-	// list blobfuse mounted directories
-	cliOut = listBlobfuseMounts(suite)
-	suite.NotEqual(0, len(cliOut))
-	suite.Contains(string(cliOut), mntDir)
-
-	// unmount
-	blobfuseUnmount(suite, mntDir)
-
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-
-	printEnvVar()
-}
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+// }
 
 func TestMountSuite(t *testing.T) {
 	suite.Run(t, new(mountSuite))

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -259,6 +259,95 @@ func (suite *mountSuite) TestEnvVarMount() {
 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
 }
 
+// mount test using environment variables for mounting with cli options
+func (suite *mountSuite) TestEnvVarMountCliParams() {
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	suite.Equal(nil, err)
+
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
+
+	// create environment variables
+	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+
+	tempFile := viper.GetString("file_cache.path")
+
+	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
+		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
+		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
+	cliOut, err := mountCmd.Output()
+	fmt.Println(string(cliOut))
+	suite.Equal(0, len(cliOut))
+	suite.Equal(nil, err)
+
+	// wait for mount
+	time.Sleep(4 * time.Second)
+
+	// list blobfuse mounted directories
+	cliOut = listBlobfuseMounts(suite)
+	suite.NotEqual(0, len(cliOut))
+	suite.Contains(string(cliOut), mntDir)
+
+	// unmount
+	blobfuseUnmount(suite, mntDir)
+
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+}
+
+// mountv1 test using CSI driver cli options
+func (suite *mountSuite) TestEnvVarMountCSIParams() {
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	suite.Equal(nil, err)
+
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
+
+	// create environment variables
+	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+
+	tempFile := viper.GetString("file_cache.path")
+
+	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
+		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
+		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
+		"--log-level=LOG_WARNING", "--cache-size-mb=1000")
+	cliOut, err := mountCmd.Output()
+	fmt.Println(string(cliOut))
+	suite.Equal(0, len(cliOut))
+	suite.Equal(nil, err)
+
+	// wait for mount
+	time.Sleep(4 * time.Second)
+
+	// list blobfuse mounted directories
+	cliOut = listBlobfuseMounts(suite)
+	suite.NotEqual(0, len(cliOut))
+	suite.Contains(string(cliOut), mntDir)
+
+	// unmount
+	blobfuseUnmount(suite, mntDir)
+
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+}
+
 func TestMountSuite(t *testing.T) {
 	suite.Run(t, new(mountSuite))
 }
@@ -273,6 +362,10 @@ func TestMain(m *testing.M) {
 	blobfuseBinary = filepath.Join(*workingDirPtr, blobfuseBinary)
 	mntDir = filepath.Join(*pathPtr, mntDir)
 	configFile = *configPtr
+
+	blobfuseBinary = "/home/sourav/go/src/azure-storage-fuse/blobfuse2"
+	mntDir = "/home/sourav/testmntdir/mntdir"
+	configFile = "/home/sourav/config/v2/config.yaml"
 
 	err := os.RemoveAll(mntDir)
 	if err != nil {

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -233,6 +233,8 @@ func (suite *mountSuite) TestEnvVarMount() {
 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
+	printEnvVar()
+
 	tempFile := viper.GetString("file_cache.path")
 
 	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile)
@@ -257,96 +259,114 @@ func (suite *mountSuite) TestEnvVarMount() {
 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+
+	printEnvVar()
+}
+
+func printEnvVar() {
+	acc := os.Getenv("AZURE_STORAGE_ACCOUNT")
+	ep := os.Getenv("AZURE_STORAGE_BLOB_ENDPOINT")
+	con := os.Getenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+	typ := os.Getenv("AZURE_STORAGE_ACCOUNT_TYPE")
+	fmt.Printf("%v, %v, %v, %v\n", acc, ep, con, typ)
 }
 
 // mount test using environment variables for mounting with cli options
-// func (suite *mountSuite) TestEnvVarMountCliParams() {
-// 	// read config file
-// 	configData, err := os.ReadFile(configFile)
-// 	suite.Equal(nil, err)
+func (suite *mountSuite) TestEnvVarMountCliParams() {
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	suite.Equal(nil, err)
 
-// 	viper.SetConfigType("yaml")
-// 	viper.ReadConfig(bytes.NewBuffer(configData))
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
 
-// 	// create environment variables
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+	// create environment variables
+	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-// 	tempFile := viper.GetString("file_cache.path")
+	printEnvVar()
 
-// 	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
-// 		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
-// 		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
-// 	cliOut, err := mountCmd.Output()
-// 	fmt.Println(string(cliOut))
-// 	suite.Equal(0, len(cliOut))
-// 	suite.Equal(nil, err)
+	tempFile := viper.GetString("file_cache.path")
 
-// 	// wait for mount
-// 	time.Sleep(4 * time.Second)
+	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
+		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
+		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
+	cliOut, err := mountCmd.Output()
+	fmt.Println(string(cliOut))
+	suite.Equal(0, len(cliOut))
+	suite.Equal(nil, err)
 
-// 	// list blobfuse mounted directories
-// 	cliOut = listBlobfuseMounts(suite)
-// 	suite.NotEqual(0, len(cliOut))
-// 	suite.Contains(string(cliOut), mntDir)
+	// wait for mount
+	time.Sleep(4 * time.Second)
 
-// 	// unmount
-// 	blobfuseUnmount(suite, mntDir)
+	// list blobfuse mounted directories
+	cliOut = listBlobfuseMounts(suite)
+	suite.NotEqual(0, len(cliOut))
+	suite.Contains(string(cliOut), mntDir)
 
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-// }
+	// unmount
+	blobfuseUnmount(suite, mntDir)
 
-// // mountv1 test using CSI driver cli options
-// func (suite *mountSuite) TestEnvVarMountCSIParams() {
-// 	// read config file
-// 	configData, err := os.ReadFile(configFile)
-// 	suite.Equal(nil, err)
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
 
-// 	viper.SetConfigType("yaml")
-// 	viper.ReadConfig(bytes.NewBuffer(configData))
+	printEnvVar()
+}
 
-// 	// create environment variables
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+// mountv1 test using CSI driver cli options
+func (suite *mountSuite) TestEnvVarMountCSIParams() {
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	suite.Equal(nil, err)
 
-// 	tempFile := viper.GetString("file_cache.path")
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
 
-// 	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
-// 		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
-// 		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
-// 		"--log-level=LOG_WARNING", "--cache-size-mb=1000")
-// 	cliOut, err := mountCmd.Output()
-// 	fmt.Println(string(cliOut))
-// 	suite.Equal(0, len(cliOut))
-// 	suite.Equal(nil, err)
+	// create environment variables
+	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-// 	// wait for mount
-// 	time.Sleep(4 * time.Second)
+	printEnvVar()
 
-// 	// list blobfuse mounted directories
-// 	cliOut = listBlobfuseMounts(suite)
-// 	suite.NotEqual(0, len(cliOut))
-// 	suite.Contains(string(cliOut), mntDir)
+	tempFile := viper.GetString("file_cache.path")
 
-// 	// unmount
-// 	blobfuseUnmount(suite, mntDir)
+	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
+		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
+		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
+		"--log-level=LOG_WARNING", "--cache-size-mb=1000")
+	cliOut, err := mountCmd.Output()
+	fmt.Println(string(cliOut))
+	suite.Equal(0, len(cliOut))
+	suite.Equal(nil, err)
 
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-// }
+	// wait for mount
+	time.Sleep(4 * time.Second)
+
+	// list blobfuse mounted directories
+	cliOut = listBlobfuseMounts(suite)
+	suite.NotEqual(0, len(cliOut))
+	suite.Contains(string(cliOut), mntDir)
+
+	// unmount
+	blobfuseUnmount(suite, mntDir)
+
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+
+	printEnvVar()
+}
 
 func TestMountSuite(t *testing.T) {
 	suite.Run(t, new(mountSuite))

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -219,13 +219,6 @@ func (suite *mountSuite) TestEnvVarMountFailure() {
 
 // mount test using environment variables for mounting
 func (suite *mountSuite) TestEnvVarMount() {
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	suite.Equal(nil, err)
-
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
-
 	// create environment variables
 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
@@ -261,13 +254,6 @@ func (suite *mountSuite) TestEnvVarMount() {
 
 // mount test using environment variables for mounting with cli options
 func (suite *mountSuite) TestEnvVarMountCliParams() {
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	suite.Equal(nil, err)
-
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
-
 	// create environment variables
 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
@@ -286,7 +272,7 @@ func (suite *mountSuite) TestEnvVarMountCliParams() {
 	suite.Equal(nil, err)
 
 	// wait for mount
-	time.Sleep(4 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	// list blobfuse mounted directories
 	cliOut = listBlobfuseMounts(suite)
@@ -305,13 +291,6 @@ func (suite *mountSuite) TestEnvVarMountCliParams() {
 
 // mountv1 test using CSI driver cli options
 func (suite *mountSuite) TestEnvVarMountCSIParams() {
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	suite.Equal(nil, err)
-
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
-
 	// create environment variables
 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
@@ -331,7 +310,7 @@ func (suite *mountSuite) TestEnvVarMountCSIParams() {
 	suite.Equal(nil, err)
 
 	// wait for mount
-	time.Sleep(4 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	// list blobfuse mounted directories
 	cliOut = listBlobfuseMounts(suite)
@@ -368,6 +347,15 @@ func TestMain(m *testing.M) {
 		fmt.Println("Could not cleanup mount directory before testing")
 	}
 	os.Mkdir(mntDir, 0777)
+
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	if err != nil {
+		fmt.Printf("Unable to read config file, %v : [%v]", configFile, err)
+	}
+
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
 
 	m.Run()
 

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -260,93 +260,93 @@ func (suite *mountSuite) TestEnvVarMount() {
 }
 
 // mount test using environment variables for mounting with cli options
-func (suite *mountSuite) TestEnvVarMountCliParams() {
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	suite.Equal(nil, err)
+// func (suite *mountSuite) TestEnvVarMountCliParams() {
+// 	// read config file
+// 	configData, err := os.ReadFile(configFile)
+// 	suite.Equal(nil, err)
 
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
+// 	viper.SetConfigType("yaml")
+// 	viper.ReadConfig(bytes.NewBuffer(configData))
 
-	// create environment variables
-	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+// 	// create environment variables
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-	tempFile := viper.GetString("file_cache.path")
+// 	tempFile := viper.GetString("file_cache.path")
 
-	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
-		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
-		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
-	cliOut, err := mountCmd.Output()
-	fmt.Println(string(cliOut))
-	suite.Equal(0, len(cliOut))
-	suite.Equal(nil, err)
+// 	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
+// 		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
+// 		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
+// 	cliOut, err := mountCmd.Output()
+// 	fmt.Println(string(cliOut))
+// 	suite.Equal(0, len(cliOut))
+// 	suite.Equal(nil, err)
 
-	// wait for mount
-	time.Sleep(10 * time.Second)
+// 	// wait for mount
+// 	time.Sleep(10 * time.Second)
 
-	// list blobfuse mounted directories
-	cliOut = listBlobfuseMounts(suite)
-	suite.NotEqual(0, len(cliOut))
-	suite.Contains(string(cliOut), mntDir)
+// 	// list blobfuse mounted directories
+// 	cliOut = listBlobfuseMounts(suite)
+// 	suite.NotEqual(0, len(cliOut))
+// 	suite.Contains(string(cliOut), mntDir)
 
-	// unmount
-	blobfuseUnmount(suite, mntDir)
+// 	// unmount
+// 	blobfuseUnmount(suite, mntDir)
 
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-}
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+// }
 
-// mountv1 test using CSI driver cli options
-func (suite *mountSuite) TestEnvVarMountCSIParams() {
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	suite.Equal(nil, err)
+// // mountv1 test using CSI driver cli options
+// func (suite *mountSuite) TestEnvVarMountCSIParams() {
+// 	// read config file
+// 	configData, err := os.ReadFile(configFile)
+// 	suite.Equal(nil, err)
 
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
+// 	viper.SetConfigType("yaml")
+// 	viper.ReadConfig(bytes.NewBuffer(configData))
 
-	// create environment variables
-	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+// 	// create environment variables
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-	tempFile := viper.GetString("file_cache.path")
+// 	tempFile := viper.GetString("file_cache.path")
 
-	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
-		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
-		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
-		"--log-level=LOG_WARNING", "--cache-size-mb=1000", "--output-file=configV1.yaml")
-	cliOut, err := mountCmd.Output()
-	fmt.Println(string(cliOut))
-	suite.Equal(0, len(cliOut))
-	suite.Equal(nil, err)
+// 	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
+// 		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
+// 		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
+// 		"--log-level=LOG_WARNING", "--cache-size-mb=1000", "--output-file=configV1.yaml")
+// 	cliOut, err := mountCmd.Output()
+// 	fmt.Println(string(cliOut))
+// 	suite.Equal(0, len(cliOut))
+// 	suite.Equal(nil, err)
 
-	// wait for mount
-	time.Sleep(10 * time.Second)
+// 	// wait for mount
+// 	time.Sleep(10 * time.Second)
 
-	// list blobfuse mounted directories
-	cliOut = listBlobfuseMounts(suite)
-	suite.NotEqual(0, len(cliOut))
-	suite.Contains(string(cliOut), mntDir)
+// 	// list blobfuse mounted directories
+// 	cliOut = listBlobfuseMounts(suite)
+// 	suite.NotEqual(0, len(cliOut))
+// 	suite.Contains(string(cliOut), mntDir)
 
-	// unmount
-	blobfuseUnmount(suite, mntDir)
+// 	// unmount
+// 	blobfuseUnmount(suite, mntDir)
 
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-}
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+// }
 
 func TestMountSuite(t *testing.T) {
 	suite.Run(t, new(mountSuite))

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -85,7 +85,7 @@ func blobfuseUnmount(suite *mountSuite, unmountOutput string) {
 	suite.Contains(string(cliOut), unmountOutput)
 
 	// wait after unmount
-	time.Sleep(5 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	// validate unmount
 	cliOut = listBlobfuseMounts(suite)
@@ -102,7 +102,7 @@ func (suite *mountSuite) TestMountCmd() {
 	suite.Equal(nil, err)
 
 	// wait for mount
-	time.Sleep(10 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	// validate mount
 	cliOut = listBlobfuseMounts(suite)
@@ -219,6 +219,13 @@ func (suite *mountSuite) TestEnvVarMountFailure() {
 
 // mount test using environment variables for mounting
 func (suite *mountSuite) TestEnvVarMount() {
+	// read config file
+	configData, err := os.ReadFile(configFile)
+	suite.Equal(nil, err)
+
+	viper.SetConfigType("yaml")
+	viper.ReadConfig(bytes.NewBuffer(configData))
+
 	// create environment variables
 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
@@ -235,7 +242,7 @@ func (suite *mountSuite) TestEnvVarMount() {
 	suite.Equal(nil, err)
 
 	// wait for mount
-	time.Sleep(10 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	// list blobfuse mounted directories
 	cliOut = listBlobfuseMounts(suite)
@@ -253,79 +260,93 @@ func (suite *mountSuite) TestEnvVarMount() {
 }
 
 // mount test using environment variables for mounting with cli options
-func (suite *mountSuite) TestEnvVarMountCliParams() {
-	// create environment variables
-	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+// func (suite *mountSuite) TestEnvVarMountCliParams() {
+// 	// read config file
+// 	configData, err := os.ReadFile(configFile)
+// 	suite.Equal(nil, err)
 
-	tempFile := viper.GetString("file_cache.path")
+// 	viper.SetConfigType("yaml")
+// 	viper.ReadConfig(bytes.NewBuffer(configData))
 
-	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
-		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
-		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
-	cliOut, err := mountCmd.Output()
-	fmt.Println(string(cliOut))
-	suite.Equal(0, len(cliOut))
-	suite.Equal(nil, err)
+// 	// create environment variables
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-	// wait for mount
-	time.Sleep(10 * time.Second)
+// 	tempFile := viper.GetString("file_cache.path")
 
-	// list blobfuse mounted directories
-	cliOut = listBlobfuseMounts(suite)
-	suite.NotEqual(0, len(cliOut))
-	suite.Contains(string(cliOut), mntDir)
+// 	mountCmd := exec.Command(blobfuseBinary, "mount", mntDir, "--tmp-path="+tempFile, "--allow-other",
+// 		"--file-cache-timeout=120", "--cancel-list-on-mount-seconds=10", "--attr-timeout=120", "--entry-timeout=120",
+// 		"--negative-timeout=120", "--log-level=LOG_WARNING", "--cache-size-mb=1000")
+// 	cliOut, err := mountCmd.Output()
+// 	fmt.Println(string(cliOut))
+// 	suite.Equal(0, len(cliOut))
+// 	suite.Equal(nil, err)
 
-	// unmount
-	blobfuseUnmount(suite, mntDir)
+// 	// wait for mount
+// 	time.Sleep(4 * time.Second)
 
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-}
+// 	// list blobfuse mounted directories
+// 	cliOut = listBlobfuseMounts(suite)
+// 	suite.NotEqual(0, len(cliOut))
+// 	suite.Contains(string(cliOut), mntDir)
 
-// mountv1 test using CSI driver cli options
-func (suite *mountSuite) TestEnvVarMountCSIParams() {
-	// create environment variables
-	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
-	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
-	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
-	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
+// 	// unmount
+// 	blobfuseUnmount(suite, mntDir)
 
-	tempFile := viper.GetString("file_cache.path")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+// }
 
-	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
-		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
-		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
-		"--log-level=LOG_WARNING", "--cache-size-mb=1000")
-	cliOut, err := mountCmd.Output()
-	fmt.Println(string(cliOut))
-	suite.Equal(0, len(cliOut))
-	suite.Equal(nil, err)
+// // mountv1 test using CSI driver cli options
+// func (suite *mountSuite) TestEnvVarMountCSIParams() {
+// 	// read config file
+// 	configData, err := os.ReadFile(configFile)
+// 	suite.Equal(nil, err)
 
-	// wait for mount
-	time.Sleep(10 * time.Second)
+// 	viper.SetConfigType("yaml")
+// 	viper.ReadConfig(bytes.NewBuffer(configData))
 
-	// list blobfuse mounted directories
-	cliOut = listBlobfuseMounts(suite)
-	suite.NotEqual(0, len(cliOut))
-	suite.Contains(string(cliOut), mntDir)
+// 	// create environment variables
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT", viper.GetString("azstorage.account-name"))
+// 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", viper.GetString("azstorage.account-key"))
+// 	os.Setenv("AZURE_STORAGE_BLOB_ENDPOINT", viper.GetString("azstorage.endpoint"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_CONTAINER", viper.GetString("azstorage.container"))
+// 	os.Setenv("AZURE_STORAGE_ACCOUNT_TYPE", viper.GetString("azstorage.type"))
 
-	// unmount
-	blobfuseUnmount(suite, mntDir)
+// 	tempFile := viper.GetString("file_cache.path")
 
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
-	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
-	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
-	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
-}
+// 	mountCmd := exec.Command(blobfuseBinary, "mountv1", mntDir, "--tmp-path="+tempFile, "-o", "allow_other",
+// 		"--file-cache-timeout-in-seconds=120", "--use-attr-cache=true", "--cancel-list-on-mount-seconds=10",
+// 		"-o", "attr_timeout=120", "-o", "entry_timeout=120", "-o", "negative_timeout=120",
+// 		"--log-level=LOG_WARNING", "--cache-size-mb=1000")
+// 	cliOut, err := mountCmd.Output()
+// 	fmt.Println(string(cliOut))
+// 	suite.Equal(0, len(cliOut))
+// 	suite.Equal(nil, err)
+
+// 	// wait for mount
+// 	time.Sleep(4 * time.Second)
+
+// 	// list blobfuse mounted directories
+// 	cliOut = listBlobfuseMounts(suite)
+// 	suite.NotEqual(0, len(cliOut))
+// 	suite.Contains(string(cliOut), mntDir)
+
+// 	// unmount
+// 	blobfuseUnmount(suite, mntDir)
+
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCESS_KEY")
+// 	os.Unsetenv("AZURE_STORAGE_BLOB_ENDPOINT")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_CONTAINER")
+// 	os.Unsetenv("AZURE_STORAGE_ACCOUNT_TYPE")
+// }
 
 func TestMountSuite(t *testing.T) {
 	suite.Run(t, new(mountSuite))
@@ -347,15 +368,6 @@ func TestMain(m *testing.M) {
 		fmt.Println("Could not cleanup mount directory before testing")
 	}
 	os.Mkdir(mntDir, 0777)
-
-	// read config file
-	configData, err := os.ReadFile(configFile)
-	if err != nil {
-		fmt.Printf("Unable to read config file, %v : [%v]", configFile, err)
-	}
-
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(configData))
 
 	m.Run()
 


### PR DESCRIPTION
Resolving a bug where the mount fails when we use tilde (~) character in the paths for mounted directory, config file or file cache path.