### PR TITLE
Block cache disable random write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.1 (Unreleased)
 **NOTICE**
-- Due to data integrity issues, few random write operations has been disabled in block cache. Refer [#1484](https://github.com/Azure/azure-storage-fuse/pull/1484) for blocked scenarios.
+- Due to data integrity issues, random write operations has been disabled in block cache. Refer [#1484](https://github.com/Azure/azure-storage-fuse/pull/1484) for blocked scenarios.
 
 **Bug Fixes**
 - Fixed the case where file creation using SAS on HNS accounts was returning back wrong error code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - In flush operation, the blocks will be committed only if the handle is dirty.
 - Reset block data to null before reuse.
 - Sparse file data integrity issues fixed.
-- Fixed block-cache read of small files where file size is not multiple of kernel buffer size. 
+- Fixed block-cache read of small files where file size is not multiple of kernel buffer size.
 
 **Other Changes**
 - LFU policy in file cache has been deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2.3.1 (Unreleased)
+**NOTICE**
+- Due to data integrity issues, few random write operations has been disabled in block cache. Refer [#1484](https://github.com/Azure/azure-storage-fuse/pull/1484) for blocked scenarios.
+
 **Bug Fixes**
 - Fixed the case where file creation using SAS on HNS accounts was returning back wrong error code.
 - [#1402](https://github.com/Azure/azure-storage-fuse/issues/1402) Fixed proxy URL parsing.
@@ -6,8 +9,6 @@
 - In flush operation, the blocks will be committed only if the handle is dirty.
 - Reset block data to null before reuse.
 - Sparse file data integrity issues fixed.
-
-**Features**
 
 **Other Changes**
 - LFU policy in file cache has been deprecated.

--- a/azure-pipeline-templates/cleanup.yml
+++ b/azure-pipeline-templates/cleanup.yml
@@ -8,6 +8,11 @@ parameters:
 
 steps:
   - script: |
+      ps -ef | grep blobfuse2
+      df -h
+    displayName: 'Check process info'
+
+  - script: |
       sudo fusermount -u ${mount_dir}
       sudo fusermount3 -u ${mount_dir}
       sudo kill -9 `pidof blobfuse2` || true

--- a/azure-pipeline-templates/e2e-tests-block-cache.yml
+++ b/azure-pipeline-templates/e2e-tests-block-cache.yml
@@ -240,6 +240,17 @@ steps:
       $(WORK_DIR)/blobfuse2 unmount all
     displayName: 'Unmount RW mount'
 
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: blobfuse2-logs.txt
+      artifactName: 'blobfuse_block_cache.txt'
+    condition: always()
+    
+  - script: |
+      tail -n 200 blobfuse2-logs.txt
+    displayName: 'View Logs'
+    condition: failed()
+
   - template: 'cleanup.yml'
     parameters:
       working_dir: $(WORK_DIR)

--- a/azure-pipeline-templates/e2e-tests-block-cache.yml
+++ b/azure-pipeline-templates/e2e-tests-block-cache.yml
@@ -244,7 +244,7 @@ steps:
     inputs:
       pathToPublish: blobfuse2-logs.txt
       artifactName: 'blobfuse_block_cache.txt'
-    condition: always()
+    condition: failed()
     
   - script: |
       tail -n 200 blobfuse2-logs.txt

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -937,7 +937,8 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 
 	// check for possible random write scenario and block the write request
 	blockIndex := bc.getBlockIndex(uint64(options.Offset))
-	if int64(blockIndex*bc.blockSize) < options.Handle.Size-int64(MIN_WRITE_BLOCK*bc.blockSize) {
+	lastBlockIndex := bc.getBlockIndex(uint64(options.Offset))
+	if lastBlockIndex-blockIndex > MIN_WRITE_BLOCK {
 		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v and block %v, where handle size is %v", options.Offset, blockIndex, options.Handle.Size)
 		if !bc.enableRandomWrite {
 			log.Err("BlockCache::WriteFile : Blocking random write")

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -938,7 +938,7 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 	// check for possible random write scenario and block the write request
 	blockIndex := bc.getBlockIndex(uint64(options.Offset))
 	lastBlockIndex := bc.getBlockIndex(uint64(options.Offset))
-	if lastBlockIndex-blockIndex > MIN_WRITE_BLOCK {
+	if (blockIndex < lastBlockIndex) && ((lastBlockIndex-1)-blockIndex > MIN_WRITE_BLOCK) {
 		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v and block %v, where handle size is %v", options.Offset, blockIndex, options.Handle.Size)
 		if !bc.enableRandomWrite {
 			log.Err("BlockCache::WriteFile : Blocking random write")

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -938,7 +938,7 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 	// check for possible random write scenario and block the write request
 	blockIndex := bc.getBlockIndex(uint64(options.Offset))
 	lastBlockIndex := bc.getBlockIndex(uint64(options.Offset))
-	if (blockIndex < lastBlockIndex) && ((lastBlockIndex+1)-blockIndex > MIN_WRITE_BLOCK) {
+	if (blockIndex < lastBlockIndex) && ((lastBlockIndex+1)-blockIndex > uint64(bc.prefetch)) {
 		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v and block %v, where handle size is %v", options.Offset, blockIndex, options.Handle.Size)
 		if !bc.enableRandomWrite {
 			log.Err("BlockCache::WriteFile : Blocking random write")

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -931,11 +931,12 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 	// log.Debug("BlockCache::WriteFile : Writing handle %v=>%v: offset %v, %v bytes", options.Handle.ID, options.Handle.Path, options.Offset, len(options.Data))
 
 	// check for possible random write scenario and block the write request
-	if options.Offset < options.Handle.Size-int64(MIN_WRITE_BLOCK*bc.blockSize) {
-		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v where handle size is %v", options.Offset, options.Handle.Size)
+	blockIndex := bc.getBlockIndex(uint64(options.Offset))
+	if int64(blockIndex*bc.blockSize) < options.Handle.Size-int64(MIN_WRITE_BLOCK*bc.blockSize) {
+		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v and block %v, where handle size is %v", options.Offset, blockIndex, options.Handle.Size)
 		if !bc.enableRandomWrite {
 			log.Err("BlockCache::WriteFile : Blocking random write")
-			return 0, fmt.Errorf("blocking random write for write offset %v where handle size is %v", options.Offset, options.Handle.Size)
+			return 0, fmt.Errorf("blocking random write for write offset %v and block %v where handle size is %v", options.Offset, blockIndex, options.Handle.Size)
 		}
 	}
 

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -68,21 +68,22 @@ import (
 type BlockCache struct {
 	internal.BaseComponent
 
-	blockSize       uint64          // Size of each block to be cached
-	memSize         uint64          // Mem size to be used for caching at the startup
-	tmpPath         string          // Disk path where these blocks will be cached
-	diskSize        uint64          // Size of disk space allocated for the caching
-	diskTimeout     uint32          // Timeout for which disk blocks will be cached
-	workers         uint32          // Number of threads working to fetch the blocks
-	prefetch        uint32          // Number of blocks to be prefetched
-	diskPolicy      *tlru.TLRU      // Disk cache eviction policy
-	blockPool       *BlockPool      // Pool of blocks
-	threadPool      *ThreadPool     // Pool of threads
-	fileLocks       *common.LockMap // Locks for each file_blockid to avoid multiple threads to fetch same block
-	fileNodeMap     sync.Map        // Map holding files that are there in our cache
-	maxDiskUsageHit bool            // Flag to indicate if we have hit max disk usage
-	noPrefetch      bool            // Flag to indicate if prefetch is disabled
-	prefetchOnOpen  bool            // Start prefetching on file open call instead of waiting for first read
+	blockSize         uint64          // Size of each block to be cached
+	memSize           uint64          // Mem size to be used for caching at the startup
+	tmpPath           string          // Disk path where these blocks will be cached
+	diskSize          uint64          // Size of disk space allocated for the caching
+	diskTimeout       uint32          // Timeout for which disk blocks will be cached
+	workers           uint32          // Number of threads working to fetch the blocks
+	prefetch          uint32          // Number of blocks to be prefetched
+	diskPolicy        *tlru.TLRU      // Disk cache eviction policy
+	blockPool         *BlockPool      // Pool of blocks
+	threadPool        *ThreadPool     // Pool of threads
+	fileLocks         *common.LockMap // Locks for each file_blockid to avoid multiple threads to fetch same block
+	fileNodeMap       sync.Map        // Map holding files that are there in our cache
+	maxDiskUsageHit   bool            // Flag to indicate if we have hit max disk usage
+	noPrefetch        bool            // Flag to indicate if prefetch is disabled
+	prefetchOnOpen    bool            // Start prefetching on file open call instead of waiting for first read
+	enableRandomWrite bool            // Enable random write in block cache
 
 	lazyWrite    bool           // Flag to indicate if lazy write is enabled
 	fileCloseOpt sync.WaitGroup // Wait group to wait for all async close operations to complete
@@ -90,14 +91,15 @@ type BlockCache struct {
 
 // Structure defining your config parameters
 type BlockCacheOptions struct {
-	BlockSize      float64 `config:"block-size-mb" yaml:"block-size-mb,omitempty"`
-	MemSize        uint64  `config:"mem-size-mb" yaml:"mem-size-mb,omitempty"`
-	TmpPath        string  `config:"path" yaml:"path,omitempty"`
-	DiskSize       uint64  `config:"disk-size-mb" yaml:"disk-size-mb,omitempty"`
-	DiskTimeout    uint32  `config:"disk-timeout-sec" yaml:"timeout-sec,omitempty"`
-	PrefetchCount  uint32  `config:"prefetch" yaml:"prefetch,omitempty"`
-	Workers        uint32  `config:"parallelism" yaml:"parallelism,omitempty"`
-	PrefetchOnOpen bool    `config:"prefetch-on-open" yaml:"prefetch-on-open,omitempty"`
+	BlockSize         float64 `config:"block-size-mb" yaml:"block-size-mb,omitempty"`
+	MemSize           uint64  `config:"mem-size-mb" yaml:"mem-size-mb,omitempty"`
+	TmpPath           string  `config:"path" yaml:"path,omitempty"`
+	DiskSize          uint64  `config:"disk-size-mb" yaml:"disk-size-mb,omitempty"`
+	DiskTimeout       uint32  `config:"disk-timeout-sec" yaml:"timeout-sec,omitempty"`
+	PrefetchCount     uint32  `config:"prefetch" yaml:"prefetch,omitempty"`
+	Workers           uint32  `config:"parallelism" yaml:"parallelism,omitempty"`
+	PrefetchOnOpen    bool    `config:"prefetch-on-open" yaml:"prefetch-on-open,omitempty"`
+	EnableRandomWrite bool    `config:"enable-random-write" yaml:"enable-random-write,omitempty"`
 }
 
 const (
@@ -211,6 +213,7 @@ func (bc *BlockCache) Configure(_ bool) error {
 	bc.prefetchOnOpen = conf.PrefetchOnOpen
 	bc.prefetch = uint32(math.Max((MIN_PREFETCH*2)+1, (float64)(2*runtime.NumCPU())))
 	bc.noPrefetch = false
+	bc.enableRandomWrite = conf.EnableRandomWrite
 
 	if defaultMemSize && (uint64(bc.prefetch)*uint64(bc.blockSize)) > bc.memSize {
 		bc.prefetch = (MIN_PREFETCH * 2) + 1
@@ -272,8 +275,8 @@ func (bc *BlockCache) Configure(_ bool) error {
 		return fmt.Errorf("config error in %s [memory limit too low for configured prefetch]", bc.Name())
 	}
 
-	log.Info("BlockCache::Configure : block size %v, mem size %v, worker %v, prefetch %v, disk path %v, max size %v, disk timeout %v, prefetch-on-open %t, maxDiskUsageHit %v, noPrefetch %v",
-		bc.blockSize, bc.memSize, bc.workers, bc.prefetch, bc.tmpPath, bc.diskSize, bc.diskTimeout, bc.prefetchOnOpen, bc.maxDiskUsageHit, bc.noPrefetch)
+	log.Info("BlockCache::Configure : block size %v, mem size %v, worker %v, prefetch %v, disk path %v, max size %v, disk timeout %v, prefetch-on-open %t, maxDiskUsageHit %v, noPrefetch %v, enable-random-write %v",
+		bc.blockSize, bc.memSize, bc.workers, bc.prefetch, bc.tmpPath, bc.diskSize, bc.diskTimeout, bc.prefetchOnOpen, bc.maxDiskUsageHit, bc.noPrefetch, bc.enableRandomWrite)
 
 	bc.blockPool = NewBlockPool(bc.blockSize, bc.memSize)
 	if bc.blockPool == nil {
@@ -927,6 +930,15 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 
 	// log.Debug("BlockCache::WriteFile : Writing handle %v=>%v: offset %v, %v bytes", options.Handle.ID, options.Handle.Path, options.Offset, len(options.Data))
 
+	// check for possible random write scenario and block the write request
+	if options.Offset < options.Handle.Size-int64(MIN_WRITE_BLOCK*bc.blockSize) {
+		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v where handle size is %v", options.Offset, options.Handle.Size)
+		if !bc.enableRandomWrite {
+			log.Err("BlockCache::WriteFile : Blocking random write")
+			return 0, fmt.Errorf("blocking random write for write offset %v where handle size is %v", options.Offset, options.Handle.Size)
+		}
+	}
+
 	// Keep getting next blocks until you read the request amount of data
 	dataWritten := int(0)
 	for dataWritten < len(options.Data) {
@@ -996,7 +1008,14 @@ func (bc *BlockCache) getOrCreateBlock(handle *handlemap.Handle, offset uint64) 
 
 		if block.offset < uint64(handle.Size) {
 			// TODO: add case for committing the dirty blocks and download the given block
-			_, shouldDownload := shouldCommitAndDownload(block.id, handle)
+			shouldCommit, shouldDownload := shouldCommitAndDownload(block.id, handle)
+
+			// if a block has been staged and deleted from the buffer list, then we should commit the existing blocks
+			// TODO: commit the dirty blocks and download the given block
+			if shouldCommit {
+				log.Err("BlockCache::getOrCreateBlock : Fetching an uncommitted block %v for %v=>%s", block.id, handle.ID, handle.Path)
+				return nil, fmt.Errorf("fetching an uncommitted block %v for %v=>%s", block.id, handle.ID, handle.Path)
+			}
 
 			// download the block if,
 			//    - it was already committed
@@ -1043,6 +1062,10 @@ func (bc *BlockCache) getOrCreateBlock(handle *handlemap.Handle, offset uint64) 
 			<-block.state
 			block.flags.Clear(BlockFlagDownloading)
 			block.Unblock()
+		} else if block.flags.IsSet(BlockFlagUploading) {
+			// TODO: wait till a block is uploaded and then write to it
+			log.Err("BlockCache::getOrCreateBlock : Race condition where block %v is being uploaded and written to in parallel for %v=>%s", block.id, handle.ID, handle.Path)
+			return nil, fmt.Errorf("race condition where block %v is being uploaded and written to in parallel for %v=>%s", block.id, handle.ID, handle.Path)
 		}
 	}
 
@@ -1328,6 +1351,12 @@ func (bc *BlockCache) getBlockIDList(handle *handlemap.Handle) ([]string, error)
 
 	for i < len(offsets) {
 		if index == offsets[i] {
+			// TODO: when a staged block (not last block) has data less than block size
+			if i != len(offsets)-1 && listMap[offsets[i]].size != bc.blockSize {
+				log.Err("BlockCache::getBlockIDList : Staged block %v has less data %v for %v=>%s", offsets[i], listMap[offsets[i]].size, handle.ID, handle.Path)
+				return nil, fmt.Errorf("staged block %v has less data %v for %v=>%s", offsets[i], listMap[offsets[i]].size, handle.ID, handle.Path)
+			}
+
 			blockIDList = append(blockIDList, listMap[offsets[i]].id)
 			log.Debug("BlockCache::getBlockIDList : Preparing blocklist for %v=>%s (%v :  %v, size %v)", handle.ID, handle.Path, offsets[i], listMap[offsets[i]].id, listMap[offsets[i]].size)
 			index++
@@ -1580,4 +1609,9 @@ func init() {
 	blockCachePrefetchOnOpen := config.AddBoolFlag("block-cache-prefetch-on-open", false, "Start prefetching on open or wait for first read.")
 	config.BindPFlag(compName+".prefetch-on-open", blockCachePrefetchOnOpen)
 
+	// flag is hidden and its default value is false.
+	// It will block the random write cases where data-integrity issues have been observed.
+	blockCacheEnableRandomWrite := config.AddBoolFlag("block-cache-enable-random-write", false, "Enable random write in block cache")
+	config.BindPFlag(compName+".enable-random-write", blockCacheEnableRandomWrite)
+	blockCacheEnableRandomWrite.Hidden = true
 }

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -938,7 +938,7 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 	// check for possible random write scenario and block the write request
 	blockIndex := bc.getBlockIndex(uint64(options.Offset))
 	lastBlockIndex := bc.getBlockIndex(uint64(options.Offset))
-	if (blockIndex < lastBlockIndex) && ((lastBlockIndex-1)-blockIndex > MIN_WRITE_BLOCK) {
+	if (blockIndex < lastBlockIndex) && ((lastBlockIndex+1)-blockIndex > MIN_WRITE_BLOCK) {
 		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v and block %v, where handle size is %v", options.Offset, blockIndex, options.Handle.Size)
 		if !bc.enableRandomWrite {
 			log.Err("BlockCache::WriteFile : Blocking random write")

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -937,7 +937,7 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 
 	// check for possible random write scenario and block the write request
 	blockIndex := bc.getBlockIndex(uint64(options.Offset))
-	lastBlockIndex := bc.getBlockIndex(uint64(options.Offset))
+	lastBlockIndex := bc.getBlockIndex(uint64(options.Handle.Size))
 	if (blockIndex < lastBlockIndex) && ((lastBlockIndex+1)-blockIndex > uint64(bc.prefetch)) {
 		log.Debug("BlockCache::WriteFile : Random write detection for write offset %v and block %v, where handle size is %v", options.Offset, blockIndex, options.Handle.Size)
 		if !bc.enableRandomWrite {

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -819,7 +819,8 @@ func (suite *blockCacheTestSuite) TestWriteFileMultiBlock() {
 }
 
 func (suite *blockCacheTestSuite) TestWriteFileMultiBlockWithOverwrite() {
-	tobj, err := setupPipeline("")
+	cfg := "block_cache:\n  block-size-mb: 1\n  mem-size-mb: 20\n  prefetch: 12\n  parallelism: 10\n  enable-random-write: true"
+	tobj, err := setupPipeline(cfg)
 	defer tobj.cleanupPipeline()
 
 	suite.assert.Nil(err)
@@ -870,7 +871,8 @@ func (suite *blockCacheTestSuite) TestWriteFileMultiBlockWithOverwrite() {
 }
 
 func (suite *blockCacheTestSuite) TestWritefileWithAppend() {
-	tobj, err := setupPipeline("")
+	cfg := "block_cache:\n  block-size-mb: 1\n  mem-size-mb: 20\n  prefetch: 12\n  parallelism: 10\n  enable-random-write: true"
+	tobj, err := setupPipeline(cfg)
 	defer tobj.cleanupPipeline()
 
 	suite.assert.Nil(err)

--- a/component/block_cache/blockpool_test.go
+++ b/component/block_cache/blockpool_test.go
@@ -153,6 +153,9 @@ func (suite *blockpoolTestSuite) TestUsage() {
 		bp.Release(blk)
 	}
 
+	// adding wait for the blocks to be reset and pushed back to the blocks channel
+	time.Sleep(2 * time.Second)
+
 	usage = bp.Usage()
 	suite.assert.Equal(usage, uint32(20)) // because of zeroBlock
 

--- a/testdata/config/azure_block_perf.yaml
+++ b/testdata/config/azure_block_perf.yaml
@@ -23,6 +23,7 @@ block_cache:
   parallelism: 128
   disk-timeout-sec: 200
   prefetch-on-open: true
+  enable-random-write: true
 
 attr_cache:
   timeout-sec: 7200

--- a/testdata/config/azure_key_bc.yaml
+++ b/testdata/config/azure_key_bc.yaml
@@ -25,6 +25,7 @@ block_cache:
 
   prefetch: 120
   parallelism: 128
+  enable-random-write: true
 
 attr_cache:
   timeout-sec: 3600


### PR DESCRIPTION
Random write operations in block cache will be disabled by default. It can be enabled by passing the CLI flag `--block-cache-enable-random-write` in the mount command.

This PR also checks and returns error in the following cases:

1. Race condition between uploading and writing to a same block.
2. Random write scenario where a block has been staged and cleared from the in-memory cache and write call comes for that block.
3. A staged block (not last block) has data less than the block size.

The fixes for the above will be done in future PRs.