### PR TITLE
Make 'virtual-directory' as default option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [#1036](https://github.com/Azure/azure-storage-fuse/issues/1036) Respect --default-working-dir cli param and use it as default log file path.
 - If version check fails due to network issues, mount/mountall/mountv1 command used to terminate. From this release it will just emit an error log and mount will continue.
 - If default work directory does not exists, mount shall create it before daemonizing.
-
+- Default value of 'virtual-directory' is changed to true. If your data is created using Blobfuse or AzCopy pass this flag as false in mount command.
 
 ## 2.0.1 (2022-12-02)
 - Copy of GA release of Blobfuse2. This release was necessary to ensure the GA version resolves ahead of the preview versions.

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -497,7 +497,11 @@ func ParseAndReadDynamicConfig(az *AzStorage, opt AzStorageOptions, reload bool)
 	az.stConfig.validateMD5 = opt.ValidateMD5
 	az.stConfig.updateMD5 = opt.UpdateMD5
 
-	az.stConfig.virtualDirectory = opt.VirtualDirectory
+	if config.IsSet(compName + ".virtual-directory") {
+		az.stConfig.virtualDirectory = opt.VirtualDirectory
+	} else {
+		az.stConfig.virtualDirectory = true
+	}
 
 	// Auth related reconfig
 	switch opt.AuthMode {

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -1,6 +1,6 @@
 # MUST READ : 
 #   If you are creating a blobfuse2 config file using this kindly take care of below points 
-#   1. All boolean configs (true|false config) (except ignore-open-flags) are set to 'false' by default. 
+#   1. All boolean configs (true|false config) (except ignore-open-flags, virtual-directory) are set to 'false' by default. 
 #      No need to mention them in your config file unless you are setting them to true.
 #   2. 'loopbackfs' is purely for testing and shall not be used in production configuration.
 #   3. 'stream' and 'file_cache' can not co-exist and config file shall have only one of them based on your use case.
@@ -20,6 +20,9 @@
 #   7. If are you using 'allow-other: true' config then make sure user_allow_other is enabled in /etc/fuse.conf file as 
 #      well otherwise mount will fail. By default /etc/fuse.conf will have this option disabled we just need to 
 #      enable it and save the file.
+#   8. If data in your storage account (non-HNS) is created using Blobfuse or AzCopy then there are marker files present
+#      in your container to mark a directory. In such cases you can optimize your listing by setting 'virtual-directory'
+#      flag to false in mount command.
 # -----------------------------------------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Most customers trying out Blobfuse2 have complains that in non-HNS account they are not able to list the directories. This is due to missing marker files when data set was not uploaded/created using Blobfuse or AzCopy, In such cases we need to detect presence of directory in different way, which reduces Blobfuse performance a bit. For performance reasons this method of detecting the directory was disabled by default. By looking at pattern where most customers are hitting this issue and we have to suggest them to turn on this feature, it makes more sense to enable this feature by default.