### PR TITLE
Enhancement: Adding CPK support 

### DIFF
--- a/component/azstorage/azauth_test.go
+++ b/component/azstorage/azauth_test.go
@@ -67,14 +67,17 @@ type storageTestConfiguration struct {
 	AdlsSas            string `json:"adls-sas"`
 	// AdlsDirSasUbn18    string `json:"adls-dir-sas-ubn-18"`
 	// AdlsDirSasUbn20    string `json:"adls-dir-sas-ubn-20"`
-	MsiAppId        string `json:"msi-appid"`
-	MsiResId        string `json:"msi-resid"`
-	MsiObjId        string `json:"msi-objid"`
-	SpnClientId     string `json:"spn-client"`
-	SpnTenantId     string `json:"spn-tenant"`
-	SpnClientSecret string `json:"spn-secret"`
-	SkipMsi         bool   `json:"skip-msi"`
-	ProxyAddress    string `json:"proxy-address"`
+	MsiAppId               string `json:"msi-appid"`
+	MsiResId               string `json:"msi-resid"`
+	MsiObjId               string `json:"msi-objid"`
+	SpnClientId            string `json:"spn-client"`
+	SpnTenantId            string `json:"spn-tenant"`
+	SpnClientSecret        string `json:"spn-secret"`
+	SkipMsi                bool   `json:"skip-msi"`
+	ProxyAddress           string `json:"proxy-address"`
+	CPKEnabled             bool   `json:"cpk-enabled"`
+	CPKEncryptionKey       string `json:"cpk-encryption-key"`
+	CPKEncryptionKeySha256 string `json:"cpk-encryption-key-sha256"`
 }
 
 var storageTestConfigurationParameters storageTestConfiguration

--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -644,6 +644,9 @@ func init() {
 	config.BindPFlag(compName+".honour-acl", honourACL)
 	honourACL.Hidden = true
 
+	cpkEnabled := config.AddBoolFlag("cpk-enabled", false, "Enable client provided key.")
+	config.BindPFlag(compName+".cpk-enabled", cpkEnabled)
+
 	config.RegisterFlagCompletionFunc("container-name", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -85,11 +85,16 @@ func (bb *BlockBlob) Configure(cfg AzStorageConfig) error {
 	bb.Config = cfg
 
 	bb.blobAccCond = azblob.BlobAccessConditions{}
-	bb.blobCPKOpt = azblob.ClientProvidedKeyOptions{}
+	bb.blobCPKOpt = azblob.ClientProvidedKeyOptions{
+		EncryptionKey:       &bb.Config.cpkEncryptionKey,
+		EncryptionKeySha256: &bb.Config.cpkEncryptionKeySha256,
+		EncryptionAlgorithm: "AES256",
+	}
 
 	bb.downloadOptions = azblob.DownloadFromBlobOptions{
-		BlockSize:   bb.Config.blockSize,
-		Parallelism: bb.Config.maxConcurrency,
+		BlockSize:                bb.Config.blockSize,
+		Parallelism:              bb.Config.maxConcurrency,
+		ClientProvidedKeyOptions: bb.blobCPKOpt,
 	}
 
 	bb.listDetails = azblob.BlobListingDetails{
@@ -889,6 +894,7 @@ func (bb *BlockBlob) WriteFromFile(name string, metadata map[string]string, fi *
 			ContentType: getContentType(name),
 			ContentMD5:  md5sum,
 		},
+		ClientProvidedKeyOptions: bb.blobCPKOpt,
 	}
 	if common.MonitorBfs() && stat.Size() > 0 {
 		uploadOptions.Progress = func(bytesTransferred int64) {
@@ -936,6 +942,7 @@ func (bb *BlockBlob) WriteFromBuffer(name string, metadata map[string]string, da
 		BlobHTTPHeaders: azblob.BlobHTTPHeaders{
 			ContentType: getContentType(name),
 		},
+		ClientProvidedKeyOptions: bb.blobCPKOpt,
 	})
 
 	if err != nil {

--- a/component/azstorage/connection.go
+++ b/component/azstorage/connection.go
@@ -80,6 +80,11 @@ type AzStorageConfig struct {
 	telemetry      string
 	honourACL      bool
 	disableSymlink bool
+
+	// CPK related config
+	cpkEnabled             bool
+	cpkEncryptionKey       string
+	cpkEncryptionKeySha256 string
 }
 
 type AzStorageConnection struct {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/montanaflynn/stats v0.7.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+	github.com/pkg/errors v0.9.1
 	github.com/radovskyb/watcher v1.0.7
 	github.com/sevlyar/go-daemon v0.1.6
 	github.com/spf13/cobra v1.8.0
@@ -58,7 +59,6 @@ require (
 	github.com/minio/minio-go v6.0.14+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -167,7 +167,10 @@ azstorage:
   max-results-for-list: <maximum number of results returned in a single list API call while getting file attributes. Default - 2>
   telemetry : <additional information that customer want to push in user-agent>
   honour-acl: true|false <honour ACLs on files and directories when mounted using MSI Auth and object-ID is provided in config>
-  
+  cpk-enabled: true|false <enable client provided key encryption>
+  cpk-encryption-key: <customer provided base64-encoded AES-256 encryption key value>
+  cpk-encryption-key-sha256:  <customer provided base64-encoded sha256 of the encryption key>
+
 # Mount all configuration
 mountall:
   # allowlist takes precedence over denylist in case of conflicts


### PR DESCRIPTION
- Allows support of mounting containers with CPK. 
- Usage : --cpk-enabled=true flag with CPK_ENCRYPTION_KEY and CPK_ENCRYPTION_KEY_SHA256 set in environment variable or config file.  
Note: This change does not affect HNS accounts. 