### PR TITLE
Attribute cache invalidation on PathAlreadyExists error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3 (Unreleased)
+**Bug Fixes**
+- Invalidate attribute cache entry on `PathAlreadyExists` error in create directory operation.
+
 ## 2.1.2 (2023-11-17)
 **Bug Fixes**
 - [#1243](https://github.com/Azure/azure-storage-fuse/issues/1243) Fixed issue where symlink was not working for ADLS accounts.

--- a/common/types.go
+++ b/common/types.go
@@ -47,7 +47,7 @@ import (
 
 // Standard config default values
 const (
-	blobfuse2Version_ = "2.1.2"
+	blobfuse2Version_ = "2.1.3"
 
 	DefaultMaxLogFileSize = 512
 	DefaultLogFileCount   = 10

--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -232,7 +232,7 @@ func (ac *AttrCache) CreateDir(options internal.CreateDirOptions) error {
 	log.Trace("AttrCache::CreateDir : %s", options.Name)
 	err := ac.NextComponent().CreateDir(options)
 
-	if err == nil {
+	if err == nil || err == syscall.EEXIST {
 		ac.cacheLock.RLock()
 		defer ac.cacheLock.RUnlock()
 		ac.invalidatePath(options.Name)

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -270,6 +270,9 @@ func (dl *Datalake) CreateDirectory(name string) error {
 		if serr == InvalidPermission {
 			log.Err("Datalake::CreateDirectory : Insufficient permissions for %s [%s]", name, err.Error())
 			return syscall.EACCES
+		} else if serr == ErrFileAlreadyExists {
+			log.Err("Datalake::CreateDirectory : Path already exists for %s [%s]", name, err.Error())
+			return syscall.EEXIST
 		} else {
 			log.Err("Datalake::CreateDirectory : Failed to create directory %s [%s]", name, err.Error())
 			return err

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -430,6 +430,8 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 		log.Err("Libfuse::libfuse2_mkdir : Failed to create %s [%s]", name, err.Error())
 		if os.IsPermission(err) {
 			return -C.EACCES
+		} else if os.IsExist(err) {
+			return -C.EEXIST
 		} else {
 			return -C.EIO
 		}

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -436,6 +436,8 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 		log.Err("Libfuse::libfuse_mkdir : Failed to create %s [%s]", name, err.Error())
 		if os.IsPermission(err) {
 			return -C.EACCES
+		} else if os.IsExist(err) {
+			return -C.EEXIST
 		} else {
 			return -C.EIO
 		}


### PR DESCRIPTION
- Get stat of a directory not present in the storage account
- Create the directory using Azure portal
- Run mkdir command -> Attribute cache will now invalidate the entry of the directory if it gets `PathAlreadyExists` error
- Create file inside the directory

**NOTE:** When directory is created using some other process (not blobfuse), then `negative-entry-expiration-sec` parameter in libfuse component must be set to 0 to disable kernel caching.