### PR TITLE
Auto detect auth mode if user has not provided it as config

### DIFF
--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -343,11 +343,13 @@ func ParseAndValidateConfig(az *AzStorage, opt AzStorageOptions) error {
 		return err
 	}
 
-	var authType AuthType
 	if opt.AuthMode == "" {
-		opt.AuthMode = "key"
+		// Based on other config decide the auth mode
+		// for e.g. if sas token is set then mode shall be set to sas and if key is set then authmode shall be key
+		opt.AuthMode = autoDetectAuthMode(opt)
 	}
 
+	var authType AuthType
 	err = authType.Parse(opt.AuthMode)
 	if err != nil {
 		log.Err("ParseAndValidateConfig : Invalid auth type %s", opt.AccountType)

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -578,5 +578,6 @@ func autoDetectAuthMode(opt AzStorageOptions) string {
 	} else if opt.ClientID != "" || opt.ClientSecret != "" || opt.TenantID != "" {
 		return "spn"
 	}
-	return "key"
+
+	return "invalid_auth"
 }

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -567,3 +567,16 @@ func getMD5(fi *os.File) ([]byte, error) {
 
 	return hasher.Sum(nil), nil
 }
+
+func autoDetectAuthMode(opt AzStorageOptions) string {
+	if opt.ApplicationID != "" || opt.ResourceID != "" {
+		return "msi"
+	} else if opt.AccountKey != "" {
+		return "key"
+	} else if opt.SaSKey != "" {
+		return "sas"
+	} else if opt.ClientID != "" || opt.ClientSecret != "" || opt.TenantID != "" {
+		return "spn"
+	}
+	return "key"
+}

--- a/component/azstorage/utils_test.go
+++ b/component/azstorage/utils_test.go
@@ -266,38 +266,44 @@ func (s *utilsTestSuite) TestBfsProxyOptions() {
 func (s *utilsTestSuite) TestAutoDetectAuthMode() {
 	assert := assert.New(s.T())
 
-	atuhType := autoDetectAuthMode(AzStorageOptions{AccountKey: "abc"})
-	assert.Equal(atuhType, "key")
+	var authType string
+	authType = autoDetectAuthMode(AzStorageOptions{})
+	assert.Equal(authType, "invalid_auth")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{})
-	assert.Equal(atuhType, "key")
+	var authType_ AuthType
+	err := authType_.Parse(authType)
+	assert.Nil(err)
+	assert.Equal(authType_, EAuthType.INVALID_AUTH())
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{SaSKey: "abc"})
-	assert.Equal(atuhType, "sas")
+	authType = autoDetectAuthMode(AzStorageOptions{AccountKey: "abc"})
+	assert.Equal(authType, "key")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{ApplicationID: "abc"})
-	assert.Equal(atuhType, "msi")
+	authType = autoDetectAuthMode(AzStorageOptions{SaSKey: "abc"})
+	assert.Equal(authType, "sas")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{ResourceID: "abc"})
-	assert.Equal(atuhType, "msi")
+	authType = autoDetectAuthMode(AzStorageOptions{ApplicationID: "abc"})
+	assert.Equal(authType, "msi")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{ClientID: "abc"})
-	assert.Equal(atuhType, "spn")
+	authType = autoDetectAuthMode(AzStorageOptions{ResourceID: "abc"})
+	assert.Equal(authType, "msi")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{ClientSecret: "abc"})
-	assert.Equal(atuhType, "spn")
+	authType = autoDetectAuthMode(AzStorageOptions{ClientID: "abc"})
+	assert.Equal(authType, "spn")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{TenantID: "abc"})
-	assert.Equal(atuhType, "spn")
+	authType = autoDetectAuthMode(AzStorageOptions{ClientSecret: "abc"})
+	assert.Equal(authType, "spn")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{ApplicationID: "abc", AccountKey: "abc", SaSKey: "abc", ClientID: "abc"})
-	assert.Equal(atuhType, "msi")
+	authType = autoDetectAuthMode(AzStorageOptions{TenantID: "abc"})
+	assert.Equal(authType, "spn")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{AccountKey: "abc", SaSKey: "abc", ClientID: "abc"})
-	assert.Equal(atuhType, "key")
+	authType = autoDetectAuthMode(AzStorageOptions{ApplicationID: "abc", AccountKey: "abc", SaSKey: "abc", ClientID: "abc"})
+	assert.Equal(authType, "msi")
 
-	atuhType = autoDetectAuthMode(AzStorageOptions{SaSKey: "abc", ClientID: "abc"})
-	assert.Equal(atuhType, "sas")
+	authType = autoDetectAuthMode(AzStorageOptions{AccountKey: "abc", SaSKey: "abc", ClientID: "abc"})
+	assert.Equal(authType, "key")
+
+	authType = autoDetectAuthMode(AzStorageOptions{SaSKey: "abc", ClientID: "abc"})
+	assert.Equal(authType, "sas")
 }
 
 func TestUtilsTestSuite(t *testing.T) {

--- a/component/azstorage/utils_test.go
+++ b/component/azstorage/utils_test.go
@@ -262,6 +262,44 @@ func (s *utilsTestSuite) TestBfsProxyOptions() {
 	assert.EqualValues(ro.MaxTries, 3)
 	assert.NotEqual(po.RequestLog.SyslogDisabled, true)
 }
+
+func (s *utilsTestSuite) TestAutoDetectAuthMode() {
+	assert := assert.New(s.T())
+
+	atuhType := autoDetectAuthMode(AzStorageOptions{AccountKey: "abc"})
+	assert.Equal(atuhType, "key")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{})
+	assert.Equal(atuhType, "key")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{SaSKey: "abc"})
+	assert.Equal(atuhType, "sas")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{ApplicationID: "abc"})
+	assert.Equal(atuhType, "msi")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{ResourceID: "abc"})
+	assert.Equal(atuhType, "msi")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{ClientID: "abc"})
+	assert.Equal(atuhType, "spn")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{ClientSecret: "abc"})
+	assert.Equal(atuhType, "spn")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{TenantID: "abc"})
+	assert.Equal(atuhType, "spn")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{ApplicationID: "abc", AccountKey: "abc", SaSKey: "abc", ClientID: "abc"})
+	assert.Equal(atuhType, "msi")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{AccountKey: "abc", SaSKey: "abc", ClientID: "abc"})
+	assert.Equal(atuhType, "key")
+
+	atuhType = autoDetectAuthMode(AzStorageOptions{SaSKey: "abc", ClientID: "abc"})
+	assert.Equal(atuhType, "sas")
+}
+
 func TestUtilsTestSuite(t *testing.T) {
 	suite.Run(t, new(utilsTestSuite))
 }


### PR DESCRIPTION
- auto detect auth mode if user has not given any mode on cli or config file
- based on other parameters detect the mode for e.g., if sas key is set then assume auth mode is sas.