### PR TITLE
Adding FUSE option direct_io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 **Features**
 - Added new config parameter "max-fuse-threads" under "libfuse" config to control max threads allowed at libfuse layer.
 - Added new config parameter 'refresh-sec' in 'file-cache'. When file-cache-timeout is set to a large value, this field can control when to refresh the file if file in container has changed.
+- Added FUSE option `dirrect_io` to bypass the kernel cache and perform direct I/O operations.
 
 **Bug Fixes**
 - [#1116](https://github.com/Azure/azure-storage-fuse/issues/1116)] Relative path for tmp-cache is resulting into file read-write failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 **Features**
 - Added new config parameter "max-fuse-threads" under "libfuse" config to control max threads allowed at libfuse layer.
 - Added new config parameter 'refresh-sec' in 'file-cache'. When file-cache-timeout is set to a large value, this field can control when to refresh the file if file in container has changed.
-- Added FUSE option `dirrect_io` to bypass the kernel cache and perform direct I/O operations.
+- Added FUSE option `direct_io` to bypass the kernel cache and perform direct I/O operations.
 
 **Bug Fixes**
 - [#1116](https://github.com/Azure/azure-storage-fuse/issues/1116)] Relative path for tmp-cache is resulting into file read-write failure.

--- a/azure-pipeline-templates/verbose-tests.yml
+++ b/azure-pipeline-templates/verbose-tests.yml
@@ -361,6 +361,24 @@ steps:
       verbose_log: ${{ parameters.verbose_log }}
 
 
+  - template: e2e-tests-spcl.yml
+    parameters:
+      conf_template: azure_key_directio.yaml
+      config_file: ${{ parameters.config }}
+      container: ${{ parameters.container }}
+      temp_dir: ${{ parameters.temp_dir }}
+      mount_dir: ${{ parameters.mount_dir }}
+      adls: ${{ parameters.adls }}
+      account_name: ${{ parameters.account_name }}
+      account_key: ${{ parameters.account_key }}
+      account_type: ${{ parameters.account_type }}
+      account_endpoint: ${{ parameters.account_endpoint }}
+      idstring: "${{ parameters.service }} LRU policy create empty"
+      distro_name: ${{ parameters.distro_name }}
+      quick_test: ${{ parameters.quick_test }}
+      verbose_log: ${{ parameters.verbose_log }}
+
+
 #--------------------------------------- Setup: End to end tests with different File Cache configurations ------------------------------------------
   - script: |
       cd ${{ parameters.working_dir }}

--- a/azure-pipeline-templates/verbose-tests.yml
+++ b/azure-pipeline-templates/verbose-tests.yml
@@ -373,7 +373,7 @@ steps:
       account_key: ${{ parameters.account_key }}
       account_type: ${{ parameters.account_type }}
       account_endpoint: ${{ parameters.account_endpoint }}
-      idstring: "${{ parameters.service }} LRU policy create empty"
+      idstring: "${{ parameters.service }} Direct IO tests"
       distro_name: ${{ parameters.distro_name }}
       quick_test: ${{ parameters.quick_test }}
       verbose_log: ${{ parameters.verbose_log }}

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -329,6 +329,8 @@ var mountCmd = &cobra.Command{
 						return fmt.Errorf("failed to parse gid [%s]", err.Error())
 					}
 					config.Set("libfuse.gid", fmt.Sprint(val))
+				} else if v == "direct_io" || v == "direct_io=true" {
+					config.Set("libfuse.direct_io", "true")
 				} else {
 					return errors.New(common.FuseAllowedFlags)
 				}

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -330,7 +330,7 @@ var mountCmd = &cobra.Command{
 					}
 					config.Set("libfuse.gid", fmt.Sprint(val))
 				} else if v == "direct_io" || v == "direct_io=true" {
-					config.Set("libfuse.direct_io", "true")
+					config.Set("libfuse.direct-io", "true")
 				} else {
 					return errors.New(common.FuseAllowedFlags)
 				}

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -366,6 +366,7 @@ func (suite *mountTestSuite) TestFuseOptions() {
 		{opt: "umask=777", ignore: false},
 		{opt: "uid=1000", ignore: false},
 		{opt: "gid=1000", ignore: false},
+		{opt: "direct_io", ignore: false},
 	}
 
 	for _, val := range opts {

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -102,7 +102,7 @@ type LibfuseOptions struct {
 	Uid                     uint32 `config:"uid" yaml:"uid,omitempty"`
 	Gid                     uint32 `config:"gid" yaml:"uid,omitempty"`
 	MaxFuseThreads          uint32 `config:"max-fuse-threads" yaml:"max-fuse-threads,omitempty"`
-	DirectIO                bool   `config:"direct_io" yaml:"direct_io,omitempty"`
+	DirectIO                bool   `config:"direct-io" yaml:"direct-io,omitempty"`
 }
 
 const compName = "libfuse"

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -72,6 +72,7 @@ type Libfuse struct {
 	nonEmptyMount         bool
 	lsFlags               common.BitMap16
 	maxFuseThreads        uint32
+	directIO              bool
 }
 
 // To support pagination in readdir calls this structure holds a block of items for a given directory
@@ -101,6 +102,7 @@ type LibfuseOptions struct {
 	Uid                     uint32 `config:"uid" yaml:"uid,omitempty"`
 	Gid                     uint32 `config:"gid" yaml:"uid,omitempty"`
 	MaxFuseThreads          uint32 `config:"max-fuse-threads" yaml:"max-fuse-threads,omitempty"`
+	DirectIO                bool   `config:"direct_io" yaml:"direct_io,omitempty"`
 }
 
 const compName = "libfuse"
@@ -181,6 +183,7 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 	lf.disableWritebackCache = opt.DisableWritebackCache
 	lf.ignoreOpenFlags = opt.IgnoreOpenFlags
 	lf.nonEmptyMount = opt.nonEmptyMount
+	lf.directIO = opt.DirectIO
 
 	if opt.allowOther {
 		lf.dirPermission = uint(common.DefaultAllowOtherPermissionBits)

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -214,6 +214,13 @@ func populateFuseArgs(opts *C.fuse_options_t, args *C.fuse_args_t) (*C.fuse_opti
 	if opts.readonly {
 		options += ",ro"
 	}
+
+	// direct_io option is used to bypass the kernel cache. It disables the use of
+	// page cache (file content cache) in the kernel for the filesystem.
+	if fuseFS.directIO {
+		options += ",direct_io"
+	}
+
 	// Why we pass -f
 	// CGo is not very good with handling forks - so if the user wants to run blobfuse in the
 	// background we fork on mount in GO (mount.go) and we just always force libfuse to mount in foreground

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -312,6 +312,12 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 	//conn.max_write = (4 * 1024 * 1024)
 	//conn.max_read =  (4 * 1024 * 1024)
 
+	// direct_io option is used to bypass the kernel cache. It disables the use of
+	// page cache (file content cache) in the kernel for the filesystem.
+	if fuseFS.directIO {
+		cfg.direct_io = C.int(1)
+	}
+
 	return nil
 }
 

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -58,12 +58,13 @@ func (suite *libfuseTestSuite) TestDefault() {
 	suite.assert.Equal(suite.libfuse.negativeTimeout, uint32(120))
 	suite.assert.False(suite.libfuse.disableWritebackCache)
 	suite.assert.True(suite.libfuse.ignoreOpenFlags)
+	suite.assert.False(suite.libfuse.directIO)
 }
 
 func (suite *libfuseTestSuite) TestConfig() {
 	defer suite.cleanupTest()
 	suite.cleanupTest() // clean up the default libfuse generated
-	config := "allow-other: true\nread-only: true\nlibfuse:\n  attribute-expiration-sec: 60\n  entry-expiration-sec: 60\n  negative-entry-expiration-sec: 60\n  fuse-trace: true\n  disable-writeback-cache: true\n  ignore-open-flags: false\n"
+	config := "allow-other: true\nread-only: true\nlibfuse:\n  attribute-expiration-sec: 60\n  entry-expiration-sec: 60\n  negative-entry-expiration-sec: 60\n  fuse-trace: true\n  disable-writeback-cache: true\n  ignore-open-flags: false\n  direct-io: true\n"
 	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
 
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
@@ -79,12 +80,13 @@ func (suite *libfuseTestSuite) TestConfig() {
 	suite.assert.Equal(suite.libfuse.entryExpiration, uint32(60))
 	suite.assert.Equal(suite.libfuse.attributeExpiration, uint32(60))
 	suite.assert.Equal(suite.libfuse.negativeTimeout, uint32(60))
+	suite.assert.True(suite.libfuse.directIO)
 }
 
 func (suite *libfuseTestSuite) TestConfigZero() {
 	defer suite.cleanupTest()
 	suite.cleanupTest() // clean up the default libfuse generated
-	config := "read-only: true\nlibfuse:\n  attribute-expiration-sec: 0\n  entry-expiration-sec: 0\n  negative-entry-expiration-sec: 0\n  fuse-trace: true\n"
+	config := "read-only: true\nlibfuse:\n  attribute-expiration-sec: 0\n  entry-expiration-sec: 0\n  negative-entry-expiration-sec: 0\n  fuse-trace: true\n  direct-io: false\n"
 	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
 
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
@@ -98,12 +100,13 @@ func (suite *libfuseTestSuite) TestConfigZero() {
 	suite.assert.Equal(suite.libfuse.entryExpiration, uint32(0))
 	suite.assert.Equal(suite.libfuse.attributeExpiration, uint32(0))
 	suite.assert.Equal(suite.libfuse.negativeTimeout, uint32(0))
+	suite.assert.False(suite.libfuse.directIO)
 }
 
 func (suite *libfuseTestSuite) TestConfigDefaultPermission() {
 	defer suite.cleanupTest()
 	suite.cleanupTest() // clean up the default libfuse generated
-	config := "read-only: true\nlibfuse:\n  default-permission: 0555\n  attribute-expiration-sec: 0\n  entry-expiration-sec: 0\n  negative-entry-expiration-sec: 0\n  fuse-trace: true\n"
+	config := "read-only: true\nlibfuse:\n  default-permission: 0555\n  attribute-expiration-sec: 0\n  entry-expiration-sec: 0\n  negative-entry-expiration-sec: 0\n  fuse-trace: true\n   direct-io: true\n"
 	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
 
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
@@ -117,6 +120,7 @@ func (suite *libfuseTestSuite) TestConfigDefaultPermission() {
 	suite.assert.Equal(suite.libfuse.entryExpiration, uint32(0))
 	suite.assert.Equal(suite.libfuse.attributeExpiration, uint32(0))
 	suite.assert.Equal(suite.libfuse.negativeTimeout, uint32(0))
+	suite.assert.True(suite.libfuse.directIO)
 }
 
 func (suite *libfuseTestSuite) TestDisableWritebackCache() {

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -106,7 +106,7 @@ func (suite *libfuseTestSuite) TestConfigZero() {
 func (suite *libfuseTestSuite) TestConfigDefaultPermission() {
 	defer suite.cleanupTest()
 	suite.cleanupTest() // clean up the default libfuse generated
-	config := "read-only: true\nlibfuse:\n  default-permission: 0555\n  attribute-expiration-sec: 0\n  entry-expiration-sec: 0\n  negative-entry-expiration-sec: 0\n  fuse-trace: true\n   direct-io: true\n"
+	config := "read-only: true\nlibfuse:\n  default-permission: 0555\n  attribute-expiration-sec: 0\n  entry-expiration-sec: 0\n  negative-entry-expiration-sec: 0\n  fuse-trace: true\n  direct-io: true\n"
 	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
 
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -68,6 +68,7 @@ libfuse:
   disable-writeback-cache: true|false <disallow libfuse to buffer write requests if you must strictly open files in O_WRONLY or O_APPEND mode. alternatively, you can set ignore-open-flags.>
   ignore-open-flags: true|false <ignore the append and write only flag since O_APPEND and O_WRONLY is not supported with writeback caching. alternatively, you can disable-writeback-cache. Default value is true>
   max-fuse-threads: <number of threads allowed at libfuse layer for highly parallel operations, Default is 128>
+  direct-io: true|false <enable to bypass the kernel cache>
  
   # Streaming configuration
 stream:

--- a/test/e2e_tests/file_test.go
+++ b/test/e2e_tests/file_test.go
@@ -205,7 +205,7 @@ func (suite *fileTestSuite) TestFileCreateMultiSpclCharWithinSpclDir() {
 	}
 	suite.Equal(true, found)
 
-	suite.fileTestCleanup([]string{fileName, secFile, speclDirName + "/" + "abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|", speclDirName})
+	suite.fileTestCleanup([]string{speclDirName})
 }
 
 func (suite *fileTestSuite) TestFileCreateLongName() {

--- a/test/e2e_tests/file_test.go
+++ b/test/e2e_tests/file_test.go
@@ -175,7 +175,7 @@ func (suite *fileTestSuite) TestFileCreatEncodeChar() {
 func (suite *fileTestSuite) TestFileCreateMultiSpclCharWithinSpclDir() {
 	speclChar := "abcd%23ABCD%34123-._~!$&'()*+,;=!@ΣΑΠΦΩ$भारत.txt"
 	speclDirName := suite.testPath + "/" + "abc%23%24%25efg-._~!$&'()*+,;=!@ΣΑΠΦΩ$भारत"
-	secFile := speclDirName + "/" + "abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|\\abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|.txt"
+	secFile := speclDirName + "/" + "abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|abcd123~!@#$%^&*()_+=-{}][\":;'?><,.|.txt"
 	fileName := speclDirName + "/" + speclChar
 
 	err := os.Mkdir(speclDirName, 0777)
@@ -224,7 +224,7 @@ func (suite *fileTestSuite) TestFileCreateSlashName() {
 	suite.Equal(nil, err)
 	srcFile.Close()
 
-	suite.fileTestCleanup([]string{fileName})
+	suite.fileTestCleanup([]string{fileName, suite.testPath + "/abcd"})
 }
 
 func (suite *fileTestSuite) TestFileCreateLabel() {

--- a/testdata/config/azure_key_directio.yaml
+++ b/testdata/config/azure_key_directio.yaml
@@ -1,0 +1,34 @@
+logging:
+  level: log_debug
+  file-path: "blobfuse2-logs.txt"
+  type: base
+
+components:
+  - libfuse
+  - file_cache
+  - azstorage
+
+libfuse:
+  attribute-expiration-sec: 0
+  entry-expiration-sec: 0
+  negative-entry-expiration-sec: 0
+  ignore-open-flags: true
+  direct-io: true
+
+file_cache:
+  path: { 1 }
+  timeout-sec: 0
+  max-size-mb: 2048
+  allow-non-empty-temp: true
+  cleanup-on-start: true
+  
+azstorage:
+  type: { ACCOUNT_TYPE }
+  endpoint: { ACCOUNT_ENDPOINT }
+  use-http: { USE_HTTP }
+  account-name: { NIGHTLY_STO_ACC_NAME }
+  account-key: { NIGHTLY_STO_ACC_KEY }
+  mode: key
+  container: { 0 }
+  tier: hot
+  sdk-trace: { VERBOSE_LOG }


### PR DESCRIPTION
direct_io can be used to bypass the kernel cache. It disables the use of page cache in the kernel.

TODO: add this option for fuse2.