### PR TITLE
Multiple Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [#1230](https://github.com/Azure/azure-storage-fuse/issues/1230) Disable deletion of files from local-cache on sync. Use `--ignore-sync` cli option to enable this.
 - Rename API for HNS account now works with user delegation SAS
 - SAS token is redacted in logs for rename api over dfs endpoint
-- Allow user to configure custome AAD endpoint using MSI_ENPOINT environment variable for MSI based authentication
+- Allow user to configure custom AAD endpoint using MSI_ENPOINT environment variable for MSI based authentication
 
 **Optimizations**
 - Optimized file-cache to skip download when O_TRUNC flag is provided in open call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 **Bug Fixes**
 - [#1237](https://github.com/Azure/azure-storage-fuse/issues/1237) Fixed the case sensitivity of content type for file extensions.
 - [#1230](https://github.com/Azure/azure-storage-fuse/issues/1230) Disable deletion of files from local-cache on sync. Use `--ignore-sync` cli option to enable this.
+- Rename API for HNS account now works with user delegation SAS
+- SAS token is redacted in logs for rename api over dfs endpoint
+- Allow user to configure custome AAD endpoint using MSI_ENPOINT environment variable for MSI based authentication
 
 **Optimizations**
 - Optimized file-cache to skip download when O_TRUNC flag is provided in open call.

--- a/common/types.go
+++ b/common/types.go
@@ -47,7 +47,7 @@ import (
 
 // Standard config default values
 const (
-	blobfuse2Version_ = "2.1.1-preview.1"
+	blobfuse2Version_ = "2.1.1-preview.2"
 
 	DefaultMaxLogFileSize = 512
 	DefaultLogFileCount   = 10

--- a/component/azstorage/azauthmsi.go
+++ b/component/azstorage/azauthmsi.go
@@ -61,7 +61,7 @@ type azAuthMSI struct {
 }
 
 // fetchToken : Generates a token based on the config
-func (azmsi *azAuthMSI) fetchToken() (*common.OAuthTokenInfo, error) {
+func (azmsi *azAuthMSI) fetchToken(endpoint string) (*common.OAuthTokenInfo, error) {
 	// Resource string is fixed and has no relation with any of the user inputs
 	// This is not the resource URL, rather a way to identify the resource type and tenant
 	// There are two options in the structure datalake and storage but datalake is not populated
@@ -74,6 +74,7 @@ func (azmsi *azAuthMSI) fetchToken() (*common.OAuthTokenInfo, error) {
 			ClientID: azmsi.config.ApplicationID,
 			ObjectID: azmsi.config.ObjectID,
 			MSIResID: azmsi.config.ResourceID},
+		ActiveDirectoryEndpoint: endpoint,
 	}
 
 	token, err := oAuthTokenInfo.GetNewTokenFromMSI(context.Background())
@@ -177,8 +178,13 @@ func (azmsi *azAuthBlobMSI) getCredential() interface{} {
 	}
 
 	if token == nil {
-		log.Debug("azAuthBlobMSI::getCredential : Going for conventional fetchToken")
-		token, err = azmsi.fetchToken()
+		log.Debug("azAuthBlobMSI::getCredential : Going for conventional fetchToken. MSI Endpoint : %s", msi_endpoint)
+		token, err = azmsi.fetchToken(msi_endpoint)
+
+		if token == nil {
+			log.Debug("azAuthBlobMSI::getCredential : Going for conventional fetchToken without endpoint")
+			token, err = azmsi.fetchToken("")
+		}
 	}
 
 	if err != nil {
@@ -251,8 +257,13 @@ func (azmsi *azAuthBfsMSI) getCredential() interface{} {
 	}
 
 	if token == nil {
-		log.Debug("azAuthBfsMSI::getCredential : Going for conventional fetchToken")
-		token, err = azmsi.fetchToken()
+		log.Debug("azAuthBfsMSI::getCredential : Going for conventional fetchToken. MSI Endpoint : %s", msi_endpoint)
+		token, err = azmsi.fetchToken(msi_endpoint)
+
+		if token == nil {
+			log.Debug("azAuthBfsMSI::getCredential : Going for conventional fetchToken without endpoint")
+			token, err = azmsi.fetchToken("")
+		}
 	}
 
 	if err != nil {

--- a/component/loopback/loopback_fs.go
+++ b/component/loopback/loopback_fs.go
@@ -459,9 +459,6 @@ func (lfs *LoopbackFS) Chown(options internal.ChownOptions) error {
 	return os.Chown(path, options.Owner, options.Group)
 }
 
-func (lfs *LoopbackFS) InvalidateObject(_ string) {
-}
-
 func NewLoopbackFSComponent() internal.Component {
 	lfs := &LoopbackFS{}
 	lfs.SetName(compName)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.4-0.20220425205405-09e6f201e1e4
-	github.com/Azure/azure-storage-azcopy/v10 v10.19.1-0.20230717101935-ab8ff0a85e48
+	github.com/Azure/azure-storage-azcopy/v10 v10.19.1-0.20230922105010-921333dc17ce
 	github.com/Azure/azure-storage-blob-go v0.15.0
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/adal v0.9.23
@@ -87,6 +87,8 @@ require (
 )
 
 replace github.com/spf13/cobra => github.com/gapra-msft/cobra v1.4.1-0.20220411185530-5b83e8ba06dd
+
+//replace github.com/Azure/azure-storage-azcopy/v10 v10.19.1-0.20230717101935-ab8ff0a85e48 => <local path>/azure-storage-azcopy
 
 // Take AzCopy dependencyon this branch only
 // go get github.com/Azure/azure-storage-azcopy/v10@ab8ff0a85e48ea781a8051b23a05dbf4def2c17c

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/Azure/azure-pipeline-go v0.2.4-0.20220425205405-09e6f201e1e4 h1:hDJIm
 github.com/Azure/azure-pipeline-go v0.2.4-0.20220425205405-09e6f201e1e4/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-storage-azcopy/v10 v10.19.1-0.20230717101935-ab8ff0a85e48 h1:wFGbKERZQHivqPPN4foUtXpO9s8WvrsZXuUVwbDpBOY=
 github.com/Azure/azure-storage-azcopy/v10 v10.19.1-0.20230717101935-ab8ff0a85e48/go.mod h1:TUB6fvsBwrBW1S6mDQU+ecIA3JtUBOVpfGntT5bVqrc=
+github.com/Azure/azure-storage-azcopy/v10 v10.19.1-0.20230922105010-921333dc17ce h1:Zkaj43pVuQXHfzZ1OfboyQ9bWLAe/uKwZuisTft7XKg=
+github.com/Azure/azure-storage-azcopy/v10 v10.19.1-0.20230922105010-921333dc17ce/go.mod h1:TUB6fvsBwrBW1S6mDQU+ecIA3JtUBOVpfGntT5bVqrc=
 github.com/Azure/azure-storage-blob-go v0.15.0 h1:rXtgp8tN1p29GvpGgfJetavIG0V7OgcSXPpwp3tx6qk=
 github.com/Azure/azure-storage-blob-go v0.15.0/go.mod h1:vbjsVbX0dlxnRc4FFMPsS9BsJWPcne7GB7onqlPvz58=
 github.com/Azure/azure-storage-file-go v0.6.1-0.20201111053559-3c1754dc00a5 h1:aHEvBM4oXIWSTOVdL55nCYXO0Cl7ie3Ui5xMQhLVez8=

--- a/internal/base_component.go
+++ b/internal/base_component.go
@@ -310,12 +310,6 @@ func (base *BaseComponent) Chown(options ChownOptions) error {
 	return nil
 }
 
-func (base *BaseComponent) InvalidateObject(name string) {
-	if base.next != nil {
-		base.next.InvalidateObject(name)
-	}
-}
-
 func (base *BaseComponent) FileUsed(name string) error {
 	if base.next != nil {
 		return base.next.FileUsed(name)

--- a/internal/component.go
+++ b/internal/component.go
@@ -133,8 +133,6 @@ type Component interface {
 
 	Chmod(ChmodOptions) error
 	Chown(ChownOptions) error
-	//InvalidateObject: function used to clear any inode information relating to a particular fs object
-	InvalidateObject(string) // TODO: What does this do? Why do we need it if its a noop?
 	GetFileBlockOffsets(options GetFileBlockOffsetsOptions) (*common.BlockOffsetList, error)
 
 	FileUsed(name string) error

--- a/internal/mock_component.go
+++ b/internal/mock_component.go
@@ -298,18 +298,6 @@ func (mr *MockComponentMockRecorder) GetAttr(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttr", reflect.TypeOf((*MockComponent)(nil).GetAttr), arg0)
 }
 
-// InvalidateObject mocks base method.
-func (m *MockComponent) InvalidateObject(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "InvalidateObject", arg0)
-}
-
-// InvalidateObject indicates an expected call of InvalidateObject.
-func (mr *MockComponentMockRecorder) InvalidateObject(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateObject", reflect.TypeOf((*MockComponent)(nil).InvalidateObject), arg0)
-}
-
 // GetFileBlockOffsets mocks base method.
 func (m *MockComponent) GetFileBlockOffsets(arg0 GetFileBlockOffsetsOptions) (*common.BlockOffsetList, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- Refer to AzCopy private branch where
    -  Rename API works with delegation sas
    - SAS token is redacted from x-ms-rename-source header
    - msi allows custom endpoint to fetch token
- Allow user to configure custome msi-endpoint using env variable