### PR TITLE
Added stream data validation test cases

### DIFF
--- a/azure-pipeline-templates/distro-tests.yml
+++ b/azure-pipeline-templates/distro-tests.yml
@@ -180,7 +180,7 @@ steps:
         adls: false
         idstring: 'Distro BlockBlob with Stream Key Credentials'
         distro_name: ${{ parameters.distro_name }}
-        quick_test: true
+        quick_test: ${{ parameters.quick_test }}
         artifact_name: '${{ parameters.distro_name }}_block_stream_key.txt'
         verbose_log: ${{ parameters.verbose_log }}
         clone: false
@@ -232,7 +232,7 @@ steps:
         adls: false
         idstring: 'Distro BlockBlob with Stream with Filename Caching Key Credentials'
         distro_name: ${{ parameters.distro_name }}
-        quick_test: true
+        quick_test: ${{ parameters.quick_test }}
         artifact_name: '${{ parameters.distro_name }}_block_stream_key.txt'
         verbose_log: ${{ parameters.verbose_log }}
         clone: false

--- a/azure-pipeline-templates/distro-tests.yml
+++ b/azure-pipeline-templates/distro-tests.yml
@@ -231,6 +231,7 @@ steps:
         artifact_name: '${{ parameters.distro_name }}_block_stream_direct_key.txt'
         verbose_log: ${{ parameters.verbose_log }}
         clone: false
+        stream_direct_test: true
         mountStep:
           script: |
             ${{ parameters.working_dir }}/blobfuse2 mount ${{ parameters.mount_dir }} --config-file=${{ parameters.stream_config }}
@@ -325,6 +326,7 @@ steps:
         artifact_name: '${{ parameters.distro_name }}_block_stream_filename_direct_key.txt'
         verbose_log: ${{ parameters.verbose_log }}
         clone: false
+        stream_direct_test: true
         mountStep:
           script: |
             ${{ parameters.working_dir }}/blobfuse2 mount ${{ parameters.mount_dir }} --config-file=${{ parameters.stream_filename_config }}

--- a/azure-pipeline-templates/distro-tests.yml
+++ b/azure-pipeline-templates/distro-tests.yml
@@ -145,7 +145,7 @@ steps:
       mount_dir: ${{ parameters.mount_dir }}
       temp_dir: ${{ parameters.temp_dir }}
 
-# STREAMING
+# STREAMING with filehandle
   - ${{ if eq(parameters.test_stream, true) }}:
     - script: |
         cd ${{ parameters.working_dir }}
@@ -197,6 +197,53 @@ steps:
         mount_dir: ${{ parameters.mount_dir }}
         temp_dir: ${{ parameters.temp_dir }}
 
+# STREAMING with filehandle direct
+  - ${{ if eq(parameters.test_stream, true) }}:
+    - script: |
+        cd ${{ parameters.working_dir }}
+        ${{ parameters.working_dir }}/blobfuse2 gen-test-config --config-file=azure_stream_direct.yaml --container-name=${{ parameters.container }} --temp-path=${{ parameters.temp_dir }} --output-file=${{ parameters.stream_config }}
+      displayName: 'Create Stream Direct Config File'
+      env:
+        NIGHTLY_STO_ACC_NAME: ${{ parameters.blob_account_name }}
+        NIGHTLY_STO_ACC_KEY: ${{ parameters.blob_account_key }}
+        ACCOUNT_TYPE: 'block'
+        ACCOUNT_ENDPOINT: 'https://${{ parameters.blob_account_name }}.blob.core.windows.net'
+        VERBOSE_LOG: ${{ parameters.verbose_log }}
+        USE_HTTP: false
+      continueOnError: false
+
+    # Print config file
+    - script: |
+        cat ${{ parameters.stream_config }}
+      displayName: 'Print Stream Direct config file'
+
+    # Basic End to End test to check sanity on this distro
+    # Start End to End test on this distro
+    - template: 'e2e-tests.yml'
+      parameters:
+        working_dir: ${{ parameters.working_dir }}
+        mount_dir: ${{ parameters.mount_dir }}
+        temp_dir: ${{ parameters.temp_dir }}
+        adls: false
+        idstring: 'Distro BlockBlob with Stream Direct Key Credentials'
+        distro_name: ${{ parameters.distro_name }}
+        quick_test: ${{ parameters.quick_test }}
+        artifact_name: '${{ parameters.distro_name }}_block_stream_direct_key.txt'
+        verbose_log: ${{ parameters.verbose_log }}
+        clone: false
+        mountStep:
+          script: |
+            ${{ parameters.working_dir }}/blobfuse2 mount ${{ parameters.mount_dir }} --config-file=${{ parameters.stream_config }}
+          displayName: 'E2E TEST: Mount container'
+          timeoutInMinutes: 3
+          continueOnError: false
+
+    - template: 'cleanup.yml'
+      parameters:
+        working_dir: ${{ parameters.working_dir }}
+        mount_dir: ${{ parameters.mount_dir }}
+        temp_dir: ${{ parameters.temp_dir }}
+
 # STREAMING with filename
   - ${{ if eq(parameters.test_stream, true) }}:
     - script: |
