### PR TITLE
Exit with non-zero status code if allow_other is used but not enabled in fuse config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.3 (WIP)
 **Bug Fixes**
 - [#1080](https://github.com/Azure/azure-storage-fuse/issues/1080) HNS rename flow does not encode source path correctly.
+- [#1081](https://github.com/Azure/azure-storage-fuse/issues/1081) Blobfuse will exit with non-zero status code if allow_other option is used but not enabled in fuse config.
 
 ## 2.0.2 (2022-02-23)
 **Bug Fixes**

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -281,6 +281,7 @@ var mountCmd = &cobra.Command{
 		}
 
 		skipNonEmpty := false
+
 		if config.IsSet("libfuse-options") {
 			for _, v := range options.LibfuseOptions {
 				parameter := strings.Split(v, "=")

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -142,7 +142,6 @@ func (suite *mountTestSuite) TestMountDirNotEmpty() {
 
 	op, err = executeCommandC(rootCmd, "mount", mntDir, fmt.Sprintf("--config-file=%s", confFileMntTest), "-o", "nonempty", "--foreground")
 	suite.assert.NotNil(err)
-	suite.assert.Contains(op, "failed to authenticate credential")
 }
 
 // mount failure test where the mount path is not provided
@@ -155,6 +154,7 @@ func (suite *mountTestSuite) TestMountPathNotProvided() {
 
 	op, err = executeCommandC(rootCmd, "mount", "all", "", fmt.Sprintf("--config-file=%s", confFileMntTest))
 	suite.assert.NotNil(err)
+	suite.assert.Contains(op, "mount path not provided")
 }
 
 // mount failure test where the config file type is unsupported

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -140,7 +140,7 @@ func (suite *mountTestSuite) TestMountDirNotEmpty() {
 	suite.assert.NotNil(err)
 	suite.assert.Contains(op, "mount directory is not empty")
 
-	op, err = executeCommandC(rootCmd, "mount", mntDir, fmt.Sprintf("--config-file=%s", confFileMntTest), "-o", "nonempty", "--foreground", "-o", "allow_other=false")
+	op, err = executeCommandC(rootCmd, "mount", mntDir, fmt.Sprintf("--config-file=%s", confFileMntTest), "-o", "nonempty", "--foreground")
 	suite.assert.NotNil(err)
 	suite.assert.Contains(op, "failed to authenticate credential")
 }
@@ -155,7 +155,6 @@ func (suite *mountTestSuite) TestMountPathNotProvided() {
 
 	op, err = executeCommandC(rootCmd, "mount", "all", "", fmt.Sprintf("--config-file=%s", confFileMntTest))
 	suite.assert.NotNil(err)
-	suite.assert.Contains(op, "mount path not provided")
 }
 
 // mount failure test where the config file type is unsupported

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -140,7 +140,7 @@ func (suite *mountTestSuite) TestMountDirNotEmpty() {
 	suite.assert.NotNil(err)
 	suite.assert.Contains(op, "mount directory is not empty")
 
-	op, err = executeCommandC(rootCmd, "mount", mntDir, fmt.Sprintf("--config-file=%s", confFileMntTest), "-o", "nonempty", "--foreground")
+	op, err = executeCommandC(rootCmd, "mount", mntDir, fmt.Sprintf("--config-file=%s", confFileMntTest), "-o", "nonempty", "--foreground", "-o", "allow_other=false")
 	suite.assert.NotNil(err)
 	suite.assert.Contains(op, "failed to authenticate credential")
 }

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -38,6 +38,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/config"
@@ -214,9 +215,12 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		cmd.Stderr = &errb
 		cliOut, err := cmd.Output()
 		data := string(cliOut)
-		if err == nil && data[0] == '#' {
-			log.Err("Libfuse::Validate : config error [user_allow_other is not enabled in /etc/fuse.conf]")
-			return fmt.Errorf("user_allow_other is not enabled in /etc/fuse.conf")
+		if err == nil {
+			data = strings.TrimSpace(data)
+			if data == "" || data[0] == '#' {
+				log.Err("Libfuse::Validate : config error [user_allow_other is not enabled in /etc/fuse.conf]")
+				return fmt.Errorf("user_allow_other is not enabled in /etc/fuse.conf")
+			}
 		}
 	}
 

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -37,6 +37,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -207,8 +208,9 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		lf.negativeTimeout = defaultNegativeEntryExpiration
 	}
 
-	if lf.allowOther {
-		// Validate allow_other is enabled in fuse.conf file or not
+	// When root user mounts, allow_other works even if its not set in /etc/fuse.conf file
+	// for other user libfuse init will fail. Adding a pre-condition here for validation
+	if lf.allowOther && 0 != os.Getuid() && 0 != os.Getgid() {
 		cmd := exec.Command("bash", "-c", "cat /etc/fuse.conf | grep -i user_allow_other$")
 
 		var errb bytes.Buffer

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -223,6 +223,8 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 				log.Err("Libfuse::Validate : config error [user_allow_other is not enabled in /etc/fuse.conf]")
 				return fmt.Errorf("user_allow_other is not enabled in /etc/fuse.conf")
 			}
+		} else {
+			log.Err("Libfuse::Validate : failed to check fuse config file [%s]", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Fix for #1081 