### PR TITLE
panic on calling close on close channel

### DIFF
--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -1102,7 +1102,6 @@ func (bc *BlockCache) getOrCreateBlock(handle *handlemap.Handle, offset uint64) 
 			}
 			block.flags.Clear(BlockFlagUploading)
 			block.flags.Clear(BlockFlagSynced) //clearing the BlockFlagSynced flag since the block has been staged and will be used again for write
-			block.Unblock()
 
 			if block.node != nil {
 				_ = handle.Buffers.Cooked.Remove(block.node)

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -1213,11 +1213,12 @@ func (bc *BlockCache) waitAndFreeUploadedBlocks(handle *handlemap.Handle, cnt in
 		block := node.Value.(*Block)
 		if block.id != -1 {
 			// Wait for upload of this block to complete
-			<-block.state
+			_, ok := <-block.state
+			if ok {
+				block.Unblock()
+			}
 			block.flags.Clear(BlockFlagUploading)
 		}
-
-		block.Unblock()
 
 		if block.IsFailed() {
 			log.Err("BlockCache::waitAndFreeUploadedBlocks : Failed to upload block, posting back to cooking list %v=>%s (index %v, offset %v)", handle.ID, handle.Path, block.id, block.offset)


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-storage-fuse/issues/1426

Closing the channel twice causing the panic.
This can happen in 3 scenarios:
1. Closing the file.
2. when requesting a block for writing.
3. Evicting the blocks when the file is in rand-read mode.

Both call the same method waitAndFreeUploadedBlocks, which unblocks the requested no of blocks inside the cooked list. but cooked list might contain the blocks which were unblocked already (i.e., when blocks are downloaded they were moved to cooked list when there is a reader for them and unblocked), hence calling unblock on them again causes panic.
