### PR TITLE
[fixed] unexpected maximum might incur security issues.

### DIFF
--- a/blobfuse/src/BlobStreamer.cpp
+++ b/blobfuse/src/BlobStreamer.cpp
@@ -102,13 +102,14 @@ BlobBlock* BlobStreamer::GetBlock(const char* file_name, uint64_t offset, Stream
             obj->GetSize() > 0) 
         {
             if ((start_offset + download_size) > obj->GetSize()) {
+                download_size = obj->GetSize() - start_offset;
+                
                 if (download_size == 0 || obj->GetSize() <= start_offset) {
                     obj->UnLock();
                     syslog(LOG_ERR, "Failed to download block of %s with offset %lu.  Errno : (Out of range).\n", file_name, start_offset);
                     errno = 416;
                     return NULL;
                 }
-                download_size = obj->GetSize() - start_offset;
             }
         }
 

--- a/blobfuse/src/BlobStreamer.cpp
+++ b/blobfuse/src/BlobStreamer.cpp
@@ -101,8 +101,8 @@ BlobBlock* BlobStreamer::GetBlock(const char* file_name, uint64_t offset, Stream
         if (download_size > MAX_BLOCK_SIZE_FOR_SINGLE_READ && 
             obj->GetSize() > 0) 
         {
-            if ((start_offset + download_size) > obj->GetSize()) {                
-                if (obj->GetSize() <= start_offset) {
+            if ((start_offset + download_size) > obj->GetSize()) {
+                if (download_size == 0 || obj->GetSize() <= start_offset) {
                     obj->UnLock();
                     syslog(LOG_ERR, "Failed to download block of %s with offset %lu.  Errno : (Out of range).\n", file_name, start_offset);
                     errno = 416;

--- a/blobfuse/src/BlobStreamer.cpp
+++ b/blobfuse/src/BlobStreamer.cpp
@@ -101,14 +101,14 @@ BlobBlock* BlobStreamer::GetBlock(const char* file_name, uint64_t offset, Stream
         if (download_size > MAX_BLOCK_SIZE_FOR_SINGLE_READ && 
             obj->GetSize() > 0) 
         {
-            if ((start_offset + download_size) > obj->GetSize()) {
-                download_size = obj->GetSize() - start_offset;
-                if (download_size == 0) {
+            if ((start_offset + download_size) > obj->GetSize()) {                
+                if (obj->GetSize() <= start_offset) {
                     obj->UnLock();
                     syslog(LOG_ERR, "Failed to download block of %s with offset %lu.  Errno : (Out of range).\n", file_name, start_offset);
                     errno = 416;
                     return NULL;
                 }
+                download_size = obj->GetSize() - start_offset;
             }
         }
 


### PR DESCRIPTION
Hi Blobfuse team,
Found a case that might be missed: 
when calling `BlobStreamer::GetBlock` if `start_offset `> `obj->GetSize()`, `download_size `will get a maximum of `download_size`'s type.

Like when `block_size` equals 512 * 1024 * 1024, `offset` equals 512 * 1024 * 1024 + 100, `obj->GetSize()` equals 10. 
`start_offset ` will get 512 * 1024 * 1024 - 100 and it gonna execute` download_size = obj->GetSize() - start_offset;` .`obj->GetSize() - start_offset` logically would get negative. 
But, if we assign the negative value to `download_size `of type uint64_t, `download_size ` will be converted to UINT64_MAX. 

I think this should be an unexpected behavior. The risk of memory leak might incur security issues.

I hope it helps thx,
jack
