### PR TITLE
sync call can force upload a file to storage if configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - [#1079](https://github.com/Azure/azure-storage-fuse/issues/1079) Shell returns before child process mounts the container and if user tries to bind the mount it leads to inconsistent state.
 - If mount fails in forked child, blobfuse2 will return back with status error code.
 
+**Features**
+- Added new CLI parameter "--sync-to-flush". Once configured sync() call on file will force upload a file to storage container. As this is file handle based api, if file was not in file-cache it will first download and then upload the file. 
+
 
 ## 2.0.2 (2022-02-23)
 **Bug Fixes**

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ To learn about a specific command, just include the name of the command (For exa
     * `--cache-size-mb=<SIZE IN MB>`: Amount of disk cache that can be used by blobfuse.
     * `--high-disk-threshold=<PERCENTAGE>`: If local cache usage exceeds this, start early eviction of files from cache.
     * `--low-disk-threshold=<PERCENTAGE>`: If local cache usage comes below this threshold then stop early eviction.
+    * `--sync-to-flush` : Sync call will force upload a file to storage container
 - Stream options
     * `--block-size-mb=<SIZE IN MB>`: Size of a block to be downloaded during streaming.
 - Fuse options

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -73,6 +73,7 @@ type FileCache struct {
 	mountPath       string
 	allowOther      bool
 	offloadIO       bool
+	syncToFlush     bool
 	maxCacheSize    float64
 
 	defaultPermission os.FileMode
@@ -101,6 +102,7 @@ type FileCacheOptions struct {
 	// v1 support
 	V1Timeout     uint32 `config:"file-cache-timeout-in-seconds" yaml:"-"`
 	EmptyDirCheck bool   `config:"empty-dir-check" yaml:"-"`
+	SyncToFlush   bool   `config:"sync-to-flush" yaml:"sync-to-flush,omitempty"`
 }
 
 const (
@@ -220,6 +222,7 @@ func (c *FileCache) Configure(_ bool) error {
 	c.policyTrace = conf.EnablePolicyTrace
 	c.offloadIO = conf.OffloadIO
 	c.maxCacheSize = conf.MaxSizeMB
+	c.syncToFlush = conf.SyncToFlush
 
 	c.tmpPath = common.ExpandPath(conf.TmpPath)
 	if c.tmpPath == "" {
@@ -286,6 +289,9 @@ func (c *FileCache) Configure(_ bool) error {
 	}
 	if config.IsSet(compName + ".upload-modified-only") {
 		log.Warn("unsupported v1 CLI parameter: upload-modified-only is always true in blobfuse2.")
+	}
+	if config.IsSet(compName + ".sync-to-flush") {
+		log.Warn("Sync will upload current contents of file.")
 	}
 
 	log.Info("FileCache::Configure : create-empty %t, cache-timeout %d, tmp-path %s, max-size-mb %d, high-mark %d, low-mark %d",
@@ -1037,14 +1043,19 @@ func (fc *FileCache) WriteFile(options internal.WriteFileOptions) (int, error) {
 }
 
 func (fc *FileCache) SyncFile(options internal.SyncFileOptions) error {
-	err := fc.NextComponent().SyncFile(options)
-	if err != nil {
-		log.Err("FileCache::SyncFile : %s failed", options.Handle.Path)
-		return err
+	if fc.syncToFlush {
+		options.Handle.Flags.Set(handlemap.HandleFlagDirty)
+	} else {
+		err := fc.NextComponent().SyncFile(options)
+		if err != nil {
+			log.Err("FileCache::SyncFile : %s failed", options.Handle.Path)
+			return err
+		}
+
+		options.Handle.Flags.Set(handlemap.HandleFlagFSynced)
 	}
 
-	options.Handle.Flags.Set(handlemap.HandleFlagFSynced)
-	return err
+	return nil
 }
 
 // in SyncDir we're not going to clear the file cache for now
@@ -1411,6 +1422,9 @@ func init() {
 	uploadModifiedOnly := config.AddBoolFlag("upload-modified-only", false, "Flag to turn off unnecessary uploads to storage.")
 	config.BindPFlag(compName+".upload-modified-only", uploadModifiedOnly)
 	uploadModifiedOnly.Hidden = true
+
+	syncToFlush := config.AddBoolFlag("sync-to-flush", false, "Sync call on file will force a upload of the file.")
+	config.BindPFlag(compName+".sync-to-flush", syncToFlush)
 
 	config.RegisterFlagCompletionFunc("tmp-path", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveDefault

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1429,5 +1429,4 @@ func init() {
 	config.RegisterFlagCompletionFunc("tmp-path", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveDefault
 	})
-
 }

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -93,6 +93,7 @@ file_cache:
   cleanup-on-start: true|false <cleanup the temp directory on startup, if its not empty>
   policy-trace: true|false <generate eviction policy logs showing which files will expire soon>
   offload-io: true|false <by default libfuse will service reads/writes to files for better perf. Set to true to make file-cache component service read/write calls.>
+  sync-to-flush: true|false <sync call to a file will force upload of the contents to storage account>
 
 # Attribute cache related configuration
 attr_cache:


### PR DESCRIPTION
--sync-to-flush added new flag to control this behaviour