### PR TITLE
Fixed the priority level of libfuse

### DIFF
--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -139,6 +139,10 @@ func (lf *Libfuse) SetNextComponent(nc internal.Component) {
 	lf.BaseComponent.SetNextComponent(nc)
 }
 
+func (lf *Libfuse) Priority() internal.ComponentPriority {
+	return internal.EComponentPriority.Producer()
+}
+
 // Start : Pipeline calls this method to start the component functionality
 //
 //	this shall not block the call otherwise pipeline will not start


### PR DESCRIPTION
Earlier if the config file given by the user had any other component except "libfuse" as the first component, blobfuse2 still successfully mounted the user's container. This behaviour was not desired. 
I made the required changes for libfuse to have highest priority in the component list. This will fix this issue.