@@ -217,11 +264,6 @@ steps:
         cat ${{ parameters.stream_filename_config }}
       displayName: 'Print Stream with Filename caching config file'
 
-    # Cli option test
-    - script: |
-        ${{ parameters.working_dir }}/blobfuse2 --help
-      displayName: 'CLI help string check'
-
     # Basic End to End test to check sanity on this distro
     # Start End to End test on this distro
     - template: 'e2e-tests.yml'
@@ -233,7 +275,7 @@ steps:
         idstring: 'Distro BlockBlob with Stream with Filename Caching Key Credentials'
         distro_name: ${{ parameters.distro_name }}
         quick_test: ${{ parameters.quick_test }}
-        artifact_name: '${{ parameters.distro_name }}_block_stream_key.txt'
+        artifact_name: '${{ parameters.distro_name }}_block_stream_filename_key.txt'
         verbose_log: ${{ parameters.verbose_log }}
         clone: false
         mountStep:
@@ -249,6 +291,54 @@ steps:
         mount_dir: ${{ parameters.mount_dir }}
         temp_dir: ${{ parameters.temp_dir }}
 
+# STREAMING with filename direct
+  - ${{ if eq(parameters.test_stream, true) }}:
+    - script: |
+        cd ${{ parameters.working_dir }}
+        ${{ parameters.working_dir }}/blobfuse2 gen-test-config --config-file=azure_stream_filename_direct.yaml --container-name=${{ parameters.container }} --temp-path=${{ parameters.temp_dir }} --output-file=${{ parameters.stream_filename_config }}
+      displayName: 'Create Stream with Filename caching Direct Config File'
+      env:
+        NIGHTLY_STO_ACC_NAME: ${{ parameters.blob_account_name }}
+        NIGHTLY_STO_ACC_KEY: ${{ parameters.blob_account_key }}
+        ACCOUNT_TYPE: 'block'
+        ACCOUNT_ENDPOINT: 'https://${{ parameters.blob_account_name }}.blob.core.windows.net'
+        VERBOSE_LOG: ${{ parameters.verbose_log }}
+        USE_HTTP: false
+      continueOnError: false
+
+    # Print config file
+    - script: |
+        cat ${{ parameters.stream_filename_config }}
+      displayName: 'Print Stream with Filename caching Direct config file'
+
+    # Basic End to End test to check sanity on this distro
+    # Start End to End test on this distro
+    - template: 'e2e-tests.yml'
+      parameters:
+        working_dir: ${{ parameters.working_dir }}
+        mount_dir: ${{ parameters.mount_dir }}
+        temp_dir: ${{ parameters.temp_dir }}
+        adls: false
+        idstring: 'Distro BlockBlob with Stream with Filename Caching Direct Key Credentials'
+        distro_name: ${{ parameters.distro_name }}
+        quick_test: ${{ parameters.quick_test }}
+        artifact_name: '${{ parameters.distro_name }}_block_stream_filename_direct_key.txt'
+        verbose_log: ${{ parameters.verbose_log }}
+        clone: false
+        mountStep:
+          script: |
+            ${{ parameters.working_dir }}/blobfuse2 mount ${{ parameters.mount_dir }} --config-file=${{ parameters.stream_filename_config }}
+          displayName: 'E2E TEST: Mount container'
+          timeoutInMinutes: 3
+          continueOnError: false
+
+    - template: 'cleanup.yml'
+      parameters:
+        working_dir: ${{ parameters.working_dir }}
+        mount_dir: ${{ parameters.mount_dir }}
+        temp_dir: ${{ parameters.temp_dir }}
+
+# ADLS Test
   - script: |
       cd ${{ parameters.working_dir }}
       ${{ parameters.working_dir }}/blobfuse2 gen-test-config --config-file=azure_key.yaml --container-name=${{ parameters.container }} --temp-path=${{ parameters.temp_dir }} --output-file=${{ parameters.config_path }}

