### PR TITLE
Add lazy-write feature to make flush and close async in nature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 2.2.2 (Unreleased)
+## 2.3.0 (Unreleased)
 **Bug Fixes**
+
 **Features**
+- lazy-write support for async flush and close file call. Actual upload will be scheduled in background when this feature is enable.
 
 ## 2.2.1 (2024-02-28)
 **Bug Fixes**

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ To learn about a specific command, just include the name of the command (For exa
     * `--passphrase=<STRING>` : Passphrase used to encrypt/decrypt config file.
     * `--wait-for-mount=<TIMEOUT IN SECONDS>` : Let parent process wait for given timeout before exit to ensure child has started. 
     * `--block-cache` : To enable block-cache instead of file-cache. This works only when mounted without any config file.
+    * `--lazy-write` : To enable async close file handle call and schedule the upload in background.
 - Attribute cache options
     * `--attr-cache-timeout=<TIMEOUT IN SECONDS>`: The timeout for the attribute cache entries.
     * `--no-symlinks=true`: To improve performance disable symlink support.

--- a/azure-pipeline-templates/blobfuse2-ci-template.yml
+++ b/azure-pipeline-templates/blobfuse2-ci-template.yml
@@ -78,7 +78,7 @@ steps:
   - script: |
       curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
       $(go env GOPATH)/bin/golangci-lint --version
-      $(go env GOPATH)/bin/golangci-lint run --tests=false --build-tags ${{ parameters.tags }} --skip-dirs test,common/stats_collector,common/stats_monitor --max-issues-per-linter=0 --skip-files component/libfuse/libfuse2_handler_test_wrapper.go,component/libfuse/libfuse_handler_test_wrapper.go > lint.log
+      $(go env GOPATH)/bin/golangci-lint run --tests=false --build-tags ${{ parameters.tags }} --exclude-dirs test,common/stats_collector,common/stats_monitor --max-issues-per-linter=0 --exclude-files component/libfuse/libfuse2_handler_test_wrapper.go,component/libfuse/libfuse_handler_test_wrapper.go > lint.log
       result=$(cat lint.log | wc -l)
       if [ $result -ne 0 ]; then
         echo "-----------------------------------"

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -87,6 +87,7 @@ type mountOptions struct {
 	ProfilerIP        string         `config:"profiler-ip"`
 	MonitorOpt        monitorOptions `config:"health_monitor"`
 	WaitForMount      time.Duration  `config:"wait-for-mount"`
+	LazyWrite         bool           `config:"lazy-write"`
 
 	// v1 support
 	Streaming      bool     `config:"streaming"`
@@ -674,6 +675,9 @@ func init() {
 
 	mountCmd.PersistentFlags().Bool("read-only", false, "Mount the system in read only mode. Default value false.")
 	config.BindPFlag("read-only", mountCmd.PersistentFlags().Lookup("read-only"))
+
+	mountCmd.PersistentFlags().Bool("lazy-write", false, "Async write to storage container after file handle is closed.")
+	config.BindPFlag("lazy-write", mountCmd.PersistentFlags().Lookup("lazy-write"))
 
 	mountCmd.PersistentFlags().String("default-working-dir", "", "Default working directory for storing log files and other blobfuse2 information")
 	mountCmd.PersistentFlags().Lookup("default-working-dir").Hidden = true

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -420,7 +420,7 @@ func (bc *BlockCache) CloseFile(options internal.CloseFileOptions) error {
 
 	// Async close is called so schedule the upload and return here
 	bc.asyncClose.Add(1)
-	go bc.closeFileInternal(options)
+	go bc.closeFileInternal(options) //nolint
 	return nil
 }
 

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -80,6 +80,9 @@ type BlockCache struct {
 	maxDiskUsageHit bool            // Flag to indicate if we have hit max disk usage
 	noPrefetch      bool            // Flag to indicate if prefetch is disabled
 	prefetchOnOpen  bool            // Start prefetching on file open call instead of waiting for first read
+
+	lazyWrite  bool           // Flag to indicate if lazy write is enabled
+	asyncClose sync.WaitGroup // Wait group to wait for all async close operations to complete
 }
 
 // Structure defining your config parameters
@@ -145,6 +148,10 @@ func (bc *BlockCache) Start(ctx context.Context) error {
 // Stop : Stop the component functionality and kill all threads started
 func (bc *BlockCache) Stop() error {
 	log.Trace("BlockCache::Stop : Stopping component %s", bc.Name())
+
+	// Wait for all async upload to complete if any
+	log.Info("BlockCache::Stop : Waiting for async close to complete")
+	bc.asyncClose.Wait()
 
 	// Wait for thread pool to stop
 	bc.threadPool.Stop()
@@ -214,6 +221,12 @@ func (bc *BlockCache) Configure(_ bool) error {
 	bc.prefetchOnOpen = conf.PrefetchOnOpen
 	bc.prefetch = MIN_PREFETCH
 	bc.noPrefetch = false
+
+	err = config.UnmarshalKey("lazy-write", &bc.lazyWrite)
+	if err != nil {
+		log.Err("BlockCache: config error [unable to obtain lazy-write]")
+		return fmt.Errorf("config error in %s [%s]", bc.Name(), err.Error())
+	}
 
 	if config.IsSet(compName + ".prefetch") {
 		bc.prefetch = conf.PrefetchCount
@@ -380,6 +393,12 @@ func (bc *BlockCache) prepareHandleForBlockCache(handle *handlemap.Handle) {
 func (bc *BlockCache) FlushFile(options internal.FlushFileOptions) error {
 	log.Trace("BlockCache::FlushFile : handle=%d, path=%s", options.Handle.ID, options.Handle.Path)
 
+	if bc.lazyWrite && !options.CloseInProgress {
+		// As lazy-write is enable, upload will be scheduled when file is closed.
+		log.Info("BlockCache::FlushFile : %s will be flushed when handle %d is closed", options.Handle.Path, options.Handle.ID)
+		return nil
+	}
+
 	options.Handle.Lock()
 	defer options.Handle.Unlock()
 
@@ -394,11 +413,26 @@ func (bc *BlockCache) FlushFile(options internal.FlushFileOptions) error {
 
 // CloseFile: File is closed by application so release all the blocks and submit back to blockPool
 func (bc *BlockCache) CloseFile(options internal.CloseFileOptions) error {
+	if !bc.lazyWrite {
+		// Sync close is called so wait till the upload completes
+		return bc.closeFileInternal(options)
+	}
+
+	// Async close is called so schedule the upload and return here
+	bc.asyncClose.Add(1)
+	go bc.closeFileInternal(options)
+	return nil
+}
+
+// closeFileInternal: Actual handling of the close file goes here
+func (bc *BlockCache) closeFileInternal(options internal.CloseFileOptions) error {
 	log.Trace("BlockCache::CloseFile : name=%s, handle=%d", options.Handle.Path, options.Handle.ID)
+
+	defer bc.asyncClose.Done()
 
 	if options.Handle.Dirty() {
 		log.Info("BlockCache::CloseFile : name=%s, handle=%d dirty. Flushing the file.", options.Handle.Path, options.Handle.ID)
-		err := bc.FlushFile(internal.FlushFileOptions{Handle: options.Handle}) //nolint
+		err := bc.FlushFile(internal.FlushFileOptions{Handle: options.Handle, CloseInProgress: true}) //nolint
 		if err != nil {
 			log.Err("BlockCache::CloseFile : failed to flush file %s", options.Handle.Path)
 			return err
@@ -1339,10 +1373,13 @@ func (bc *BlockCache) RenameFile(options internal.RenameFileOptions) error {
 func (bc *BlockCache) SyncFile(options internal.SyncFileOptions) error {
 	log.Trace("BlockCache::SyncFile : handle=%d, path=%s", options.Handle.ID, options.Handle.Path)
 
-	options.Handle.Lock()
-	defer options.Handle.Unlock()
+	err := bc.FlushFile(internal.FlushFileOptions{Handle: options.Handle, CloseInProgress: true}) //nolint
+	if err != nil {
+		log.Err("BlockCache::SyncFile : failed to flush file %s", options.Handle.Path)
+		return err
+	}
 
-	return bc.commitBlocks(options.Handle)
+	return nil
 }
 
 // ------------------------- Factory -------------------------------------------

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -899,24 +899,28 @@ func (suite *blockCacheTestSuite) TestTempCacheCleanup() {
 	suite.assert.Contains(err.Error(), "failed to list directory")
 }
 
-// func (suite *blockCacheTestSuite) TestZZLazyWrite() {
-// 	tobj, _ := setupPipeline("")
-// 	defer tobj.cleanupPipeline()
+func (suite *blockCacheTestSuite) TestZZZZLazyWrite() {
+	tobj, _ := setupPipeline("")
+	defer tobj.cleanupPipeline()
 
-// 	tobj.blockCache.lazyWrite = true
+	tobj.blockCache.lazyWrite = true
 
-// 	file := "file101"
-// 	handle, _ := tobj.blockCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-// 	data := make([]byte, 10*1024*1024)
-// 	_, _ = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
-// 	_ = tobj.blockCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+	file := "file101"
+	handle, _ := tobj.blockCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
+	data := make([]byte, 10*1024*1024)
+	_, _ = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
+	_ = tobj.blockCache.FlushFile(internal.FlushFileOptions{Handle: handle})
 
-// 	// As lazy write is enabled flush shall not upload the file
-// 	suite.assert.True(handle.Dirty())
+	// As lazy write is enabled flush shall not upload the file
+	suite.assert.True(handle.Dirty())
 
-// 	_ = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: handle})
-// 	time.Sleep(5 * time.Second)
-// }
+	_ = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: handle})
+	time.Sleep(5 * time.Second)
+	tobj.blockCache.lazyWrite = false
+
+	// As lazy write is enabled flush shall not upload the file
+	suite.assert.False(handle.Dirty())
+}
 
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -899,24 +899,24 @@ func (suite *blockCacheTestSuite) TestTempCacheCleanup() {
 	suite.assert.Contains(err.Error(), "failed to list directory")
 }
 
-func (suite *blockCacheTestSuite) TestZZLazyWrite() {
-	tobj, _ := setupPipeline("")
-	defer tobj.cleanupPipeline()
+// func (suite *blockCacheTestSuite) TestZZLazyWrite() {
+// 	tobj, _ := setupPipeline("")
+// 	defer tobj.cleanupPipeline()
 
-	tobj.blockCache.lazyWrite = true
+// 	tobj.blockCache.lazyWrite = true
 
-	file := "file101"
-	handle, _ := tobj.blockCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	data := make([]byte, 10*1024*1024)
-	_, _ = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
-	_ = tobj.blockCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+// 	file := "file101"
+// 	handle, _ := tobj.blockCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
+// 	data := make([]byte, 10*1024*1024)
+// 	_, _ = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
+// 	_ = tobj.blockCache.FlushFile(internal.FlushFileOptions{Handle: handle})
 
-	// As lazy write is enabled flush shall not upload the file
-	suite.assert.True(handle.Dirty())
+// 	// As lazy write is enabled flush shall not upload the file
+// 	suite.assert.True(handle.Dirty())
 
-	_ = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: handle})
-	time.Sleep(5 * time.Second)
-}
+// 	_ = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: handle})
+// 	time.Sleep(5 * time.Second)
+// }
 
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -899,6 +899,29 @@ func (suite *blockCacheTestSuite) TestTempCacheCleanup() {
 	suite.assert.Contains(err.Error(), "failed to list directory")
 }
 
+func (suite *blockCacheTestSuite) TestZZLazyWrite() {
+	tobj, _ := setupPipeline("")
+	defer tobj.cleanupPipeline()
+
+	tobj.blockCache.lazyWrite = true
+
+	file := "file101"
+	handle, _ := tobj.blockCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
+	data := make([]byte, 10*1024*1024)
+	_, _ = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
+	_ = tobj.blockCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+
+	// As lazy write is enabled flush shall not upload the file
+	suite.assert.True(handle.Dirty())
+
+	err := tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: handle})
+	suite.assert.Nil(err)
+	suite.assert.True(handle.Dirty())
+
+	time.Sleep(5 * time.Second)
+	suite.assert.False(handle.Dirty())
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestBlockCacheTestSuite(t *testing.T) {

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -914,12 +914,8 @@ func (suite *blockCacheTestSuite) TestZZLazyWrite() {
 	// As lazy write is enabled flush shall not upload the file
 	suite.assert.True(handle.Dirty())
 
-	err := tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: handle})
-	suite.assert.Nil(err)
-	suite.assert.True(handle.Dirty())
-
+	_ = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 	time.Sleep(5 * time.Second)
-	suite.assert.False(handle.Dirty())
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1007,7 +1007,7 @@ func (fc *FileCache) CloseFile(options internal.CloseFileOptions) error {
 
 	// Async close is called so schedule the upload and return here
 	fc.asyncClose.Add(1)
-	go fc.closeFileInternal(options, flock)
+	go fc.closeFileInternal(options, flock) //nolint
 	return nil
 }
 

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1683,26 +1683,30 @@ func (suite *fileCacheTestSuite) TestZZOffloadIO() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 }
 
-// func (suite *fileCacheTestSuite) TestZZLazyWrite() {
-// 	defer suite.cleanupTest()
-// 	configuration := fmt.Sprintf("file_cache:\n  path: %s\n  timeout-sec: 0\n\nloopbackfs:\n  path: %s",
-// 		suite.cache_path, suite.fake_storage_path)
+func (suite *fileCacheTestSuite) TestZZZZLazyWrite() {
+	defer suite.cleanupTest()
+	configuration := fmt.Sprintf("file_cache:\n  path: %s\n  timeout-sec: 0\n\nloopbackfs:\n  path: %s",
+		suite.cache_path, suite.fake_storage_path)
 
-// 	suite.setupTestHelper(configuration)
-// 	suite.fileCache.lazyWrite = true
+	suite.setupTestHelper(configuration)
+	suite.fileCache.lazyWrite = true
 
-// 	file := "file101"
-// 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-// 	data := make([]byte, 10*1024*1024)
-// 	_, _ = suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
-// 	_ = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+	file := "file101"
+	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
+	data := make([]byte, 10*1024*1024)
+	_, _ = suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
+	_ = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
 
-// 	// As lazy write is enabled flush shall not upload the file
-// 	suite.assert.True(handle.Dirty())
+	// As lazy write is enabled flush shall not upload the file
+	suite.assert.True(handle.Dirty())
 
-// 	_ = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
-// 	time.Sleep(5 * time.Second)
-// }
+	_ = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
+	time.Sleep(5 * time.Second)
+	suite.fileCache.lazyWrite = false
+
+	// As lazy write is enabled flush shall not upload the file
+	suite.assert.False(handle.Dirty())
+}
 
 func (suite *fileCacheTestSuite) TestStatFS() {
 	defer suite.cleanupTest()

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1683,6 +1683,31 @@ func (suite *fileCacheTestSuite) TestZZOffloadIO() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 }
 
+func (suite *fileCacheTestSuite) TestZZLazyWrite() {
+	defer suite.cleanupTest()
+	configuration := fmt.Sprintf("file_cache:\n  path: %s\n  timeout-sec: 0\n\nloopbackfs:\n  path: %s",
+		suite.cache_path, suite.fake_storage_path)
+
+	suite.setupTestHelper(configuration)
+	suite.fileCache.lazyWrite = true
+
+	file := "file101"
+	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
+	data := make([]byte, 10*1024*1024)
+	_, _ = suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
+	_ = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+
+	// As lazy write is enabled flush shall not upload the file
+	suite.assert.True(handle.Dirty())
+
+	err := suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
+	suite.assert.Nil(err)
+	suite.assert.True(handle.Dirty())
+
+	time.Sleep(5 * time.Second)
+	suite.assert.False(handle.Dirty())
+}
+
 func (suite *fileCacheTestSuite) TestStatFS() {
 	defer suite.cleanupTest()
 	cacheTimeout := 5

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1700,12 +1700,8 @@ func (suite *fileCacheTestSuite) TestZZLazyWrite() {
 	// As lazy write is enabled flush shall not upload the file
 	suite.assert.True(handle.Dirty())
 
-	err := suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
-	suite.assert.Nil(err)
-	suite.assert.True(handle.Dirty())
-
+	_ = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 	time.Sleep(5 * time.Second)
-	suite.assert.False(handle.Dirty())
 }
 
 func (suite *fileCacheTestSuite) TestStatFS() {

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1683,26 +1683,26 @@ func (suite *fileCacheTestSuite) TestZZOffloadIO() {
 	suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
 }
 
-func (suite *fileCacheTestSuite) TestZZLazyWrite() {
-	defer suite.cleanupTest()
-	configuration := fmt.Sprintf("file_cache:\n  path: %s\n  timeout-sec: 0\n\nloopbackfs:\n  path: %s",
-		suite.cache_path, suite.fake_storage_path)
+// func (suite *fileCacheTestSuite) TestZZLazyWrite() {
+// 	defer suite.cleanupTest()
+// 	configuration := fmt.Sprintf("file_cache:\n  path: %s\n  timeout-sec: 0\n\nloopbackfs:\n  path: %s",
+// 		suite.cache_path, suite.fake_storage_path)
 
-	suite.setupTestHelper(configuration)
-	suite.fileCache.lazyWrite = true
+// 	suite.setupTestHelper(configuration)
+// 	suite.fileCache.lazyWrite = true
 
-	file := "file101"
-	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
-	data := make([]byte, 10*1024*1024)
-	_, _ = suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
-	_ = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
+// 	file := "file101"
+// 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
+// 	data := make([]byte, 10*1024*1024)
+// 	_, _ = suite.fileCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
+// 	_ = suite.fileCache.FlushFile(internal.FlushFileOptions{Handle: handle})
 
-	// As lazy write is enabled flush shall not upload the file
-	suite.assert.True(handle.Dirty())
+// 	// As lazy write is enabled flush shall not upload the file
+// 	suite.assert.True(handle.Dirty())
 
-	_ = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
-	time.Sleep(5 * time.Second)
-}
+// 	_ = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: handle})
+// 	time.Sleep(5 * time.Second)
+// }
 
 func (suite *fileCacheTestSuite) TestStatFS() {
 	defer suite.cleanupTest()

--- a/component/stream/read_write.go
+++ b/component/stream/read_write.go
@@ -233,7 +233,7 @@ func (rw *ReadWriteCache) FlushFile(options internal.FlushFileOptions) error {
 func (rw *ReadWriteCache) CloseFile(options internal.CloseFileOptions) error {
 	log.Trace("Stream::CloseFile : name=%s, handle=%d", options.Handle.Path, options.Handle.ID)
 	// try to flush again to make sure it's cleaned up
-	err := rw.FlushFile(internal.FlushFileOptions(options))
+	err := rw.FlushFile(internal.FlushFileOptions{Handle: options.Handle})
 	if err != nil {
 		log.Err("Stream::CloseFile : error flushing file %s [%s]", options.Handle.Path, err.Error())
 		return err
@@ -525,7 +525,7 @@ func (rw *ReadWriteCache) readWriteBlocks(handle *handlemap.Handle, offset int64
 func (rw *ReadWriteCache) SyncFile(options internal.SyncFileOptions) error {
 	log.Trace("ReadWriteCache::SyncFile : handle=%d, path=%s", options.Handle.ID, options.Handle.Path)
 
-	err := rw.FlushFile(internal.FlushFileOptions(options))
+	err := rw.FlushFile(internal.FlushFileOptions{Handle: options.Handle})
 	if err != nil {
 		log.Err("Stream::SyncFile : error flushing file %s [%s]", options.Handle.Path, err.Error())
 		return err

--- a/component/stream/read_write_filename.go
+++ b/component/stream/read_write_filename.go
@@ -179,7 +179,7 @@ func (rw *ReadWriteFilenameCache) RenameFile(options internal.RenameFileOptions)
 func (rw *ReadWriteFilenameCache) CloseFile(options internal.CloseFileOptions) error {
 	log.Trace("Stream::CloseFile : name=%s, handle=%d", options.Handle.Path, options.Handle.ID)
 	// try to flush again to make sure it's cleaned up
-	err := rw.FlushFile(internal.FlushFileOptions(options))
+	err := rw.FlushFile(internal.FlushFileOptions{Handle: options.Handle})
 	if err != nil {
 		log.Err("Stream::CloseFile : error flushing file %s [%s]", options.Handle.Path, err.Error())
 		return err
@@ -482,7 +482,7 @@ func (rw *ReadWriteFilenameCache) readWriteBlocks(handle *handlemap.Handle, offs
 func (rw *ReadWriteFilenameCache) SyncFile(options internal.SyncFileOptions) error {
 	log.Trace("ReadWriteFilenameCache::SyncFile : handle=%d, path=%s", options.Handle.ID, options.Handle.Path)
 
-	err := rw.FlushFile(internal.FlushFileOptions(options))
+	err := rw.FlushFile(internal.FlushFileOptions{Handle: options.Handle})
 	if err != nil {
 		log.Err("Stream::SyncFile : error flushing file %s [%s]", options.Handle.Path, err.Error())
 		return err

--- a/go_installer.sh
+++ b/go_installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 work_dir=$(echo $1 | sed 's:/*$::')
-version="1.20.5"
+version="1.22.1"
 arch=`hostnamectl | grep "Arch" | rev | cut -d " " -f 1 | rev`
 
 if [ $arch != "arm64" ]

--- a/internal/component_options.go
+++ b/internal/component_options.go
@@ -140,7 +140,8 @@ type CopyFromFileOptions struct {
 }
 
 type FlushFileOptions struct {
-	Handle *handlemap.Handle
+	Handle          *handlemap.Handle
+	CloseInProgress bool
 }
 
 type SyncFileOptions struct {


### PR DESCRIPTION
- Close and flush will return immediately when lazy-write is enabled and upload of dirty file will be scheduled
- File will be locked till upload is in progress and no new handle for the same file can be created during this time
- Before unmount ensure all downloads are complete