### PR TITLE
Fix line to disable medium file for stream direct

### DIFF
--- a/test/e2e_tests/data_validation_test.go
+++ b/test/e2e_tests/data_validation_test.go
@@ -151,7 +151,7 @@ func (suite *dataValidationTestSuite) TestSmallFileData() {
 
 // data validation for medium sized files
 func (suite *dataValidationTestSuite) TestMediumFileData() {
-	if strings.ToLower(fileTestDistroName) == "ubuntu-20.04" {
+	if strings.ToLower(streamDirectTest) == "true" {
 		fmt.Println("Skipping this test case for stream direct")
 		return
 	}


### PR DESCRIPTION
Test case takes too long, so we will rely on small files for data validation for stream direct case. 