### PR TITLE
libfuse-3.3 does not support 1MB max_write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.3.0 (Unreleased)
 **Bug Fixes**
-- [#1359](https://github.com/Azure/azure-storage-fuse/issues/1359) Fixed RHEL 8.6 mount failure
-- [#1368](https://github.com/Azure/azure-storage-fuse/issues/1368) Fixed RHEL 8.6 mount failure
+- [#1359](https://github.com/Azure/azure-storage-fuse/issues/1359), [#1368](https://github.com/Azure/azure-storage-fuse/issues/1368) Fixed RHEL 8.6 mount failure
 
 **Features**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 2.2.2 (Unreleased)
+## 2.3.0 (Unreleased)
 **Bug Fixes**
+- [#1359](https://github.com/Azure/azure-storage-fuse/issues/1359) Fixed RHEL 8.6 mount failure
+- [#1368](https://github.com/Azure/azure-storage-fuse/issues/1368) Fixed RHEL 8.6 mount failure
+
 **Features**
 
 ## 2.2.1 (2024-02-28)

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -323,11 +323,12 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 	// RHEL still has 3.3 fuse version and it does not allow max_write beyond 128K
 	// Setting this value to 1 MB will fail the mount.
 	fuse_minor := C.get_fuse_minor_version()
-	if fuse_minor > 5 {
+	if fuse_minor > 4 {
 		log.Info("Libfuse::libfuse_init : Setting 1MB max_write for fuse minor %v", fuse_minor)
 		conn.max_write = (1 * 1024 * 1024)
 	} else {
 		log.Info("Libfuse::libfuse_init : Ignoring max_write for fuse minor %v", fuse_minor)
+		conn.max_write = (128 * 1024)
 	}
 
 	// direct_io option is used to bypass the kernel cache. It disables the use of

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -319,7 +319,13 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 	// While reading a file let kernel do readahed for better perf
 	conn.max_readahead = (4 * 1024 * 1024)
 	conn.max_read = (1 * 1024 * 1024)
-	conn.max_write = (1 * 1024 * 1024)
+
+	// RHEL still has 3.3 fuse version and it does not allow max_write beyond 128K
+	// Setting this value to 1 MB will fail the mount.
+	fuse_minor := C.get_fuse_minor_version()
+	if fuse_minor > 5 {
+		conn.max_write = (1 * 1024 * 1024)
+	}
 
 	// direct_io option is used to bypass the kernel cache. It disables the use of
 	// page cache (file content cache) in the kernel for the filesystem.

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -324,7 +324,10 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 	// Setting this value to 1 MB will fail the mount.
 	fuse_minor := C.get_fuse_minor_version()
 	if fuse_minor > 5 {
+		log.Info("Libfuse::libfuse_init : Setting 1MB max_write for fuse minor %v", fuse_minor)
 		conn.max_write = (1 * 1024 * 1024)
+	} else {
+		log.Info("Libfuse::libfuse_init : Ignoring max_write for fuse minor %v", fuse_minor)
 	}
 
 	// direct_io option is used to bypass the kernel cache. It disables the use of

--- a/component/libfuse/libfuse_wrapper.h
+++ b/component/libfuse/libfuse_wrapper.h
@@ -175,5 +175,9 @@ static int fill_dir_entry(fuse_fill_dir_t filler, void *buf, char *name, stat_t 
     );
 }
 
+// Return the fuse minor version to the application
+static int get_fuse_minor_version() {
+    return FUSE_MINOR_VERSION;
+}
 
 #endif //__LIBFUSE_H__


### PR DESCRIPTION
- Fixes #1359 
- Fixes #1368 