### PR TITLE
Set ignore-open-flags to true by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2.0.2 (WIP)
+**Breaking Changes**
+- Default value of `ignore-open-flags` config parameter changed to `true`
+
 **Bug Fixes**
 - [#999](https://github.com/Azure/azure-storage-fuse/issues/999) Upgrade dependencies to resolve known CVEs.
 - [#1002](https://github.com/Azure/azure-storage-fuse/issues/1002) In case version check fails to connect to public container, dump a log to check network and proxy settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 ## 2.0.2 (WIP)
-**Breaking Changes**
-- Default value of `ignore-open-flags` config parameter changed to `true`
-
 **Bug Fixes**
 - [#999](https://github.com/Azure/azure-storage-fuse/issues/999) Upgrade dependencies to resolve known CVEs.
 - [#1002](https://github.com/Azure/azure-storage-fuse/issues/1002) In case version check fails to connect to public container, dump a log to check network and proxy settings.
 - [#1006](https://github.com/Azure/azure-storage-fuse/issues/1006) Remove user and group config from logrotate file.
 - [csi-driver #809](https://github.com/kubernetes-sigs/blob-csi-driver/issues/809) Fail to mount when uid/gid are provided on command line.
+- [#1015](https://github.com/Azure/azure-storage-fuse/issues/1015) Default value of `ignore-open-flags` config parameter changed to `true`
 
 ## 2.0.1 (2022-12-02)
 - Copy of GA release of Blobfuse2. This release was necessary to ensure the GA version resolves ahead of the preview versions.

--- a/azure-pipeline-templates/mount-test.yml
+++ b/azure-pipeline-templates/mount-test.yml
@@ -10,6 +10,8 @@ parameters:
   - name: idstring
     type: string
     default: ''
+  - name: tags
+    type: string
 
 steps:
 
@@ -24,7 +26,7 @@ steps:
   - task: Go@0
     inputs:
       command: 'test'
-      arguments: '-timeout=120m -p 1 -v test/mount_test/mount_test.go -args -working-dir=${{ parameters.working_dir }} -mnt-path=${{ parameters.mount_dir }} -config-file=${{parameters.config}}'
+      arguments: '-timeout=120m -p 1 -v test/mount_test/mount_test.go -args -working-dir=${{ parameters.working_dir }} -mnt-path=${{ parameters.mount_dir }} -config-file=${{parameters.config}} -tags=${{ parameters.tags }}'
       workingDirectory: ${{ parameters.working_dir }}
     displayName: 'MountTest: ${{ parameters.idstring }}'
     timeoutInMinutes: 120

--- a/azure-pipeline-templates/verbose-tests.yml
+++ b/azure-pipeline-templates/verbose-tests.yml
@@ -68,6 +68,8 @@ parameters:
     default: "true"
   - name: verbose_log
     type: boolean
+  - name: tags
+    type: string
 
 #--------------------------------------- Setup: End to end tests with different Storage configurations ------------------------------------------
 # Create key credential config file if we need to test it
@@ -382,6 +384,7 @@ steps:
       temp_dir: ${{ parameters.temp_dir }}
       config: ${{ parameters.config }}
       idstring: ${{ parameters.service }} Mount Test
+      tags: $(tags)
 
   - template: stress-test.yml
     parameters:

--- a/blobfuse2-nightly.yaml
+++ b/blobfuse2-nightly.yaml
@@ -190,6 +190,7 @@ stages:
                   azurite_config: $(BLOBFUSE2_AZURITE_CFG)
                   distro_name: $(imageName)
                   verbose_log: ${{ parameters.verbose_log }}
+                  tags: $(tags)
 
             - template: azure-pipeline-templates/cleanup.yml
               parameters:
@@ -321,6 +322,7 @@ stages:
                   azurite_config: $(BLOBFUSE2_AZURITE_CFG)
                   distro_name: $(imageName)
                   verbose_log: ${{ parameters.verbose_log }}
+                  tags: $(tags)
 
             - template: azure-pipeline-templates/cleanup.yml
               parameters:

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -220,7 +220,7 @@ func (lf *Libfuse) Configure(_ bool) error {
 	log.Trace("Libfuse::Configure : %s", lf.Name())
 
 	// >> If you do not need any config parameters remove below code and return nil
-	conf := LibfuseOptions{}
+	conf := LibfuseOptions{IgnoreOpenFlags: true}
 	err := config.UnmarshalKey(lf.Name(), &conf)
 	if err != nil {
 		log.Err("Libfuse::Configure : config error [invalid config attributes]")
@@ -300,6 +300,6 @@ func init() {
 	config.BindPFlag(compName+".fuse-trace", debug)
 	debug.Hidden = true
 
-	ignoreOpenFlags := config.AddBoolFlag("ignore-open-flags", false, "Ignore unsupported open flags (APPEND, WRONLY) by blobfuse when writeback caching is enabled.")
+	ignoreOpenFlags := config.AddBoolFlag("ignore-open-flags", true, "Ignore unsupported open flags (APPEND, WRONLY) by blobfuse when writeback caching is enabled.")
 	config.BindPFlag(compName+".ignore-open-flags", ignoreOpenFlags)
 }

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -56,7 +56,7 @@ func (suite *libfuseTestSuite) TestDefault() {
 	suite.assert.Equal(suite.libfuse.attributeExpiration, uint32(120))
 	suite.assert.Equal(suite.libfuse.negativeTimeout, uint32(120))
 	suite.assert.False(suite.libfuse.disableWritebackCache)
-	suite.assert.False(suite.libfuse.ignoreOpenFlags)
+	suite.assert.True(suite.libfuse.ignoreOpenFlags)
 }
 
 func (suite *libfuseTestSuite) TestConfig() {
@@ -132,17 +132,17 @@ func (suite *libfuseTestSuite) TestDisableWritebackCache() {
 
 func (suite *libfuseTestSuite) TestIgnoreAppendFlag() {
 	defer suite.cleanupTest()
-	suite.assert.False(suite.libfuse.ignoreOpenFlags)
-
-	suite.cleanupTest() // clean up the default libfuse generated
-	config := "libfuse:\n  ignore-open-flags: true\n"
-	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
 	suite.assert.True(suite.libfuse.ignoreOpenFlags)
 
 	suite.cleanupTest() // clean up the default libfuse generated
-	config = "libfuse:\n  ignore-open-flags: false\n"
+	config := "libfuse:\n  ignore-open-flags: false\n"
 	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
 	suite.assert.False(suite.libfuse.ignoreOpenFlags)
+
+	suite.cleanupTest() // clean up the default libfuse generated
+	config = "libfuse:\n  ignore-open-flags: true\n"
+	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
+	suite.assert.True(suite.libfuse.ignoreOpenFlags)
 }
 
 // getattr

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -62,7 +62,7 @@ func (suite *libfuseTestSuite) TestDefault() {
 func (suite *libfuseTestSuite) TestConfig() {
 	defer suite.cleanupTest()
 	suite.cleanupTest() // clean up the default libfuse generated
-	config := "allow-other: true\nread-only: true\nlibfuse:\n  attribute-expiration-sec: 60\n  entry-expiration-sec: 60\n  negative-entry-expiration-sec: 60\n  fuse-trace: true\n  disable-writeback-cache: true\n  ignore-open-flags: true\n"
+	config := "allow-other: true\nread-only: true\nlibfuse:\n  attribute-expiration-sec: 60\n  entry-expiration-sec: 60\n  negative-entry-expiration-sec: 60\n  fuse-trace: true\n  disable-writeback-cache: true\n  ignore-open-flags: false\n"
 	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
 
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
@@ -70,7 +70,7 @@ func (suite *libfuseTestSuite) TestConfig() {
 	suite.assert.True(suite.libfuse.readOnly)
 	suite.assert.True(suite.libfuse.traceEnable)
 	suite.assert.True(suite.libfuse.disableWritebackCache)
-	suite.assert.True(suite.libfuse.ignoreOpenFlags)
+	suite.assert.False(suite.libfuse.ignoreOpenFlags)
 	suite.assert.True(suite.libfuse.allowOther)
 	suite.assert.Equal(suite.libfuse.dirPermission, uint(fs.FileMode(0777)))
 	suite.assert.Equal(suite.libfuse.filePermission, uint(fs.FileMode(0777)))

--- a/component/libfuse/libfuse_handler_test_wrapper.go
+++ b/component/libfuse/libfuse_handler_test_wrapper.go
@@ -236,9 +236,11 @@ func testOpenSyncDirectFlag(suite *libfuseTestSuite) {
 	suite.assert.Equal(C.int(0), info.flags&C.__O_DIRECT)
 }
 
-// WriteBack caching enabled by default
+// WriteBack caching and ignore-open-flags enabled by default
 func testOpenAppendFlagDefault(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
+	suite.libfuse.ignoreOpenFlags = false
+
 	name := "path"
 	path := C.CString("/" + name)
 	defer C.free(unsafe.Pointer(path))

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -1,6 +1,6 @@
 # MUST READ : 
 #   If you are creating a blobfuse2 config file using this kindly take care of below points 
-#   1. All boolean configs (true|false config) are set to 'false' by default. 
+#   1. All boolean configs (true|false config) (except ignore-open-flags) are set to 'false' by default. 
 #      No need to mention them in your config file unless you are setting them to true.
 #   2. 'loopbackfs' is purely for testing and shall not be used in production configuration.
 #   3. 'stream' and 'file_cache' can not co-exist and config file shall have only one of them based on your use case.
@@ -62,8 +62,8 @@ libfuse:
   negative-entry-expiration-sec: <time kernel can cache attributes of non existent paths (in sec). Default - 120 sec>
   fuse-trace: true|false <enable libfuse api trace logs for debugging>
   extension: <physical path to extension library>
-  disable-writeback-cache: true|false <disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode. alternatively, you can ignore-open-flags.>
-  ignore-open-flags: true|false <ignore the append and write only flag since O_APPEND and O_WRONLY is not supported with writeback caching. alternatively, you can disable-writeback-cache.>
+  disable-writeback-cache: true|false <disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode. alternatively, you can set ignore-open-flags.>
+  ignore-open-flags: true|false <ignore the append and write only flag since O_APPEND and O_WRONLY is not supported with writeback caching. alternatively, you can disable-writeback-cache. Default value is true>
  
   # Streaming configuration
 stream:


### PR DESCRIPTION
Fixes #1015 

By default, on fuse3 we enable write-back-cache at kernel level. To populate kernel cache, kernel issues a read command on your file. Now assume you opened a file handle in WRONLY or APPEND mode, which means handle does not have read permissions. When kernel tries to read file using such handle the read operation fails and in turn users' Open operation returns back with error. To fix this (as write-back-cache boosts performance) we added a flag to ignore the open flag. This means even if user opens a file in write/append mode we always add read permissions as well.
So, if you are not able to open a file in write only or append only mode but want to use cache you need to now give ignore-open-flags=true always. Otherwise disable the write-back cache. We made this a configurable flag because if user goes and checks the permission on the handle it will not be the same as he expects (as we added read permissions). Just to make the expectation right we ask user to explicitly set this flag.
Issues comes from CSI driver which mostly goes with default config. write-back-cache enabled and ignore-open-flag set to false. Which means append file or write only open file are bound to fail. And not just CSI driver but any other user by default will hit failure with this default setting.
To resolve this, we are now turning ignore-open-flags always true.