### PR TITLE
Correcting sync to flush behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.2 (WIP)
 **Bug Fixes**
+- sync-to-flush was only setting the dirty flag, now it will force upload the file contents to container.
 
 ## 2.1.1 (2023-10-31)
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.2 (WIP)
 **Bug Fixes**
-- sync-to-flush was only setting the dirty flag, now it will force upload the file contents to container.
+- [#1259](https://github.com/Azure/azure-storage-fuse/issues/1259) sync-to-flush will force upload the file contents to container.
 
 ## 2.1.1 (2023-10-31)
 **Bug Fixes**

--- a/common/types.go
+++ b/common/types.go
@@ -47,7 +47,7 @@ import (
 
 // Standard config default values
 const (
-	blobfuse2Version_ = "2.1.2~preview.1"
+	blobfuse2Version_ = "2.1.2-preview.1"
 
 	DefaultMaxLogFileSize = 512
 	DefaultLogFileCount   = 10

--- a/common/types.go
+++ b/common/types.go
@@ -47,7 +47,7 @@ import (
 
 // Standard config default values
 const (
-	blobfuse2Version_ = "2.1.1"
+	blobfuse2Version_ = "2.1.2~preview.1"
 
 	DefaultMaxLogFileSize = 512
 	DefaultLogFileCount   = 10

--- a/common/types.go
+++ b/common/types.go
@@ -47,7 +47,7 @@ import (
 
 // Standard config default values
 const (
-	blobfuse2Version_ = "2.1.2-preview.1"
+	blobfuse2Version_ = "2.1.2"
 
 	DefaultMaxLogFileSize = 512
 	DefaultLogFileCount   = 10

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -987,13 +987,10 @@ func (fc *FileCache) CloseFile(options internal.CloseFileOptions) error {
 
 	localPath := filepath.Join(fc.tmpPath, options.Handle.Path)
 
-	if options.Handle.Dirty() {
-		log.Info("FileCache::CloseFile : name=%s, handle=%d dirty. Flushing the file.", options.Handle.Path, options.Handle.ID)
-		err := fc.FlushFile(internal.FlushFileOptions{Handle: options.Handle}) //nolint
-		if err != nil {
-			log.Err("FileCache::CloseFile : failed to flush file %s", options.Handle.Path)
-			return err
-		}
+	err := fc.FlushFile(internal.FlushFileOptions{Handle: options.Handle}) //nolint
+	if err != nil {
+		log.Err("FileCache::CloseFile : failed to flush file %s", options.Handle.Path)
+		return err
 	}
 
 	f := options.Handle.GetFileObject()
@@ -1007,7 +1004,7 @@ func (fc *FileCache) CloseFile(options internal.CloseFileOptions) error {
 	flock.Lock()
 	defer flock.Unlock()
 
-	err := f.Close()
+	err = f.Close()
 	if err != nil {
 		log.Err("FileCache::CloseFile : error closing file %s(%d) [%s]", options.Handle.Path, int(f.Fd()), err.Error())
 		return err
@@ -1136,7 +1133,11 @@ func (fc *FileCache) WriteFile(options internal.WriteFileOptions) (int, error) {
 func (fc *FileCache) SyncFile(options internal.SyncFileOptions) error {
 	log.Trace("FileCache::SyncFile : handle=%d, path=%s", options.Handle.ID, options.Handle.Path)
 	if fc.syncToFlush {
-		options.Handle.Flags.Set(handlemap.HandleFlagDirty)
+		err := fc.FlushFile(internal.FlushFileOptions{Handle: options.Handle}) //nolint
+		if err != nil {
+			log.Err("FileCache::SyncFile : failed to flush file %s", options.Handle.Path)
+			return err
+		}
 	} else if fc.syncToDelete {
 		err := fc.NextComponent().SyncFile(options)
 		if err != nil {

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -961,7 +961,7 @@ func (suite *fileCacheTestSuite) TestReadInBufferNoFlush() {
 	// Setup
 	file := "file16"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	testData := "test data1"
+	testData := "test data"
 	data := []byte(testData)
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
@@ -979,7 +979,7 @@ func (suite *fileCacheTestSuite) TestReadInBuffer() {
 	// Setup
 	file := "file17"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	testData := "test data2"
+	testData := "test data"
 	data := []byte(testData)
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 	suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
@@ -1011,7 +1011,7 @@ func (suite *fileCacheTestSuite) TestWriteFile() {
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	handle.Flags.Clear(handlemap.HandleFlagDirty) // Technically create file will mark it as dirty, we just want to check write file updates the dirty flag, so temporarily set this to false
-	testData := "test data3"
+	testData := "test data"
 	data := []byte(testData)
 	length, err := suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
@@ -1059,7 +1059,7 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 	// Setup
 	file := "file22"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	testData := "test data4"
+	testData := "test data"
 	data := []byte(testData)
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -599,7 +599,7 @@ func (suite *fileCacheTestSuite) TestRenameDir() {
 func (suite *fileCacheTestSuite) TestCreateFile() {
 	defer suite.cleanupTest()
 	// Default is to not create empty files on create file to support immutable storage.
-	path := "file"
+	path := "file1"
 	options := internal.CreateFileOptions{Name: path}
 	f, err := suite.fileCache.CreateFile(options)
 	suite.assert.Nil(err)
@@ -641,7 +641,7 @@ func (suite *fileCacheTestSuite) TestCreateFileCreateEmptyFile() {
 		suite.cache_path, createEmptyFile, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
 
-	path := "file"
+	path := "file2"
 	options := internal.CreateFileOptions{Name: path}
 	f, err := suite.fileCache.CreateFile(options)
 	suite.assert.Nil(err)
@@ -684,7 +684,7 @@ func (suite *fileCacheTestSuite) TestCreateFileInDirCreateEmptyFile() {
 
 func (suite *fileCacheTestSuite) TestSyncFile() {
 	defer suite.cleanupTest()
-	path := "file"
+	path := "file3"
 
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
@@ -723,7 +723,7 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 
 func (suite *fileCacheTestSuite) TestDeleteFile() {
 	defer suite.cleanupTest()
-	path := "file"
+	path := "file4"
 
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
@@ -744,7 +744,7 @@ func (suite *fileCacheTestSuite) TestDeleteFile() {
 func (suite *fileCacheTestSuite) TestDeleteFileCase2() {
 	defer suite.cleanupTest()
 	// Default is to not create empty files on create file to support immutable storage.
-	path := "file"
+	path := "file5"
 	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 
 	err := suite.fileCache.DeleteFile(internal.DeleteFileOptions{Name: path})
@@ -761,7 +761,7 @@ func (suite *fileCacheTestSuite) TestDeleteFileCase2() {
 
 func (suite *fileCacheTestSuite) TestDeleteFileError() {
 	defer suite.cleanupTest()
-	path := "file"
+	path := "file6"
 	err := suite.fileCache.DeleteFile(internal.DeleteFileOptions{Name: path})
 	suite.assert.NotNil(err)
 	suite.assert.EqualValues(syscall.ENOENT, err)
@@ -769,7 +769,7 @@ func (suite *fileCacheTestSuite) TestDeleteFileError() {
 
 func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 	defer suite.cleanupTest()
-	path := "file"
+	path := "file7"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	testData := "test data"
 	data := []byte(testData)
@@ -797,7 +797,7 @@ func (suite *fileCacheTestSuite) TestOpenFileNotInCache() {
 
 func (suite *fileCacheTestSuite) TestOpenFileInCache() {
 	defer suite.cleanupTest()
-	path := "file"
+	path := "file8"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	testData := "test data"
 	data := []byte(testData)
@@ -821,7 +821,7 @@ func (suite *fileCacheTestSuite) TestOpenFileInCache() {
 func (suite *fileCacheTestSuite) TestCloseFile() {
 	defer suite.cleanupTest()
 	// Default is to not create empty files on create file to support immutable storage.
-	path := "file"
+	path := "file9"
 
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	// The file is in the cache but not in storage (see TestCreateFileInDirCreateEmptyFile)
@@ -855,7 +855,7 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 		suite.cache_path, cacheTimeout, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
 
-	path := "file"
+	path := "file10"
 
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	// The file is in the cache but not in storage (see TestCreateFileInDirCreateEmptyFile)
@@ -891,7 +891,7 @@ func (suite *fileCacheTestSuite) TestCloseFileTimeout() {
 func (suite *fileCacheTestSuite) TestReadFileEmpty() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file11"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	d, err := suite.fileCache.ReadFile(internal.ReadFileOptions{Handle: handle})
@@ -902,7 +902,7 @@ func (suite *fileCacheTestSuite) TestReadFileEmpty() {
 func (suite *fileCacheTestSuite) TestReadFile() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file12"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	testData := "test data"
 	data := []byte(testData)
@@ -919,7 +919,7 @@ func (suite *fileCacheTestSuite) TestReadFile() {
 func (suite *fileCacheTestSuite) TestReadFileNoFlush() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file13"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	testData := "test data"
 	data := []byte(testData)
@@ -935,7 +935,7 @@ func (suite *fileCacheTestSuite) TestReadFileNoFlush() {
 func (suite *fileCacheTestSuite) TestReadFileErrorBadFd() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file14"
 	handle := handlemap.NewHandle(file)
 	data, err := suite.fileCache.ReadFile(internal.ReadFileOptions{Handle: handle})
 	suite.assert.NotNil(err)
@@ -946,7 +946,7 @@ func (suite *fileCacheTestSuite) TestReadFileErrorBadFd() {
 func (suite *fileCacheTestSuite) TestReadInBufferEmpty() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file15"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	data := make([]byte, 0)
@@ -959,9 +959,9 @@ func (suite *fileCacheTestSuite) TestReadInBufferEmpty() {
 func (suite *fileCacheTestSuite) TestReadInBufferNoFlush() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file16"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	testData := "test data"
+	testData := "test data1"
 	data := []byte(testData)
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
@@ -977,9 +977,9 @@ func (suite *fileCacheTestSuite) TestReadInBufferNoFlush() {
 func (suite *fileCacheTestSuite) TestReadInBuffer() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file17"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	testData := "test data"
+	testData := "test data2"
 	data := []byte(testData)
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 	suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
@@ -996,7 +996,7 @@ func (suite *fileCacheTestSuite) TestReadInBuffer() {
 func (suite *fileCacheTestSuite) TestReadInBufferErrorBadFd() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file18"
 	handle := handlemap.NewHandle(file)
 	length, err := suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle})
 	suite.assert.NotNil(err)
@@ -1007,11 +1007,11 @@ func (suite *fileCacheTestSuite) TestReadInBufferErrorBadFd() {
 func (suite *fileCacheTestSuite) TestWriteFile() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file19"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	handle.Flags.Clear(handlemap.HandleFlagDirty) // Technically create file will mark it as dirty, we just want to check write file updates the dirty flag, so temporarily set this to false
-	testData := "test data"
+	testData := "test data3"
 	data := []byte(testData)
 	length, err := suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
@@ -1026,7 +1026,7 @@ func (suite *fileCacheTestSuite) TestWriteFile() {
 func (suite *fileCacheTestSuite) TestWriteFileErrorBadFd() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file20"
 	handle := handlemap.NewHandle(file)
 	len, err := suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle})
 	suite.assert.NotNil(err)
@@ -1037,7 +1037,7 @@ func (suite *fileCacheTestSuite) TestWriteFileErrorBadFd() {
 func (suite *fileCacheTestSuite) TestFlushFileEmpty() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file21"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	// Path should not be in fake storage
@@ -1057,9 +1057,9 @@ func (suite *fileCacheTestSuite) TestFlushFileEmpty() {
 func (suite *fileCacheTestSuite) TestFlushFile() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file22"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	testData := "test data"
+	testData := "test data4"
 	data := []byte(testData)
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
 
@@ -1083,7 +1083,7 @@ func (suite *fileCacheTestSuite) TestFlushFile() {
 func (suite *fileCacheTestSuite) TestFlushFileErrorBadFd() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file23"
 	handle := handlemap.NewHandle(file)
 	handle.Flags.Set(handlemap.HandleFlagDirty)
 	err := suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
@@ -1094,7 +1094,7 @@ func (suite *fileCacheTestSuite) TestFlushFileErrorBadFd() {
 func (suite *fileCacheTestSuite) TestGetAttrCase1() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file24"
 	// Create files directly in "fake_storage"
 	suite.loopback.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
@@ -1108,7 +1108,7 @@ func (suite *fileCacheTestSuite) TestGetAttrCase1() {
 func (suite *fileCacheTestSuite) TestGetAttrCase2() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file25"
 	// By default createEmptyFile is false, so we will not create these files in storage until they are closed.
 	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
@@ -1122,7 +1122,7 @@ func (suite *fileCacheTestSuite) TestGetAttrCase2() {
 func (suite *fileCacheTestSuite) TestGetAttrCase3() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file26"
 	// By default createEmptyFile is false, so we will not create these files in storage until they are closed.
 	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	suite.fileCache.TruncateFile(internal.TruncateFileOptions{Name: file, Size: 1024})
@@ -1140,7 +1140,7 @@ func (suite *fileCacheTestSuite) TestGetAttrCase3() {
 func (suite *fileCacheTestSuite) TestGetAttrCase4() {
 	defer suite.cleanupTest()
 	// Setup
-	file := "file"
+	file := "file27"
 	// By default createEmptyFile is false, so we will not create these files in storage until they are closed.
 	createHandle, err := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	suite.assert.Nil(err)
@@ -1191,8 +1191,8 @@ func (suite *fileCacheTestSuite) TestGetAttrCase4() {
 func (suite *fileCacheTestSuite) TestRenameFileNotInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	src := "source"
-	dst := "destination"
+	src := "source1"
+	dst := "destination1"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
@@ -1221,8 +1221,8 @@ func (suite *fileCacheTestSuite) TestRenameFileNotInCache() {
 func (suite *fileCacheTestSuite) TestRenameFileInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	src := "source"
-	dst := "destination"
+	src := "source2"
+	dst := "destination2"
 	createHandle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0666})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: createHandle})
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
@@ -1253,8 +1253,8 @@ func (suite *fileCacheTestSuite) TestRenameFileInCache() {
 func (suite *fileCacheTestSuite) TestRenameFileCase2() {
 	defer suite.cleanupTest()
 	// Default is to not create empty files on create file to support immutable storage.
-	src := "source"
-	dst := "destination"
+	src := "source3"
+	dst := "destination3"
 	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0777})
 
 	err := suite.fileCache.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst})
@@ -1280,8 +1280,8 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanup() {
 		suite.cache_path, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
 
-	src := "source1"
-	dst := "destination2"
+	src := "source4"
+	dst := "destination4"
 	createHandle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0666})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: createHandle})
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
@@ -1325,8 +1325,8 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 		suite.cache_path, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
 
-	src := "source1"
-	dst := "destination2"
+	src := "source5"
+	dst := "destination5"
 	createHandle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: src, Mode: 0666})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: createHandle})
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: src, Mode: 0666})
@@ -1361,7 +1361,7 @@ func (suite *fileCacheTestSuite) TestRenameFileAndCacheCleanupWithNoTimeout() {
 func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	path := "file"
+	path := "file30"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
@@ -1389,7 +1389,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileNotInCache() {
 func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	path := "file"
+	path := "file31"
 	createHandle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0666})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: createHandle})
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0666})
@@ -1417,7 +1417,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileInCache() {
 func (suite *fileCacheTestSuite) TestTruncateFileCase2() {
 	defer suite.cleanupTest()
 	// Default is to not create empty files on create file to support immutable storage.
-	path := "file"
+	path := "file32"
 	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0666})
 
 	size := 1024
@@ -1438,7 +1438,7 @@ func (suite *fileCacheTestSuite) TestTruncateFileCase2() {
 func (suite *fileCacheTestSuite) TestChmodNotInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	path := "file"
+	path := "file33"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
@@ -1465,7 +1465,7 @@ func (suite *fileCacheTestSuite) TestChmodNotInCache() {
 func (suite *fileCacheTestSuite) TestChmodInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	path := "file"
+	path := "file34"
 	createHandle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0666})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: createHandle})
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0666})
@@ -1492,7 +1492,7 @@ func (suite *fileCacheTestSuite) TestChmodInCache() {
 func (suite *fileCacheTestSuite) TestChmodCase2() {
 	defer suite.cleanupTest()
 	// Default is to not create empty files on create file to support immutable storage.
-	path := "file"
+	path := "file35"
 	oldMode := os.FileMode(0511)
 
 	createHandle, err := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: oldMode})
@@ -1532,7 +1532,7 @@ func (suite *fileCacheTestSuite) TestChmodCase2() {
 func (suite *fileCacheTestSuite) TestChownNotInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	path := "file"
+	path := "file36"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 
@@ -1564,7 +1564,7 @@ func (suite *fileCacheTestSuite) TestChownNotInCache() {
 func (suite *fileCacheTestSuite) TestChownInCache() {
 	defer suite.cleanupTest()
 	// Setup
-	path := "file"
+	path := "file37"
 	createHandle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: createHandle})
 	openHandle, _ := suite.fileCache.OpenFile(internal.OpenFileOptions{Name: path, Mode: 0777})
@@ -1599,7 +1599,7 @@ func (suite *fileCacheTestSuite) TestChownInCache() {
 func (suite *fileCacheTestSuite) TestChownCase2() {
 	defer suite.cleanupTest()
 	// Default is to not create empty files on create file to support immutable storage.
-	path := "file"
+	path := "file38"
 	oldMode := os.FileMode(0511)
 	suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: oldMode})
 	info, _ := os.Stat(suite.cache_path + "/" + path)
@@ -1653,7 +1653,7 @@ func (suite *fileCacheTestSuite) TestCachePathSymlink() {
 		symlinkPath, suite.fake_storage_path)
 	suite.setupTestHelper(configuration)
 
-	file := "file"
+	file := "file39"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	testData := "test data"
 	data := []byte(testData)
@@ -1674,7 +1674,7 @@ func (suite *fileCacheTestSuite) TestZZOffloadIO() {
 
 	suite.setupTestHelper(configuration)
 
-	file := "file"
+	file := "file40"
 	handle, err := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	suite.assert.Nil(err)
 	suite.assert.NotNil(handle)
@@ -1692,7 +1692,7 @@ func (suite *fileCacheTestSuite) TestStatFS() {
 	os.Mkdir(suite.cache_path, 0777)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
 
-	file := "file"
+	file := "file41"
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	data := make([]byte, 1024*1024)
 	suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
@@ -1711,7 +1711,7 @@ func (suite *fileCacheTestSuite) TestReadFileWithRefresh() {
 		suite.cache_path, createEmptyFile, suite.fake_storage_path)
 	suite.setupTestHelper(config) // setup a new file cache with a custom config (teardown will occur after the test as usual)
 
-	path := "file"
+	path := "file42"
 	err := os.WriteFile(suite.fake_storage_path+"/"+path, []byte("test data"), 0777)
 	suite.assert.Nil(err)
 

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -703,6 +703,22 @@ func (suite *fileCacheTestSuite) TestSyncFile() {
 	// Path should not be in file cache
 	_, err = os.Stat(suite.cache_path + "/" + path)
 	suite.assert.True(os.IsNotExist(err))
+
+	path = "file.fsync"
+	suite.fileCache.syncToFlush = true
+	handle, err = suite.fileCache.CreateFile(internal.CreateFileOptions{Name: path, Mode: 0777})
+	suite.assert.Nil(err)
+	_, err = suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
+	suite.assert.Nil(err)
+	suite.assert.Equal(handle.Dirty(), true)
+	err = suite.fileCache.SyncFile(internal.SyncFileOptions{Handle: handle})
+	suite.assert.Nil(err)
+	suite.assert.Equal(handle.Dirty(), false)
+	_, err = os.Stat(suite.fake_storage_path + "/" + path)
+	suite.assert.True(err == nil || os.IsExist(err))
+
+	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
+	suite.fileCache.syncToFlush = false
 }
 
 func (suite *fileCacheTestSuite) TestDeleteFile() {

--- a/test/scripts/fsync_sample.c
+++ b/test/scripts/fsync_sample.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+   char *data = "Testing fsync method";
+   int file, r;
+
+   file = creat("/usr/blob_mnt/fsync.txt", S_IWUSR | S_IRUSR);
+   if (file < -1) {
+      perror("creat()");
+      exit(1); 
+   }
+
+   r = write(file, data, strlen(data));
+   if(r < -1) {
+      perror("write()");
+      exit(1); 
+   }
+   
+   fsync(file);
+   close(file);
+   
+   return 0;
+}


### PR DESCRIPTION
sync-to-flush flag is suppose to fore upload a file to container. In previous fix it was just setting the dirty flag, which will upload the file only on close. Corrected the code to force upload the file on sync itself.