--- a/azure-pipeline-templates/e2e-tests.yml
+++ b/azure-pipeline-templates/e2e-tests.yml
@@ -19,6 +19,9 @@ parameters:
   - name: quick_test
     type: boolean
     default: true
+  - name: stream_direct_test
+    type: boolean
+    default: false
   - name: artifact_name
     type: string
   - name: verbose_log
@@ -48,7 +51,7 @@ steps:
   - task: Go@0
     inputs:
       command: 'test'
-      arguments: '-v -timeout=2h ./... -args -mnt-path=${{ parameters.mount_dir }} -adls=${{parameters.adls}} -clone=${{parameters.clone}} -tmp-path=${{parameters.temp_dir}} -quick-test=${{parameters.quick_test}} -distro-name="${{parameters.distro_name}}"'
+      arguments: '-v -timeout=2h ./... -args -mnt-path=${{ parameters.mount_dir }} -adls=${{parameters.adls}} -clone=${{parameters.clone}} -tmp-path=${{parameters.temp_dir}} -quick-test=${{parameters.quick_test}} -stream-direct-test=${{parameters.stream_direct_test}} -distro-name="${{parameters.distro_name}}"'
       workingDirectory: ${{ parameters.working_dir }}/test/e2e_tests
     displayName: 'E2E Test: ${{ parameters.idstring }}'
     timeoutInMinutes: 120

--- a/blobfuse2-nightly.yaml
+++ b/blobfuse2-nightly.yaml
@@ -1198,7 +1198,7 @@ stages:
                 blob_account_key: $(NIGHTLY_STO_BLOB_ACC_KEY)
                 adls_account_name: $(AZTEST_ADLS_ACC_NAME)
                 adls_account_key: $(AZTEST_ADLS_KEY)
-                distro_name: $(AgentName)
+                distro_name: $(imageName)
                 test_stream: true
                 quick_test: false
                 clone: true

