### PR TITLE
Preserve blocks on flush 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.2 (Unreleased)
+
+**Bug Fixes**
+- Fixed close on close channel related panic
+
+
 ## 2.3.1 (Unreleased)
 **NOTICE**
 - Due to data integrity issues, random write operations has been disabled in block cache. Refer [#1484](https://github.com/Azure/azure-storage-fuse/pull/1484) for blocked scenarios.

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -1233,10 +1233,14 @@ func (bc *BlockCache) waitAndFreeUploadedBlocks(handle *handlemap.Handle, cnt in
 		block := node.Value.(*Block)
 		if block.id != -1 {
 			// Wait for upload of this block to complete
-			<-block.state
+			_, ok := <-block.state
 			block.flags.Clear(BlockFlagUploading)
+			if ok {
+				block.Unblock()
+			}
+		} else {
+			block.Unblock()
 		}
-		block.Unblock()
 
 		if block.IsFailed() {
 			log.Err("BlockCache::waitAndFreeUploadedBlocks : Failed to upload block, posting back to cooking list %v=>%s (index %v, offset %v)", handle.ID, handle.Path, block.id, block.offset)

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -1250,9 +1250,8 @@ func (bc *BlockCache) waitAndFreeUploadedBlocks(handle *handlemap.Handle, cnt in
 		}
 		cnt--
 
-		log.Debug("BlockCache::waitAndFreeUploadedBlocks : Block cleanup for block %v=>%s (index %v, offset %v)", handle.ID, handle.Path, block.id, block.offset)
-
 		if wipeoutBlock || block.id == -1 {
+			log.Debug("BlockCache::waitAndFreeUploadedBlocks : Block cleanup for block %v=>%s (index %v, offset %v)", handle.ID, handle.Path, block.id, block.offset)
 			handle.RemoveValue(fmt.Sprintf("%v", block.id))
 			nodeList.Remove(node)
 			block.node = nil

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -972,7 +972,7 @@ func (suite *blockCacheTestSuite) TestWritefileWithAppend() {
 	tobj.blockCache.prefetchOnOpen = true
 
 	path := "testWriteBlockAppend"
-	data := make([]byte, 20*_1MB)
+	data := make([]byte, 13*_1MB)
 	_, _ = rand.Read(data)
 
 	options := internal.CreateFileOptions{Name: path, Mode: 0777}


### PR DESCRIPTION
- Do not delete blocks on sync/flush and preserve them for later usage.
- Delete them only when file is closed.