### PR TITLE
Wait for child process to complete the mount before exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 **Bug Fixes**
 - [#1080](https://github.com/Azure/azure-storage-fuse/issues/1080) HNS rename flow does not encode source path correctly.
 - [#1079](https://github.com/Azure/azure-storage-fuse/issues/1079) Shell returns before daemon process mounts the container and if user tries to bind the mount it leads to inconsistent state.
+
 ## 2.0.2 (2022-02-23)
 **Bug Fixes**
 - [#999](https://github.com/Azure/azure-storage-fuse/issues/999) Upgrade dependencies to resolve known CVEs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.0.3 (WIP)
 **Bug Fixes**
 - [#1080](https://github.com/Azure/azure-storage-fuse/issues/1080) HNS rename flow does not encode source path correctly.
-- [#1079](https://github.com/Azure/azure-storage-fuse/issues/1079) Shell returns before daemon process mounts the container and if user tries to bind the mount it leads to inconsistent state.
+- [#1079](https://github.com/Azure/azure-storage-fuse/issues/1079) Shell returns before child process mounts the container and if user tries to bind the mount it leads to inconsistent state.
 
 ## 2.0.2 (2022-02-23)
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.0.3 (WIP)
 **Bug Fixes**
 - [#1080](https://github.com/Azure/azure-storage-fuse/issues/1080) HNS rename flow does not encode source path correctly.
-
+- [#1079](https://github.com/Azure/azure-storage-fuse/issues/1079) Shell returns before daemon process mounts the container and if user tries to bind the mount it leads to inconsistent state.
 ## 2.0.2 (2022-02-23)
 **Bug Fixes**
 - [#999](https://github.com/Azure/azure-storage-fuse/issues/999) Upgrade dependencies to resolve known CVEs.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ To learn about a specific command, just include the name of the command (For exa
     * `--read-only=true`: Mount container in read-only mode.
     * `--default-working-dir`: The default working directory to store log files and other blobfuse2 related information.
     * `--disable-version-check=true`: Disable the blobfuse2 version check.
-    * `----secure-config=true` : Config file is encrypted suing 'blobfuse2 secure` command.
-    * `----passphrase=<STRING>` : Passphrase used to encrypt/decrypt config file.
+    * `--secure-config=true` : Config file is encrypted suing 'blobfuse2 secure` command.
+    * `--passphrase=<STRING>` : Passphrase used to encrypt/decrypt config file.
+    * `--wait-for-mount=<TIMEOUT IN SECONDS>` : Let parent process wait for given timeout before exit to ensure child has started. 
 - Attribute cache options
     * `--attr-cache-timeout=<TIMEOUT IN SECONDS>`: The timeout for the attribute cache entries.
     * `--no-symlinks=true`: To improve performance disable symlink support.

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -423,7 +423,14 @@ var mountCmd = &cobra.Command{
 				// Give some breather for child process to start
 				// If not given, parent process immediately exits and it may happen that child has not yet started
 				// in such cases if user tries to access or bind the mount it may lead to an inconsistent state.
-				time.Sleep(time.Duration(options.WaitForMount) * time.Second)
+				if options.WaitForMount > 0 {
+					// This if for plan-B in any case if child-parent signaling logic fails, user can always fall back to
+					// fixed amount of delay to give a chance for child process to start.
+					time.Sleep(time.Duration(options.WaitForMount) * time.Second)
+				} else {
+					// Handle child signaling process here
+
+				}
 			}
 		} else {
 			if options.CPUProfile != "" {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -644,7 +644,7 @@ func init() {
 	config.BindPFlag("libfuse-options", mountCmd.PersistentFlags().ShorthandLookup("o"))
 	mountCmd.PersistentFlags().ShorthandLookup("o").Hidden = true
 
-	mountCmd.PersistentFlags().IntVar(&options.WaitForMount, "wait-for-mount", 0, "Wait for daemon to mount")
+	mountCmd.PersistentFlags().IntVar(&options.WaitForMount, "wait-for-mount", 0, "Let parent process wait for given timeout before exit")
 
 	config.AttachToFlagSet(mountCmd.PersistentFlags())
 	config.AttachFlagCompletions(mountCmd)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -421,8 +421,8 @@ var mountCmd = &cobra.Command{
 				}
 			} else {
 				// Give some breather for child process to start
-				// If not given parent process immediatly exits and it may happen that child has not yet started
-				// in such cases if user tries to access or bind the mount it may become inconsistent state.
+				// If not given, parent process immediately exits and it may happen that child has not yet started
+				// in such cases if user tries to access or bind the mount it may lead to an inconsistent state.
 				time.Sleep(time.Duration(options.WaitForMount) * time.Second)
 			}
 		} else {


### PR DESCRIPTION
Fixes [#1079](https://github.com/Azure/azure-storage-fuse/issues/1079) Shell returns before daemon process mounts the container and if user tries to bind the mount it leads to inconsistent state. Adding cli flag to wait after demonization to ensure child process has completed the mount.