### PR TITLE
Get attribute fix for directory with cpk enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [#1057](https://github.com/Azure/azure-storage-fuse/issues/1057) Fixed the issue where user-assigned identity is not used to authenticate when system-assigned identity is enabled.
 - Listing blobs is now supported for blob names that contain characters that aren't valid in XML (U+FFFE or U+FFFF).
 - [#1359](https://github.com/Azure/azure-storage-fuse/issues/1359), [#1368](https://github.com/Azure/azure-storage-fuse/issues/1368) Fixed RHEL 8.6 mount failure
+- Fixed issue where get attributes was failing for files which are directories in case of CPK enabled flag.
 
 **Features**
 - Migrated to the latest [azblob SDK](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob).

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -585,7 +585,6 @@ func (bb *BlockBlob) List(prefix string, marker *string, count int32) ([]*intern
 				} else {
 					errors = fmt.Errorf("error fetching metadata for blob: %s, %w; %w", *blobInfo.Name, errors, err)
 				}
-				continue
 			}
 		} else {
 			attr = &internal.ObjAttr{

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -572,7 +572,6 @@ func (bb *BlockBlob) List(prefix string, marker *string, count int32) ([]*intern
 
 	// For some directories 0 byte meta file may not exists so just create a map to figure out such directories
 	var dirList = make(map[string]bool)
-	var errors error = nil
 	for _, blobInfo := range listBlob.Segment.BlobItems {
 		attr := &internal.ObjAttr{}
 		if blobInfo.Properties.CustomerProvidedKeySHA256 != nil && *blobInfo.Properties.CustomerProvidedKeySHA256 != "" {
@@ -580,11 +579,7 @@ func (bb *BlockBlob) List(prefix string, marker *string, count int32) ([]*intern
 			attr, err = bb.getAttrUsingRest(*blobInfo.Name)
 			if err != nil {
 				log.Err("BlockBlob::List : Failed to get properties of blob %s", *blobInfo.Name)
-				if errors == nil {
-					errors = err
-				} else {
-					errors = fmt.Errorf("error fetching metadata for blob: %s, %w; %w", *blobInfo.Name, errors, err)
-				}
+				return blobList, nil, err
 			}
 		} else {
 			attr = &internal.ObjAttr{
@@ -610,10 +605,6 @@ func (bb *BlockBlob) List(prefix string, marker *string, count int32) ([]*intern
 			dirList[*blobInfo.Name+"/"] = true
 			attr.Size = 4096
 		}
-	}
-
-	if err != nil {
-		return blobList, nil, errors
 	}
 
 	// In case virtual directory exists but its corresponding 0 byte marker file is not there holding hdi_isfolder then just iterating

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -572,7 +572,7 @@ func (bb *BlockBlob) List(prefix string, marker *string, count int32) ([]*intern
 
 	// For some directories 0 byte meta file may not exists so just create a map to figure out such directories
 	var dirList = make(map[string]bool)
-	var errors error
+	var errors error = nil
 	for _, blobInfo := range listBlob.Segment.BlobItems {
 		attr := &internal.ObjAttr{}
 		if blobInfo.Properties.CustomerProvidedKeySHA256 != nil && *blobInfo.Properties.CustomerProvidedKeySHA256 != "" {
@@ -580,7 +580,11 @@ func (bb *BlockBlob) List(prefix string, marker *string, count int32) ([]*intern
 			attr, err = bb.getAttrUsingRest(*blobInfo.Name)
 			if err != nil {
 				log.Err("BlockBlob::List : Failed to get properties of blob %s", *blobInfo.Name)
-				errors = fmt.Errorf("error fetching metadata for blob %s: %w; %w", *blobInfo.Name, errors, err)
+				if errors == nil {
+					errors = err
+				} else {
+					errors = fmt.Errorf("error fetching metadata for blob: %s, %w; %w", *blobInfo.Name, errors, err)
+				}
 				continue
 			}
 		} else {


### PR DESCRIPTION
- Get atrribute for directory file is failing when CPK is enabled as ListBlob  API does not return the metadata when the blob is encrypted [https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs](url)
- So fetching the metadata for encrypted blobs explicitly using get properties rest api [https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties](url)