### PR TITLE
Track2 Migration: Enable SDK logging on debug mode

### DIFF
--- a/TSG.md
+++ b/TSG.md
@@ -3,8 +3,6 @@
 Please ensure logging is turned on DEBUG mode when trying to reproduce an issue.
 This can help in many instances to understand what the underlying issue is.
 
-A useful setting in your configuration file to utilize when debugging is `sdk-trace: true` under the azstorage component. This will log all outgoing REST calls.
-
 # BlobFuse2 Health Monitor
 
 One of the biggest BlobFuse2 features is our brand new health monitor. It allows customers gain more insight into how their BlobFuse2 instance is behaving with the rest of their machine. Visit [here](https://github.com/Azure/azure-storage-fuse/blob/main/tools/health-monitor/README.md) to set it up.

--- a/component/azstorage/azauth.go
+++ b/component/azstorage/azauth.go
@@ -184,7 +184,8 @@ func (base *azOAuthBase) getAzIdentityClientOptions(config *azAuthConfig) azcore
 		return azcore.ClientOptions{}
 	}
 	opts := azcore.ClientOptions{
-		Cloud: getCloudConfiguration(config.Endpoint),
+		Cloud:   getCloudConfiguration(config.Endpoint),
+		Logging: getSDKLogOptions(),
 	}
 
 	if config.ActiveDirectoryEndpoint != "" {

--- a/component/azstorage/azauthspn.go
+++ b/component/azstorage/azauthspn.go
@@ -58,6 +58,7 @@ func (azspn *azAuthSPN) getTokenCredential() (azcore.TokenCredential, error) {
 	if azspn.config.OAuthTokenFilePath != "" {
 		log.Trace("AzAuthSPN::getTokenCredential : Going for fedrated token flow")
 
+		// TODO:: track2 : test this in AKS setup
 		cred, err = azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
 			ClientOptions: clOpts,
 			ClientID:      azspn.config.ClientID,

--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -143,7 +143,7 @@ func (az *AzStorage) configureAndTest(isParent bool) error {
 	}
 
 	// set SDK log listener to log the requests and responses
-	setSDKLogListener(az.stConfig.sdkTrace)
+	setSDKLogListener()
 
 	err = az.storage.SetPrefixPath(az.stConfig.prefixPath)
 	if err != nil {

--- a/component/azstorage/azstorage_constants.go
+++ b/component/azstorage/azstorage_constants.go
@@ -73,4 +73,5 @@ var allowedHeaders []string = []string{
 var allowedQueryParams []string = []string{
 	"comp", "delimiter", "include", "marker", "maxresults", "prefix", "restype", "blockid", "blocklisttype",
 	"directory", "recursive", "resource", "se", "sp", "spr", "srt", "ss", "st", "sv", "action", "continuation", "mode",
+	"client_id", "authorization_endpoint",
 }

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -170,7 +170,6 @@ type AzStorageOptions struct {
 	MaxRetryDelay           int32  `config:"max-retry-delay-sec" yaml:"max-retry-delay-sec,omitempty"`
 	HttpProxyAddress        string `config:"http-proxy" yaml:"http-proxy,omitempty"`
 	HttpsProxyAddress       string `config:"https-proxy" yaml:"https-proxy,omitempty"`
-	SdkTrace                bool   `config:"sdk-trace" yaml:"sdk-trace,omitempty"`
 	FailUnsupportedOp       bool   `config:"fail-unsupported-op" yaml:"fail-unsupported-op,omitempty"`
 	AuthResourceString      string `config:"auth-resource" yaml:"auth-resource,omitempty"`
 	UpdateMD5               bool   `config:"update-md5" yaml:"update-md5"`
@@ -405,10 +404,6 @@ func ParseAndValidateConfig(az *AzStorage, opt AzStorageOptions) error {
 		}
 	}
 	log.Info("ParseAndValidateConfig : using the following proxy address from the config file: %s", az.stConfig.proxyAddress)
-
-	az.stConfig.sdkTrace = opt.SdkTrace
-
-	log.Info("ParseAndValidateConfig : sdk logging from the config file: %t", az.stConfig.sdkTrace)
 
 	err = ParseAndReadDynamicConfig(az, opt, false)
 	if err != nil {

--- a/component/azstorage/connection.go
+++ b/component/azstorage/connection.go
@@ -64,7 +64,6 @@ type AzStorageConfig struct {
 	backoffTime           int32
 	maxRetryDelay         int32
 	proxyAddress          string
-	sdkTrace              bool
 	ignoreAccessModifiers bool
 	mountAllContainers    bool
 

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -140,16 +140,15 @@ func getSDKLogOptions() policy.LogOptions {
 // setSDKLogListener : log the requests and responses.
 // It is disabled if,
 //   - logging type is silent
-//   - sdk-trace is false
 //   - logging level is less than debug
-func setSDKLogListener(sdkLogging bool) {
+func setSDKLogListener() {
 	// TODO:: track2 : set/reset listener on dynamic config change
-	if log.GetType() == "silent" || !sdkLogging || log.GetLogLevel() < common.ELogLevel.LOG_DEBUG() {
+	if log.GetType() == "silent" || log.GetLogLevel() < common.ELogLevel.LOG_DEBUG() {
 		// reset listener
 		azlog.SetListener(nil)
 	} else {
 		azlog.SetListener(func(cls azlog.Event, msg string) {
-			log.Debug("SDK : %s", msg)
+			log.Debug("SDK(%s) : %s", cls, msg)
 		})
 	}
 }

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -126,7 +126,7 @@ func getAzDatalakeServiceClientOptions(conf *AzStorageConfig) *serviceBfs.Client
 
 // getLogOptions : to configure the SDK logging policy
 func getSDKLogOptions() policy.LogOptions {
-	if log.GetType() == "silent" {
+	if log.GetType() == "silent" || log.GetLogLevel() < common.ELogLevel.LOG_DEBUG() {
 		return policy.LogOptions{}
 	} else {
 		// TODO:: track2 : check which headers and query params should not be redacted

--- a/setup/baseConfig.yaml
+++ b/setup/baseConfig.yaml
@@ -157,7 +157,6 @@ azstorage:
   max-retry-delay-sec: <maximum delay between two tries (in sec). Default - 60 sec>
   http-proxy: ip-address:port <http proxy to be used for connection>
   https-proxy: ip-address:port <https proxy to be used for connection>
-  sdk-trace: true|false <enable storage sdk logging>
   fail-unsupported-op: true|false <for block blob account return failure for unsupported operations like chmod and chown>
   auth-resource: <resource string to be used during OAuth token retrieval>
   update-md5: true|false <set md5 sum on upload. Impacts performance. works only when file-cache component is part of the pipeline>

--- a/testdata/config/azure_block_perf.yaml
+++ b/testdata/config/azure_block_perf.yaml
@@ -35,6 +35,5 @@ azstorage:
   account-key: { NIGHTLY_STO_ACC_KEY }
   mode: key
   container: { 0 }
-  sdk-trace: false
   block-list-on-mount-sec: 10
   ignore-access-modify: true

--- a/testdata/config/azure_key.yaml
+++ b/testdata/config/azure_key.yaml
@@ -34,4 +34,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_bc.yaml
+++ b/testdata/config/azure_key_bc.yaml
@@ -38,4 +38,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_directio.yaml
+++ b/testdata/config/azure_key_directio.yaml
@@ -31,4 +31,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_emptyfile.yaml
+++ b/testdata/config/azure_key_emptyfile.yaml
@@ -35,4 +35,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_hmon.yaml
+++ b/testdata/config/azure_key_hmon.yaml
@@ -34,7 +34,6 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }
 
 health_monitor:
   enable-monitoring: true

--- a/testdata/config/azure_key_huge.yaml
+++ b/testdata/config/azure_key_huge.yaml
@@ -37,4 +37,3 @@ azstorage:
   container: { 0 }
   tier: hot
   block-list-on-mount-sec: 7
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_lfu.yaml
+++ b/testdata/config/azure_key_lfu.yaml
@@ -34,4 +34,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_lru_purge.yaml
+++ b/testdata/config/azure_key_lru_purge.yaml
@@ -33,4 +33,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_perf.yaml
+++ b/testdata/config/azure_key_perf.yaml
@@ -34,6 +34,5 @@ azstorage:
   account-key: { NIGHTLY_STO_ACC_KEY }
   mode: key
   container: { 0 }
-  sdk-trace: false
   block-list-on-mount-sec: 10
   ignore-access-modify: true

--- a/testdata/config/azure_key_proxy.yaml
+++ b/testdata/config/azure_key_proxy.yaml
@@ -35,4 +35,3 @@ azstorage:
   container: { 0 }
   tier: hot
   https-proxy: 127.0.0.1:8080
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_key_symlink.yaml
+++ b/testdata/config/azure_key_symlink.yaml
@@ -35,4 +35,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_msi.yaml
+++ b/testdata/config/azure_msi.yaml
@@ -34,4 +34,3 @@ azstorage:
   mode: msi
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_msi_sysid.yaml
+++ b/testdata/config/azure_msi_sysid.yaml
@@ -31,4 +31,3 @@ azstorage:
   mode: msi
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_sas.yaml
+++ b/testdata/config/azure_sas.yaml
@@ -34,4 +34,3 @@ azstorage:
   mode: sas
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_sas_proxy.yaml
+++ b/testdata/config/azure_sas_proxy.yaml
@@ -35,5 +35,4 @@ azstorage:
   container: { 0 }
   tier: hot
   https-proxy: 127.0.0.1:8080
-  sdk-trace: { VERBOSE_LOG }
   

--- a/testdata/config/azure_spn.yaml
+++ b/testdata/config/azure_spn.yaml
@@ -36,4 +36,3 @@ azstorage:
   clientsecret: { NIGHTLY_SPN_CLIENT_SECRET }
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_spn_proxy.yaml
+++ b/testdata/config/azure_spn_proxy.yaml
@@ -37,4 +37,3 @@ azstorage:
   container: { 0 }
   tier: hot
   https-proxy: 127.0.0.1:8080
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_stream.yaml
+++ b/testdata/config/azure_stream.yaml
@@ -32,4 +32,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_stream_direct.yaml
+++ b/testdata/config/azure_stream_direct.yaml
@@ -30,4 +30,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_stream_filename.yaml
+++ b/testdata/config/azure_stream_filename.yaml
@@ -33,4 +33,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }

--- a/testdata/config/azure_stream_filename_direct.yaml
+++ b/testdata/config/azure_stream_filename_direct.yaml
@@ -31,4 +31,3 @@ azstorage:
   mode: key
   container: { 0 }
   tier: hot
-  sdk-trace: { VERBOSE_LOG }


### PR DESCRIPTION
Removed `sdk-trace` from config. Setting log level to `log_debug` will log the SDK requests/responses.