### PR TITLE
Make logging of credentials in azauthmsi.go and azauthspn.go consistent

### DIFF
--- a/component/azstorage/azauthmsi.go
+++ b/component/azstorage/azauthmsi.go
@@ -122,7 +122,8 @@ func (azmsi *azAuthMSI) fetchTokenFromCLI() (*common.OAuthTokenInfo, error) {
 		return nil, fmt.Errorf(msg)
 	}
 
-	log.Info("azAuthMSI::fetchTokenFromCLI : Successfully fetched token from Azure CLI : %s", output)
+	log.Info("azAuthMSI::fetchTokenFromCLI : Successfully fetched token from Azure CLI")
+	log.Debug("azAuthMSI::fetchTokenFromCLI : Token: %s", output)
 	t := struct {
 		AccessToken      string `json:"accessToken"`
 		Authority        string `json:"_authority"`
@@ -201,7 +202,8 @@ func (azmsi *azAuthBlobMSI) getCredential() interface{} {
 
 	var tc azblob.TokenCredential
 	if norefresh {
-		log.Info("azAuthBlobMSI::getCredential : MSI Token over CLI retrieved %s (%d)", token.AccessToken, token.Expires())
+		log.Info("azAuthBlobMSI::getCredential : MSI Token over CLI retrieved")
+		log.Debug("azAuthBlobMSI::getCredential : Token: %s (%s)", token.AccessToken, token.Expires())
 		// We are running in cli mode so token can not be refreshed, on expiry just get the new token
 		tc = azblob.NewTokenCredential(token.AccessToken, func(tc azblob.TokenCredential) time.Duration {
 			for failCount := 0; failCount < 5; failCount++ {
@@ -214,7 +216,8 @@ func (azmsi *azAuthBlobMSI) getCredential() interface{} {
 
 				// set the new token value
 				tc.SetToken(newToken.AccessToken)
-				log.Debug("azAuthBlobMSI::getCredential : MSI Token retrieved %s (%d)", newToken.AccessToken, newToken.Expires())
+				log.Info("azAuthBlobMSI::getCredential : New MSI Token over CLI retrieved")
+				log.Debug("azAuthBlobMSI::getCredential : New Token: %s (%s)", newToken.AccessToken, newToken.Expires())
 
 				// Get the next token slightly before the current one expires
 				return getNextExpiryTimer(&newToken.Token)
@@ -224,7 +227,8 @@ func (azmsi *azAuthBlobMSI) getCredential() interface{} {
 			return 0
 		})
 	} else {
-		log.Info("azAuthBlobMSI::getCredential : MSI Token retrieved %s (%d)", token.AccessToken, token.Expires())
+		log.Info("azAuthBlobMSI::getCredential : MSI Token retrieved")
+		log.Debug("azAuthBlobMSI::getCredential : Token: %s (%s)", token.AccessToken, token.Expires())
 		// Using token create the credential object, here also register a call back which refreshes the token
 		tc = azblob.NewTokenCredential(token.AccessToken, func(tc azblob.TokenCredential) time.Duration {
 			// token, err := azmsi.fetchToken(msi_endpoint)
@@ -242,7 +246,8 @@ func (azmsi *azAuthBlobMSI) getCredential() interface{} {
 
 				// set the new token value
 				tc.SetToken(newToken.AccessToken)
-				log.Debug("azAuthBlobMSI::getCredential : MSI Token retrieved %s (%d)", newToken.AccessToken, newToken.Expires())
+				log.Info("azAuthBlobMSI::getCredential : New MSI Token retrieved")
+				log.Debug("azAuthBlobMSI::getCredential : New Token: %s (%s)", newToken.AccessToken, newToken.Expires())
 
 				// Get the next token slightly before the current one expires
 				return getNextExpiryTimer(newToken)
@@ -296,7 +301,8 @@ func (azmsi *azAuthBfsMSI) getCredential() interface{} {
 
 	var tc azbfs.TokenCredential
 	if norefresh {
-		log.Info("azAuthBfsMSI::getCredential : MSI Token over CLI retrieved %s (%d)", token.AccessToken, token.Expires())
+		log.Info("azAuthBfsMSI::getCredential : MSI Token over CLI retrieved")
+		log.Debug("azAuthBfsMSI::getCredential : Token: %s (%s)", token.AccessToken, token.Expires())
 		// We are running in cli mode so token can not be refreshed, on expiry just get the new token
 		tc = azbfs.NewTokenCredential(token.AccessToken, func(tc azbfs.TokenCredential) time.Duration {
 			for failCount := 0; failCount < 5; failCount++ {
@@ -309,7 +315,8 @@ func (azmsi *azAuthBfsMSI) getCredential() interface{} {
 
 				// set the new token value
 				tc.SetToken(newToken.AccessToken)
-				log.Debug("azAuthBfsMSI::getCredential : MSI Token retrieved %s (%d)", newToken.AccessToken, newToken.Expires())
+				log.Info("azAuthBfsMSI::getCredential : New MSI Token over CLI retrieved")
+				log.Debug("azAuthBfsMSI::getCredential : New Token: %s (%s)", newToken.AccessToken, newToken.Expires())
 
 				// Get the next token slightly before the current one expires
 				return getNextExpiryTimer(&newToken.Token)
@@ -318,7 +325,8 @@ func (azmsi *azAuthBfsMSI) getCredential() interface{} {
 			return 0
 		})
 	} else {
-		log.Info("azAuthBfsMSI::getCredential : MSI Token retrieved %s (%d)", token.AccessToken, token.Expires())
+		log.Info("azAuthBfsMSI::getCredential : MSI Token retrieved")
+		log.Debug("azAuthBfsMSI::getCredential : Token: %s (%s)", token.AccessToken, token.Expires())
 		// Using token create the credential object, here also register a call back which refreshes the token
 		tc = azbfs.NewTokenCredential(token.AccessToken, func(tc azbfs.TokenCredential) time.Duration {
 			// token, err := azmsi.fetchToken(msi_endpoint)
@@ -336,7 +344,8 @@ func (azmsi *azAuthBfsMSI) getCredential() interface{} {
 
 				// set the new token value
 				tc.SetToken(newToken.AccessToken)
-				log.Debug("azAuthBfsMSI::getCredential : MSI Token retrieved %s (%d)", newToken.AccessToken, newToken.Expires())
+				log.Info("azAuthBfsMSI::getCredential : New MSI Token retrieved")
+				log.Debug("azAuthBfsMSI::getCredential : New Token: %s (%s)", newToken.AccessToken, newToken.Expires())
 
 				// Get the next token slightly before the current one expires
 				return getNextExpiryTimer(newToken)

--- a/component/azstorage/azauthspn.go
+++ b/component/azstorage/azauthspn.go
@@ -141,7 +141,8 @@ func (azspn *azAuthBlobSPN) getCredential() interface{} {
 
 			// set the new token value
 			tc.SetToken(spt.Token().AccessToken)
-			log.Debug("azAuthBlobSPN::getCredential : SPN Token retrieved %s (%d)", spt.Token().AccessToken, spt.Token().Expires())
+			log.Info("azAuthBlobSPN::getCredential : SPN Token retrieved")
+			log.Debug("azAuthBlobSPN::getCredential : Token: %s (%s)", spt.Token().AccessToken, spt.Token().Expires())
 
 			// Get the next token slightly before the current one expires
 			return getNextExpiryTimerSPN(spt)
@@ -186,7 +187,8 @@ func (azspn *azAuthBfsSPN) getCredential() interface{} {
 
 			// set the new token value
 			tc.SetToken(spt.Token().AccessToken)
-			log.Debug("azAuthBfsSPN::getCredential : SPN Token retrieved %s (%d)", spt.Token().AccessToken, spt.Token().Expires())
+			log.Info("azAuthBfsSPN::getCredential : SPN Token retrieved")
+			log.Debug("azAuthBfsSPN::getCredential : Token: %s (%s)", spt.Token().AccessToken, spt.Token().Expires())
 
 			// Get the next token slightly before the current one expires
 			return getNextExpiryTimerSPN(spt)


### PR DESCRIPTION
Currently the code in `component/azstorage/azauthmsi.go` logs sensitive data such as access tokens in the `log.Info` level, which can lead to sensitive data being present in the logs.

As having the access tokens can be useful for debugging, I'd like to propose this format, where the information that the token was successfully retrieved is logged in the `Info` level, but the token itself only in the `Debug` level.