--- a/test/e2e_tests/data_validation_test.go
+++ b/test/e2e_tests/data_validation_test.go
@@ -176,7 +176,7 @@ func (suite *dataValidationTestSuite) TestMediumFileData() {
 
 // data validation for large sized files
 func (suite *dataValidationTestSuite) TestLargeFileData() {
-	if strings.ToLower(streamDirectPtr) == "true" {
+	if strings.ToLower(streamDirectTest) == "true" {
 		fmt.Println("Skipping this test case for stream direct")
 		return
 	}
@@ -335,7 +335,7 @@ func (suite *dataValidationTestSuite) TestMultipleLargeFiles() {
 }
 
 func (suite *dataValidationTestSuite) TestMultipleHugeFiles() {
-	if strings.ToLower(streamDirectPtr) == "true" {
+	if strings.ToLower(streamDirectTest) == "true" {
 		fmt.Println("Skipping this test case for stream direct")
 		return
 	}

--- a/test/e2e_tests/data_validation_test.go
+++ b/test/e2e_tests/data_validation_test.go
@@ -55,6 +55,7 @@ var dataValidationMntPathPtr string
 var dataValidationTempPathPtr string
 var dataValidationAdlsPtr string
 var quickTest string
+var streamDirectTest string
 var distro string
 
 var minBuff, medBuff, largeBuff, hugeBuff []byte
@@ -82,6 +83,7 @@ func initDataValidationFlags() {
 	dataValidationAdlsPtr = getDataValidationTestFlag("adls")
 	dataValidationTempPathPtr = getDataValidationTestFlag("tmp-path")
 	quickTest = getDataValidationTestFlag("quick-test")
+	streamDirectTest = getDataValidationTestFlag("stream-direct-test")
 	distro = getDataValidationTestFlag("distro-name")
 }
 
@@ -174,6 +176,10 @@ func (suite *dataValidationTestSuite) TestMediumFileData() {
 
 // data validation for large sized files
 func (suite *dataValidationTestSuite) TestLargeFileData() {
+	if strings.ToLower(streamDirectPtr) == "true" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	fileName := "large_data.txt"
 	localFilePath := suite.testLocalPath + "/" + fileName
 	remoteFilePath := suite.testMntPath + "/" + fileName
@@ -314,6 +320,10 @@ func (suite *dataValidationTestSuite) TestMultipleMediumFiles() {
 }
 
 func (suite *dataValidationTestSuite) TestMultipleLargeFiles() {
+	if strings.ToLower(streamDirectTest) == "true" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	if strings.Contains(strings.ToUpper(distro), "RHEL") {
 		fmt.Println("Skipping this test case for RHEL")
 		return
@@ -325,6 +335,10 @@ func (suite *dataValidationTestSuite) TestMultipleLargeFiles() {
 }
 
 func (suite *dataValidationTestSuite) TestMultipleHugeFiles() {
+	if strings.ToLower(streamDirectPtr) == "true" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	if strings.ToLower(quickTest) == "true" {
 		fmt.Println("Quick test is enabled. Skipping this test case")
 		return
@@ -408,5 +422,6 @@ func init() {
 	regDataValidationTestFlag(&dataValidationAdlsPtr, "adls", "", "Account is ADLS or not")
 	regDataValidationTestFlag(&dataValidationTempPathPtr, "tmp-path", "", "Cache dir path")
 	regDataValidationTestFlag(&quickTest, "quick-test", "true", "Run quick tests")
+	regDataValidationTestFlag(&streamDirectTest, "stream-direct-test", "false", "Run stream direct tests")
 	regDataValidationTestFlag(&distro, "distro-name", "", "Name of the distro")
 }

--- a/test/e2e_tests/data_validation_test.go
+++ b/test/e2e_tests/data_validation_test.go
@@ -151,6 +151,10 @@ func (suite *dataValidationTestSuite) TestSmallFileData() {
 
 // data validation for medium sized files
 func (suite *dataValidationTestSuite) TestMediumFileData() {
+	if strings.ToLower(fileTestDistroName) == "ubuntu-20.04" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	fileName := "medium_data.txt"
 	localFilePath := suite.testLocalPath + "/" + fileName
 	remoteFilePath := suite.testMntPath + "/" + fileName

--- a/test/e2e_tests/data_validation_test.go
+++ b/test/e2e_tests/data_validation_test.go
@@ -309,6 +309,10 @@ func (suite *dataValidationTestSuite) TestMultipleSmallFiles() {
 }
 
 func (suite *dataValidationTestSuite) TestMultipleMediumFiles() {
+	if strings.ToLower(streamDirectTest) == "true" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	if strings.Contains(strings.ToUpper(distro), "RHEL") {
 		fmt.Println("Skipping this test case for RHEL")
 		return

--- a/test/e2e_tests/dir_test.go
+++ b/test/e2e_tests/dir_test.go
@@ -44,6 +44,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,6 +63,7 @@ type dirTestSuite struct {
 var pathPtr string
 var adlsPtr string
 var clonePtr string
+var streamDirectPtr string
 
 func regDirTestFlag(p *string, name string, value string, usage string) {
 	if flag.Lookup(name) == nil {
@@ -77,6 +79,7 @@ func initDirFlags() {
 	pathPtr = getDirTestFlag("mnt-path")
 	adlsPtr = getDirTestFlag("adls")
 	clonePtr = getDirTestFlag("clone")
+	streamDirectPtr = getDirTestFlag("stream-direct-test")
 }
 
 func getTestDirName(n int) string {
@@ -355,6 +358,10 @@ func (suite *dirTestSuite) TestDirList() {
 
 // // # Rename directory with data
 func (suite *dirTestSuite) TestDirRenameFull() {
+	if strings.ToLower(streamDirectPtr) == "true" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	dirName := suite.testPath + "/full_dir"
 	newName := suite.testPath + "/full_dir_rename"
 	fileName := dirName + "/test_file_"
@@ -414,6 +421,10 @@ func (suite *dirTestSuite) TestDirRenameFull() {
 // }
 
 func (suite *dirTestSuite) TestGitStash() {
+	if strings.ToLower(streamDirectPtr) == "true" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	if clonePtr == "true" || clonePtr == "True" {
 		dirName := suite.testPath + "/stash"
 		tarName := suite.testPath + "/tardir.tar.gz"

--- a/test/e2e_tests/file_test.go
+++ b/test/e2e_tests/file_test.go
@@ -43,6 +43,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +53,8 @@ import (
 var fileTestPathPtr string
 var fileTestAdlsPtr string
 var fileTestGitClonePtr string
+var fileTestStreamDirectPtr string
+var fileTestDistroName string
 
 type fileTestSuite struct {
 	suite.Suite
@@ -76,6 +79,8 @@ func initFileFlags() {
 	fileTestPathPtr = getFileTestFlag("mnt-path")
 	fileTestAdlsPtr = getFileTestFlag("adls")
 	fileTestGitClonePtr = getFileTestFlag("clone")
+	fileTestStreamDirectPtr = getFileTestFlag("stream-direct-test")
+	fileTestDistroName = getFileTestFlag("distro-name")
 }
 
 func getFileTestDirName(n int) string {
@@ -372,6 +377,10 @@ func (suite *fileTestSuite) TestFileChmod() {
 
 // # Create multiple med files
 func (suite *fileTestSuite) TestFileCreateMulti() {
+	if strings.ToLower(fileTestStreamDirectPtr) == "true" && strings.ToLower(fileTestDistroName) == "ubuntu-20.04" {
+		fmt.Println("Skipping this test case for stream direct")
+		return
+	}
 	dirName := suite.testPath + "/multi_dir"
 	err := os.Mkdir(dirName, 0777)
 	suite.Equal(nil, err)

--- a/testdata/config/azure_stream_direct.yaml
+++ b/testdata/config/azure_stream_direct.yaml
@@ -1,0 +1,33 @@
+logging:
+  level: log_debug
+  file-path: "blobfuse2-logs.txt"
+  type: base
+
+components:
+  - libfuse
+  - stream
+  - attr_cache
+  - azstorage
+
+libfuse:
+  attribute-expiration-sec: 0
+  entry-expiration-sec: 0
+  negative-entry-expiration-sec: 0
+  ignore-open-flags: true
+
+stream:
+  buffer-size-mb: 0
+
+attr_cache:
+  timeout-sec: 3600
+
+azstorage:
+  type: { ACCOUNT_TYPE }
+  endpoint: { ACCOUNT_ENDPOINT }
+  use-http: false
+  account-name: { NIGHTLY_STO_ACC_NAME }
+  account-key: { NIGHTLY_STO_ACC_KEY }
+  mode: key
+  container: { 0 }
+  tier: hot
+  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_stream_filename_direct.yaml
+++ b/testdata/config/azure_stream_filename_direct.yaml
@@ -1,0 +1,34 @@
+logging:
+  level: log_debug
+  file-path: "blobfuse2-logs.txt"
+  type: base
+
+components:
+  - libfuse
+  - stream
+  - attr_cache
+  - azstorage
+
+libfuse:
+  attribute-expiration-sec: 0
+  entry-expiration-sec: 0
+  negative-entry-expiration-sec: 0
+  ignore-open-flags: true
+
+stream:
+  buffer-size-mb: 0
+  file-caching: true
+
+attr_cache:
+  timeout-sec: 3600
+
+azstorage:
+  type: { ACCOUNT_TYPE }
+  endpoint: { ACCOUNT_ENDPOINT }
+  use-http: false
+  account-name: { NIGHTLY_STO_ACC_NAME }
+  account-key: { NIGHTLY_STO_ACC_KEY }
+  mode: key
+  container: { 0 }
+  tier: hot
+  sdk-trace: { VERBOSE_LOG }


### PR DESCRIPTION
1. stream with file handle
2. stream with file name
3. stream with file handle direct
4. stream with file name direct
We need 2 parameters quick test and stream direct since quick enables and disables data validation and stream direct just disables certain large tests that take too much time

Successful run https://dev.azure.com/azstorage/BlobFuse/_build/results?buildId=14710&view=logs&jobId=b5bd9172-90ea-50d8-60e0-1bcee2c00945