### PR TITLE
Rename leaving destination file in temp-cache for ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.0.6 (WIP)
-- Fix for rename leaving destination file in local file-cache.
+- Fix to evict the destination file from local cache post rename file operation.
 
 ## 2.0.5 (2023-08-02)
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.0.6 (WIP)
+- Fix for rename leaving destination file in local file-cache.
 
 ## 2.0.5 (2023-08-02)
 **Features**

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1308,6 +1308,15 @@ func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 	}
 
 	fc.policy.CachePurge(localSrcPath)
+
+	if fc.cacheTimeout == 0 {
+		// Destination file needs to be deleted immediately
+		fc.policy.CachePurge(localDstPath)
+	} else {
+		// Add destination file to cache, it will be removed on timeout
+		fc.policy.CacheValid(localDstPath)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- As file is renamed the destination file remains in file-cache. This file is not added to LRU because it was never opened or closed hence policy will never delete this file.
- As a Fix add the destination file to policy after successful rename,