### PR TITLE
Reset block when released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed the case where file creation using SAS on HNS accounts was returning back wrong error code.
 - [#1402](https://github.com/Azure/azure-storage-fuse/issues/1402) Fixed proxy URL parsing.
 - If earlier instance of Blobfuse2 crashed and mount is unstable then next mount to same path will automatically cleanup the system.
+- Reset block data to null before reuse to avoid corruption
 
 **Features**
 

--- a/component/block_cache/blockpool_test.go
+++ b/component/block_cache/blockpool_test.go
@@ -242,6 +242,9 @@ func (suite *blockpoolTestSuite) TestBlockReset() {
 
 	releaseBlocks(suite, bp, blocks)
 
+	// adding wait for the blocks to be reset and pushed back to the blocks channel
+	time.Sleep(2 * time.Second)
+
 	blocks = getBlocks(suite, bp, 4)
 
 	releaseBlocks(suite, bp, blocks)

--- a/component/block_cache/blockpool_test.go
+++ b/component/block_cache/blockpool_test.go
@@ -37,7 +37,9 @@
 package block_cache
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -54,6 +56,16 @@ func (suite *blockpoolTestSuite) SetupTest() {
 func (suite *blockpoolTestSuite) cleanupTest() {
 }
 
+func validateNullData(b *Block) bool {
+	for i := 0; i < len(b.data); i++ {
+		if b.data[i] != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (suite *blockpoolTestSuite) TestAllocate() {
 	suite.assert = assert.New(suite.T())
 
@@ -66,9 +78,14 @@ func (suite *blockpoolTestSuite) TestAllocate() {
 	bp = NewBlockPool(1, 1)
 	suite.assert.NotNil(bp)
 	suite.assert.NotNil(bp.blocksCh)
+	suite.assert.NotNil(bp.resetBlockCh)
+	suite.assert.NotNil(bp.zeroBlock)
+	suite.assert.True(validateNullData(bp.zeroBlock))
 
 	bp.Terminate()
 	suite.assert.Equal(len(bp.blocksCh), 0)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.Equal(len(bp.zeroBlock.data), 0)
 }
 
 func (suite *blockpoolTestSuite) TestGetRelease() {
@@ -77,24 +94,32 @@ func (suite *blockpoolTestSuite) TestGetRelease() {
 	bp := NewBlockPool(1, 5)
 	suite.assert.NotNil(bp)
 	suite.assert.NotNil(bp.blocksCh)
-	suite.assert.Equal(len(bp.blocksCh), 5)
+	suite.assert.NotNil(bp.resetBlockCh)
+	suite.assert.NotNil(bp.zeroBlock)
+	suite.assert.Equal(len(bp.blocksCh), 4)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.True(validateNullData(bp.zeroBlock))
 
 	b := bp.MustGet()
 	suite.assert.NotNil(b)
-	suite.assert.Equal(len(bp.blocksCh), 4)
+	suite.assert.Equal(len(bp.blocksCh), 3)
 
 	bp.Release(b)
-	suite.assert.Equal(len(bp.blocksCh), 5)
+	time.Sleep(1 * time.Second)
+	suite.assert.Equal(len(bp.blocksCh), 4)
 
 	b = bp.TryGet()
 	suite.assert.NotNil(b)
-	suite.assert.Equal(len(bp.blocksCh), 4)
+	suite.assert.Equal(len(bp.blocksCh), 3)
 
 	bp.Release(b)
-	suite.assert.Equal(len(bp.blocksCh), 5)
+	time.Sleep(1 * time.Second)
+	suite.assert.Equal(len(bp.blocksCh), 4)
 
 	bp.Terminate()
 	suite.assert.Equal(len(bp.blocksCh), 0)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.Equal(len(bp.zeroBlock.data), 0)
 }
 
 func (suite *blockpoolTestSuite) TestUsage() {
@@ -103,7 +128,11 @@ func (suite *blockpoolTestSuite) TestUsage() {
 	bp := NewBlockPool(1, 5)
 	suite.assert.NotNil(bp)
 	suite.assert.NotNil(bp.blocksCh)
-	suite.assert.Equal(len(bp.blocksCh), 5)
+	suite.assert.NotNil(bp.resetBlockCh)
+	suite.assert.NotNil(bp.zeroBlock)
+	suite.assert.Equal(len(bp.blocksCh), 4)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.True(validateNullData(bp.zeroBlock))
 
 	var blocks []*Block
 	b := bp.MustGet()
@@ -111,21 +140,26 @@ func (suite *blockpoolTestSuite) TestUsage() {
 	blocks = append(blocks, b)
 
 	usage := bp.Usage()
-	suite.assert.Equal(usage, uint32(20))
+	suite.assert.Equal(usage, uint32(40))
 
 	b = bp.TryGet()
 	suite.assert.NotNil(b)
 	blocks = append(blocks, b)
 
 	usage = bp.Usage()
-	suite.assert.Equal(usage, uint32(40))
+	suite.assert.Equal(usage, uint32(60))
 
 	for _, blk := range blocks {
 		bp.Release(blk)
 	}
 
+	usage = bp.Usage()
+	suite.assert.Equal(usage, uint32(20)) // because of zeroBlock
+
 	bp.Terminate()
 	suite.assert.Equal(len(bp.blocksCh), 0)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.Equal(len(bp.zeroBlock.data), 0)
 }
 
 func (suite *blockpoolTestSuite) TestBufferExhaution() {
@@ -134,7 +168,11 @@ func (suite *blockpoolTestSuite) TestBufferExhaution() {
 	bp := NewBlockPool(1, 5)
 	suite.assert.NotNil(bp)
 	suite.assert.NotNil(bp.blocksCh)
-	suite.assert.Equal(len(bp.blocksCh), 5)
+	suite.assert.NotNil(bp.resetBlockCh)
+	suite.assert.NotNil(bp.zeroBlock)
+	suite.assert.Equal(len(bp.blocksCh), 4)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.True(validateNullData(bp.zeroBlock))
 
 	var blocks []*Block
 	for i := 0; i < 5; i++ {
@@ -159,6 +197,59 @@ func (suite *blockpoolTestSuite) TestBufferExhaution() {
 
 	bp.Terminate()
 	suite.assert.Equal(len(bp.blocksCh), 0)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.Equal(len(bp.zeroBlock.data), 0)
+}
+
+// get n blocks
+func getBlocks(suite *blockpoolTestSuite, bp *BlockPool, n int) []*Block {
+	var blocks []*Block
+	for i := 0; i < n; i++ {
+		b := bp.TryGet()
+		suite.assert.NotNil(b)
+
+		// validate that the block has null data
+		suite.assert.True(validateNullData(b))
+		blocks = append(blocks, b)
+	}
+	return blocks
+}
+
+func releaseBlocks(suite *blockpoolTestSuite, bp *BlockPool, blocks []*Block) {
+	for _, b := range blocks {
+		b.data[0] = byte(rand.Int()%100 + 1)
+		b.data[1] = byte(rand.Int()%100 + 1)
+
+		// validate that the block being released does not have null data
+		suite.assert.False(validateNullData(b))
+		bp.Release(b)
+	}
+}
+
+func (suite *blockpoolTestSuite) TestBlockReset() {
+	suite.assert = assert.New(suite.T())
+
+	bp := NewBlockPool(2, 10)
+	suite.assert.NotNil(bp)
+	suite.assert.NotNil(bp.blocksCh)
+	suite.assert.NotNil(bp.resetBlockCh)
+	suite.assert.NotNil(bp.zeroBlock)
+	suite.assert.Equal(len(bp.blocksCh), 4)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.True(validateNullData(bp.zeroBlock))
+
+	blocks := getBlocks(suite, bp, 4)
+
+	releaseBlocks(suite, bp, blocks)
+
+	blocks = getBlocks(suite, bp, 4)
+
+	releaseBlocks(suite, bp, blocks)
+
+	bp.Terminate()
+	suite.assert.Equal(len(bp.blocksCh), 0)
+	suite.assert.Equal(len(bp.resetBlockCh), 0)
+	suite.assert.Equal(len(bp.zeroBlock.data), 0)
 }
 
 func TestBlockPoolSuite(t *testing.T) {


### PR DESCRIPTION
Reset the block data to null when it is released back to the block pool. As a result of this, a block retrieved from the block pool will have null data instead of garbage data.