### PR TITLE
Auth permission mismatch error check from azstorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Remove leading slashes from subdirectory name.
 - [#1156](https://github.com/Azure/azure-storage-fuse/issues/1156) Reuse 'auth-resource' config to alter scope of SPN token.
 - [#1175](https://github.com/Azure/azure-storage-fuse/issues/1175) Divide by 0 exception in Stream in case of direct streaming option.
+- [#1161](https://github.com/Azure/azure-storage-fuse/issues/1161) Add more verbose logs for pipeline init failures
+- Return permission denied error for `AuthorizationPermissionMismatch` error from service.
 
 ## 2.0.3 (2023-04-26)
 **Bug Fixes**

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -437,6 +437,9 @@ func (bb *BlockBlob) getAttrUsingRest(name string) (attr *internal.ObjAttr, err 
 		e := storeBlobErrToErr(err)
 		if e == ErrFileNotFound {
 			return attr, syscall.ENOENT
+		} else if e == InvalidPermission {
+			log.Err("BlockBlob::getAttrUsingRest : Insufficient permissions for %s [%s]", name, err.Error())
+			return attr, syscall.EACCES
 		} else {
 			log.Err("BlockBlob::getAttrUsingRest : Failed to get blob properties for %s [%s]", name, err.Error())
 			return attr, err
@@ -482,7 +485,8 @@ func (bb *BlockBlob) getAttrUsingList(name string) (attr *internal.ObjAttr, err 
 			if e == ErrFileNotFound {
 				return attr, syscall.ENOENT
 			} else if e == InvalidPermission {
-				return attr, syscall.EPERM
+				log.Err("BlockBlob::getAttrUsingList : Insufficient permissions for %s [%s]", name, err.Error())
+				return attr, syscall.EACCES
 			} else {
 				log.Warn("BlockBlob::getAttrUsingList : Failed to list blob properties for %s [%s]", name, err.Error())
 				failCount++

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -895,6 +895,9 @@ func (bb *BlockBlob) WriteFromFile(name string, metadata map[string]string, fi *
 		if serr == BlobIsUnderLease {
 			log.Err("BlockBlob::WriteFromFile : %s is under a lease, can not update file [%s]", name, err.Error())
 			return syscall.EIO
+		} else if serr == InvalidPermission {
+			log.Err("BlockBlob::WriteFromFile : Insufficient permissions for %s [%s]", name, err.Error())
+			return syscall.EACCES
 		} else {
 			log.Err("BlockBlob::WriteFromFile : Failed to upload blob %s [%s]", name, err.Error())
 		}

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -382,6 +382,9 @@ func (dl *Datalake) GetAttr(name string) (attr *internal.ObjAttr, err error) {
 		e := storeDatalakeErrToErr(err)
 		if e == ErrFileNotFound {
 			return attr, syscall.ENOENT
+		} else if e == InvalidPermission {
+			log.Err("Datalake::GetAttr : Insufficient permissions for %s [%s]", name, err.Error())
+			return attr, syscall.EACCES
 		} else {
 			log.Err("Datalake::GetAttr : Failed to get path properties for %s [%s]", name, err.Error())
 			return attr, err

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -266,8 +266,14 @@ func (dl *Datalake) CreateDirectory(name string) error {
 	_, err := directoryURL.Create(context.Background(), false)
 
 	if err != nil {
-		log.Err("Datalake::CreateDirectory : Failed to create directory %s [%s]", name, err.Error())
-		return err
+		serr := storeDatalakeErrToErr(err)
+		if serr == InvalidPermission {
+			log.Err("Datalake::CreateDirectory : Insufficient permissions for %s [%s]", name, err.Error())
+			return syscall.EACCES
+		} else {
+			log.Err("Datalake::CreateDirectory : Failed to create directory %s [%s]", name, err.Error())
+			return err
+		}
 	}
 
 	return nil

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -187,8 +187,8 @@ func newBlobfuse2HTTPClientFactory(pipelineHTTPClient *http.Client) pipeline.Fac
 		return func(ctx context.Context, request pipeline.Request) (pipeline.Response, error) {
 			r, err := pipelineHTTPClient.Do(request.WithContext(ctx))
 			if err != nil {
+				log.Err("BlockBlob::newBlobfuse2HTTPClientFactory : HTTP request failed [%s]", err.Error())
 				err = pipeline.NewError(err, "HTTP request failed")
-				log.Err("BlockBlob::newBlobfuse2HTTPClientFactory : HTTP request failed")
 			}
 			return pipeline.NewHTTPResponse(r), err
 		}
@@ -291,6 +291,8 @@ func storeBlobErrToErr(err error) uint16 {
 			return BlobIsUnderLease
 		case azblob.ServiceCodeInsufficientAccountPermissions:
 			return InvalidPermission
+		case "AuthorizationPermissionMismatch":
+			return InvalidPermission
 		default:
 			return ErrUnknown
 		}
@@ -310,6 +312,8 @@ func storeDatalakeErrToErr(err error) uint16 {
 			return ErrFileNotFound
 		case "LeaseIdMissing":
 			return BlobIsUnderLease
+		case "AuthorizationPermissionMismatch":
+			return InvalidPermission
 		default:
 			return ErrUnknown
 		}

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -421,7 +421,11 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 	err := fuseFS.NextComponent().CreateDir(internal.CreateDirOptions{Name: name, Mode: fs.FileMode(uint32(mode) & 0xffffffff)})
 	if err != nil {
 		log.Err("Libfuse::libfuse_mkdir : Failed to create %s [%s]", name, err.Error())
-		return -C.EIO
+		if os.IsPermission(err) {
+			return -C.EACCES
+		} else {
+			return -C.EIO
+		}
 	}
 
 	libfuseStatsCollector.PushEvents(createDir, name, map[string]interface{}{md: fs.FileMode(uint32(mode) & 0xffffffff)})

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -75,6 +75,7 @@ In those calls we will convert integer value back to a pointer and get our valid
 const (
 	C_ENOENT = int(-C.ENOENT)
 	C_EIO    = int(-C.EIO)
+	C_EACCES = int(-C.EACCES)
 )
 
 // Note: libfuse prepends "/" to the path.
@@ -492,9 +493,11 @@ func libfuse2_readdir(_ *C.char, buf unsafe.Pointer, filler C.fuse_fill_dir_t, o
 		})
 
 		if err != nil {
-			log.Err("Libfuse::libfuse2_readdir : Path %s, handle: %d, offset %d. Error in retrieval", handle.Path, handle.ID, off_64)
+			log.Err("Libfuse::libfuse2_readdir : Path %s, handle: %d, offset %d. Error in retrieval %s", handle.Path, handle.ID, off_64, err.Error())
 			if os.IsNotExist(err) {
 				return C.int(C_ENOENT)
+			} else if os.IsPermission(err) {
+				return C.int(C_EACCES)
 			} else {
 				return C.int(C_EIO)
 			}
@@ -632,6 +635,8 @@ func libfuse_open(path *C.char, fi *C.fuse_file_info_t) C.int {
 		log.Err("Libfuse::libfuse_open : Failed to open %s [%s]", name, err.Error())
 		if os.IsNotExist(err) {
 			return -C.ENOENT
+		} else if os.IsPermission(err) {
+			return -C.EACCES
 		} else {
 			return -C.EIO
 		}
@@ -733,7 +738,13 @@ func libfuse_flush(path *C.char, fi *C.fuse_file_info_t) C.int {
 	err := fuseFS.NextComponent().FlushFile(internal.FlushFileOptions{Handle: handle})
 	if err != nil {
 		log.Err("Libfuse::libfuse_flush : error flushing file %s, handle: %d [%s]", handle.Path, handle.ID, err.Error())
-		return -C.EIO
+		if err == syscall.ENOENT {
+			return -C.ENOENT
+		} else if err == syscall.EACCES {
+			return -C.EACCES
+		} else {
+			return -C.EIO
+		}
 	}
 
 	return 0
@@ -779,7 +790,13 @@ func libfuse_release(path *C.char, fi *C.fuse_file_info_t) C.int {
 	err := fuseFS.NextComponent().CloseFile(internal.CloseFileOptions{Handle: handle})
 	if err != nil {
 		log.Err("Libfuse::libfuse_release : error closing file %s, handle: %d [%s]", handle.Path, handle.ID, err.Error())
-		return -C.EIO
+		if err == syscall.ENOENT {
+			return -C.ENOENT
+		} else if err == syscall.EACCES {
+			return -C.EACCES
+		} else {
+			return -C.EIO
+		}
 	}
 
 	handlemap.Delete(handle.ID)
@@ -804,6 +821,8 @@ func libfuse_unlink(path *C.char) C.int {
 		log.Err("Libfuse::libfuse_unlink : error deleting file %s [%s]", name, err.Error())
 		if os.IsNotExist(err) {
 			return -C.ENOENT
+		} else if os.IsPermission(err) {
+			return -C.EACCES
 		}
 		return -C.EIO
 	}
@@ -1006,6 +1025,8 @@ func libfuse2_chmod(path *C.char, mode C.mode_t) C.int {
 		log.Err("Libfuse::libfuse2_chmod : error in chmod of %s [%s]", name, err.Error())
 		if os.IsNotExist(err) {
 			return -C.ENOENT
+		} else if os.IsPermission(err) {
+			return -C.EACCES
 		}
 		return -C.EIO
 	}

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -361,7 +361,13 @@ func libfuse2_getattr(path *C.char, stbuf *C.stat_t) C.int {
 	attr, err := fuseFS.NextComponent().GetAttr(internal.GetAttrOptions{Name: name})
 	if err != nil {
 		//log.Err("Libfuse::libfuse2_getattr : Failed to get attributes of %s [%s]", name, err.Error())
-		return -C.ENOENT
+		if err == syscall.ENOENT {
+			return -C.ENOENT
+		} else if err == syscall.EACCES {
+			return -C.EACCES
+		} else {
+			return -C.EIO
+		}
 	}
 
 	// Populate stat

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -421,7 +421,11 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 	err := fuseFS.NextComponent().CreateDir(internal.CreateDirOptions{Name: name, Mode: fs.FileMode(uint32(mode) & 0xffffffff)})
 	if err != nil {
 		log.Err("Libfuse::libfuse_mkdir : Failed to create %s [%s]", name, err.Error())
-		return -C.EIO
+		if os.IsPermission(err) {
+			return -C.EACCES
+		} else {
+			return -C.EIO
+		}
 	}
 
 	libfuseStatsCollector.PushEvents(createDir, name, map[string]interface{}{md: fs.FileMode(uint32(mode) & 0xffffffff)})

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -392,8 +392,14 @@ func libfuse_getattr(path *C.char, stbuf *C.stat_t, fi *C.fuse_file_info_t) C.in
 	// Get attributes
 	attr, err := fuseFS.NextComponent().GetAttr(internal.GetAttrOptions{Name: name})
 	if err != nil {
-		//log.Err("Libfuse::libfuse_getattr : Failed to get attributes of %s [%s]", name, err.Error())
-		return -C.ENOENT
+		// log.Err("Libfuse::libfuse_getattr : Failed to get attributes of %s [%s]", name, err.Error())
+		if err == syscall.ENOENT {
+			return -C.ENOENT
+		} else if err == syscall.EACCES {
+			return -C.EACCES
+		} else {
+			return -C.EIO
+		}
 	}
 
 	// Populate stat


### PR DESCRIPTION
- Added error log in `newBlobfuse2HTTPClientFactory`. Fixes #1161.
- Return `C.EACCES` error from libfuse in case of AuthorizationPermissionMismatch error from azstorage.