### PR TITLE
Updating an uncommitted block which has been deleted from buffer cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug Fixes**
 - Flush shall only sync the blocks to storage and not delete them from local cache.
 - Random write has been re-enabled in block cache.
+- Writing to an uncommitted block which has been deleted from the in-memory cache.
 
 ## 2.3.1 (Unreleased)
 **NOTICE**

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -96,6 +96,11 @@ func getFakeStoragePath(base string) string {
 	return tmp_path
 }
 
+func getTestFileName(name string) string {
+	n := strings.Split(name, "/")
+	return n[len(n)-1]
+}
+
 func setupPipeline(cfg string) (*testObj, error) {
 	tobj := &testObj{
 		fake_storage_path: getFakeStoragePath("block_cache"),
@@ -309,7 +314,7 @@ func (suite *blockCacheTestSuite) TestOpenFileFail() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "a"
+	path := getTestFileName(suite.T().Name())
 	options := internal.OpenFileOptions{Name: path}
 	h, err := tobj.blockCache.OpenFile(options)
 	suite.assert.NotNil(err)
@@ -324,11 +329,11 @@ func (suite *blockCacheTestSuite) TestFileOpenClose() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	fileName := "bc.tst"
-	stroagePath := filepath.Join(tobj.fake_storage_path, fileName)
+	fileName := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, fileName)
 	data := make([]byte, 5*_1MB)
 	_, _ = rand.Read(data)
-	ioutil.WriteFile(stroagePath, data, 0777)
+	ioutil.WriteFile(storagePath, data, 0777)
 
 	options := internal.OpenFileOptions{Name: fileName}
 	h, err := tobj.blockCache.OpenFile(options)
@@ -351,9 +356,9 @@ func (suite *blockCacheTestSuite) TestValidateBlockList() {
 	suite.assert.NotNil(tobj.blockCache)
 	suite.assert.Equal(tobj.blockCache.blockSize, 20*_1MB)
 
-	fileName := "testFile"
-	stroagePath := filepath.Join(tobj.fake_storage_path, fileName)
-	os.WriteFile(stroagePath, []byte("Hello, World!"), 0777)
+	fileName := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, fileName)
+	os.WriteFile(storagePath, []byte("Hello, World!"), 0777)
 	options := internal.OpenFileOptions{Name: fileName}
 	h, err := tobj.blockCache.OpenFile(options)
 	suite.assert.Nil(err)
@@ -443,7 +448,7 @@ func (suite *blockCacheTestSuite) TestFileReadTotalBytes() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testWriteSimple"
+	path := getTestFileName(suite.T().Name())
 	options := internal.CreateFileOptions{Name: path, Mode: 0777}
 	h, err := tobj.blockCache.CreateFile(options)
 	suite.assert.Nil(err)
@@ -491,7 +496,7 @@ func (suite *blockCacheTestSuite) TestFileReadBlockCacheTmpPath() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testWriteSimple"
+	path := getTestFileName(suite.T().Name())
 	options := internal.CreateFileOptions{Name: path, Mode: 0777}
 	h, err := tobj.blockCache.CreateFile(options)
 	suite.assert.Nil(err)
@@ -581,11 +586,11 @@ func (suite *blockCacheTestSuite) TestFileReadSerial() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	fileName := "bc.tst"
-	stroagePath := filepath.Join(tobj.fake_storage_path, fileName)
+	fileName := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, fileName)
 	data := make([]byte, 50*_1MB)
 	_, _ = rand.Read(data)
-	ioutil.WriteFile(stroagePath, data, 0777)
+	ioutil.WriteFile(storagePath, data, 0777)
 
 	options := internal.OpenFileOptions{Name: fileName}
 	h, err := tobj.blockCache.OpenFile(options)
@@ -623,11 +628,11 @@ func (suite *blockCacheTestSuite) TestFileReadRandom() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	fileName := "bc.tst"
-	stroagePath := filepath.Join(tobj.fake_storage_path, fileName)
+	fileName := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, fileName)
 	data := make([]byte, 100*_1MB)
 	_, _ = rand.Read(data)
-	ioutil.WriteFile(stroagePath, data, 0777)
+	ioutil.WriteFile(storagePath, data, 0777)
 
 	options := internal.OpenFileOptions{Name: fileName}
 	h, err := tobj.blockCache.OpenFile(options)
@@ -664,11 +669,11 @@ func (suite *blockCacheTestSuite) TestFileReadRandomNoPrefetch() {
 	tobj.blockCache.noPrefetch = true
 	tobj.blockCache.prefetch = 0
 
-	fileName := "bc.tst"
-	stroagePath := filepath.Join(tobj.fake_storage_path, fileName)
+	fileName := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, fileName)
 	data := make([]byte, 100*_1MB)
 	_, _ = rand.Read(data)
-	ioutil.WriteFile(stroagePath, data, 0777)
+	ioutil.WriteFile(storagePath, data, 0777)
 
 	options := internal.OpenFileOptions{Name: fileName}
 	h, err := tobj.blockCache.OpenFile(options)
@@ -753,7 +758,7 @@ func (suite *blockCacheTestSuite) TestCreateFile() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testCreate"
+	path := getTestFileName(suite.T().Name())
 	options := internal.CreateFileOptions{Name: path}
 	h, err := tobj.blockCache.CreateFile(options)
 	suite.assert.Nil(err)
@@ -761,8 +766,8 @@ func (suite *blockCacheTestSuite) TestCreateFile() {
 	suite.assert.Equal(h.Size, int64(0))
 	suite.assert.False(h.Dirty())
 
-	stroagePath := filepath.Join(tobj.fake_storage_path, path)
-	fs, err := os.Stat(stroagePath)
+	storagePath := filepath.Join(tobj.fake_storage_path, path)
+	fs, err := os.Stat(storagePath)
 	suite.assert.Nil(err)
 	suite.assert.Equal(fs.Size(), int64(0))
 
@@ -781,11 +786,11 @@ func (suite *blockCacheTestSuite) TestOpenWithTruncate() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	fileName := "testTruncate.tst"
-	stroagePath := filepath.Join(tobj.fake_storage_path, fileName)
+	fileName := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, fileName)
 	data := make([]byte, 5*_1MB)
 	_, _ = rand.Read(data)
-	ioutil.WriteFile(stroagePath, data, 0777)
+	ioutil.WriteFile(storagePath, data, 0777)
 
 	options := internal.OpenFileOptions{Name: fileName}
 	h, err := tobj.blockCache.OpenFile(options)
@@ -814,7 +819,7 @@ func (suite *blockCacheTestSuite) TestWriteFileSimple() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testWriteSimple"
+	path := getTestFileName(suite.T().Name())
 	options := internal.CreateFileOptions{Name: path, Mode: 0777}
 	h, err := tobj.blockCache.CreateFile(options)
 	suite.assert.Nil(err)
@@ -822,8 +827,8 @@ func (suite *blockCacheTestSuite) TestWriteFileSimple() {
 	suite.assert.Equal(h.Size, int64(0))
 	suite.assert.False(h.Dirty())
 
-	stroagePath := filepath.Join(tobj.fake_storage_path, path)
-	fs, err := os.Stat(stroagePath)
+	storagePath := filepath.Join(tobj.fake_storage_path, path)
+	fs, err := os.Stat(storagePath)
 	suite.assert.Nil(err)
 	suite.assert.Equal(fs.Size(), int64(0))
 
@@ -846,8 +851,8 @@ func (suite *blockCacheTestSuite) TestWriteFileSimple() {
 	suite.assert.Nil(err)
 	suite.assert.False(h.Dirty())
 
-	stroagePath = filepath.Join(tobj.fake_storage_path, path)
-	fs, err = os.Stat(stroagePath)
+	storagePath = filepath.Join(tobj.fake_storage_path, path)
+	fs, err = os.Stat(storagePath)
 	suite.assert.Nil(err)
 	suite.assert.Equal(fs.Size(), int64(5))
 
@@ -862,8 +867,8 @@ func (suite *blockCacheTestSuite) TestWriteFileSimple() {
 	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
 	suite.assert.Nil(err)
 
-	stroagePath = filepath.Join(tobj.fake_storage_path, path)
-	fs, err = os.Stat(stroagePath)
+	storagePath = filepath.Join(tobj.fake_storage_path, path)
+	fs, err = os.Stat(storagePath)
 	suite.assert.Nil(err)
 	suite.assert.Equal(fs.Size(), int64(10))
 
@@ -877,8 +882,8 @@ func (suite *blockCacheTestSuite) TestWriteFileMultiBlock() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testWriteBlock"
-	stroagePath := filepath.Join(tobj.fake_storage_path, path)
+	path := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, path)
 
 	data := make([]byte, 5*_1MB)
 	_, _ = rand.Read(data)
@@ -901,8 +906,8 @@ func (suite *blockCacheTestSuite) TestWriteFileMultiBlock() {
 	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
 	suite.assert.Nil(err)
 
-	stroagePath = filepath.Join(tobj.fake_storage_path, path)
-	fs, err := os.Stat(stroagePath)
+	storagePath = filepath.Join(tobj.fake_storage_path, path)
+	fs, err := os.Stat(storagePath)
 	suite.assert.Nil(err)
 	suite.assert.Equal(fs.Size(), int64(len(data)))
 
@@ -916,8 +921,8 @@ func (suite *blockCacheTestSuite) TestWriteFileMultiBlockWithOverwrite() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testWriteBlock"
-	stroagePath := filepath.Join(tobj.fake_storage_path, path)
+	path := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, path)
 
 	data := make([]byte, 5*_1MB)
 	_, _ = rand.Read(data)
@@ -952,8 +957,8 @@ func (suite *blockCacheTestSuite) TestWriteFileMultiBlockWithOverwrite() {
 	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
 	suite.assert.Nil(err)
 
-	stroagePath = filepath.Join(tobj.fake_storage_path, path)
-	fs, err := os.Stat(stroagePath)
+	storagePath = filepath.Join(tobj.fake_storage_path, path)
+	fs, err := os.Stat(storagePath)
 	suite.assert.Nil(err)
 	suite.assert.Equal(fs.Size(), int64(len(data)))
 
@@ -969,7 +974,7 @@ func (suite *blockCacheTestSuite) TestWritefileWithAppend() {
 
 	tobj.blockCache.prefetchOnOpen = true
 
-	path := "testWriteBlockAppend"
+	path := getTestFileName(suite.T().Name())
 	data := make([]byte, 13*_1MB)
 	_, _ = rand.Read(data)
 
@@ -1035,7 +1040,7 @@ func (suite *blockCacheTestSuite) TestWriteBlockOutOfRange() {
 	tobj.blockCache.prefetchOnOpen = true
 	tobj.blockCache.blockSize = 10
 
-	path := "testInvalidWriteBlock"
+	path := getTestFileName(suite.T().Name())
 	data := make([]byte, 20*_1MB)
 	_, _ = rand.Read(data)
 
@@ -1145,7 +1150,7 @@ func (suite *blockCacheTestSuite) TestZZZZLazyWrite() {
 
 	tobj.blockCache.lazyWrite = true
 
-	file := "file101"
+	file := getTestFileName(suite.T().Name())
 	handle, _ := tobj.blockCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 	data := make([]byte, 10*1024*1024)
 	_, _ = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: handle, Offset: 0, Data: data})
@@ -1179,7 +1184,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFile() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testSparseWrite"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -1194,7 +1199,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFile() {
 	}(fh)
 
 	// write 1MB data at offset 0
-	n, err := fh.WriteAt(dataBuff[0:_1MB], 0)
+	n, err := fh.WriteAt(dataBuff[:_1MB], 0)
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 
@@ -1221,7 +1226,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFile() {
 	suite.assert.False(h.Dirty())
 
 	// write 1MB data at offset 0
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[0:_1MB]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[:_1MB]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 	suite.assert.True(h.Dirty())
@@ -1266,7 +1271,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFileWithPartialBlock() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testSparseWrite"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -1281,7 +1286,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFileWithPartialBlock() {
 	}(fh)
 
 	// write 1MB data at offset 0
-	n, err := fh.WriteAt(dataBuff[0:_1MB], 0)
+	n, err := fh.WriteAt(dataBuff[:_1MB], 0)
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 
@@ -1309,7 +1314,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFileWithPartialBlock() {
 
 	// write 1MB data at offset 0
 	// partial block where it has data only from 0 to 1MB
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[0:_1MB]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[:_1MB]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 	suite.assert.True(h.Dirty())
@@ -1354,7 +1359,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFileWithBlockOverlap() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testSparseWrite"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -1369,7 +1374,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFileWithBlockOverlap() {
 	}(fh)
 
 	// write 1MB data at offset 0
-	n, err := fh.WriteAt(dataBuff[0:_1MB], 0)
+	n, err := fh.WriteAt(dataBuff[:_1MB], 0)
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 
@@ -1396,7 +1401,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteSparseFileWithBlockOverlap() {
 	suite.assert.False(h.Dirty())
 
 	// write 1MB data at offset 0
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[0:_1MB]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[:_1MB]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 	suite.assert.True(h.Dirty())
@@ -1442,7 +1447,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteFileOneBlock() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testWriteOneBlock"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -1519,7 +1524,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteFlushAndOverwrite() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testSparseWrite"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -1534,7 +1539,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteFlushAndOverwrite() {
 	}(fh)
 
 	// write 1MB data at offset 0
-	n, err := fh.WriteAt(dataBuff[0:_1MB], 0)
+	n, err := fh.WriteAt(dataBuff[:_1MB], 0)
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 
@@ -1566,7 +1571,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteFlushAndOverwrite() {
 	suite.assert.False(h.Dirty())
 
 	// write 1MB data at offset 0
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[0:_1MB]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[:_1MB]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 	suite.assert.True(h.Dirty())
@@ -1613,7 +1618,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteFlushAndOverwrite() {
 	suite.assert.Equal(l, r)
 }
 
-func (suite *blockCacheTestSuite) TestDisableRandomWrite() {
+func (suite *blockCacheTestSuite) TestRandomWriteUncommittedBlock() {
 	prefetch := 12
 	cfg := fmt.Sprintf("block_cache:\n  block-size-mb: 1\n  mem-size-mb: 20\n  prefetch: %v\n  parallelism: 10", prefetch)
 	tobj, err := setupPipeline(cfg)
@@ -1622,7 +1627,7 @@ func (suite *blockCacheTestSuite) TestDisableRandomWrite() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testDisableRandomWrite"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 
 	// write using block cache
@@ -1634,20 +1639,26 @@ func (suite *blockCacheTestSuite) TestDisableRandomWrite() {
 	suite.assert.False(h.Dirty())
 
 	for i := 0; i <= prefetch; i++ {
-		n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(i * int(_1MB)), Data: dataBuff[0:_1MB]})
+		n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(i * int(_1MB)), Data: dataBuff[:_1MB]})
 		suite.assert.Nil(err)
 		suite.assert.Equal(n, int(_1MB))
 		suite.assert.True(h.Dirty())
 	}
 
+	suite.assert.Equal(h.Buffers.Cooking.Len()+h.Buffers.Cooked.Len(), prefetch)
+
 	// write 1MB data back at offset 0
-	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[0:_1MB]})
-	suite.assert.NotNil(err)
-	suite.assert.Equal(n, 0)
+	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[:_1MB]})
+	suite.assert.Nil(err)
+	suite.assert.Equal(n, int(_1MB))
+	suite.assert.True(h.Dirty())
+
+	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
+	suite.assert.Nil(err)
 
 	fs, err := os.Stat(storagePath)
 	suite.assert.Nil(err)
-	suite.assert.Equal(fs.Size(), int64(0))
+	suite.assert.Equal(fs.Size(), int64(13*_1MB))
 }
 
 func (suite *blockCacheTestSuite) TestRandomWriteExistingFile() {
@@ -1658,7 +1669,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteExistingFile() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testRandomWriteExistingFile"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 
 	// write using block cache
@@ -1690,7 +1701,7 @@ func (suite *blockCacheTestSuite) TestRandomWriteExistingFile() {
 	suite.assert.False(h.Dirty())
 
 	// write randomly in new handle at offset 2MB
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: nh, Offset: int64(2 * _1MB), Data: dataBuff[0:10]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: nh, Offset: int64(2 * _1MB), Data: dataBuff[:10]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 10)
 	suite.assert.True(nh.Dirty())
@@ -1711,7 +1722,7 @@ func (suite *blockCacheTestSuite) TestPreventRaceCondition() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testRandomWrite"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 
 	data := make([]byte, _1MB)
@@ -1726,7 +1737,7 @@ func (suite *blockCacheTestSuite) TestPreventRaceCondition() {
 	suite.assert.False(h.Dirty())
 
 	// writing at offset 0 in block 0
-	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data[0:10]})
+	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data[:10]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 10)
 	suite.assert.True(h.Dirty())
@@ -1750,7 +1761,7 @@ func (suite *blockCacheTestSuite) TestPreventRaceCondition() {
 	suite.assert.Equal(0, h.Buffers.Cooked.Len())
 
 	// writing at offset 3MB in block 3
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(3 * _1MB), Data: data[0:1]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(3 * _1MB), Data: data[:1]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 1)
 	suite.assert.True(h.Dirty())
@@ -1783,7 +1794,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWrite() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testBlockUpload"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 
 	data := make([]byte, _1MB)
@@ -1797,7 +1808,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWrite() {
 	suite.assert.False(h.Dirty())
 
 	// writing at offset 0 in block 0
-	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data[0:10]})
+	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data[:10]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 10)
 	suite.assert.True(h.Dirty())
@@ -1805,7 +1816,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWrite() {
 	suite.assert.Equal(0, h.Buffers.Cooked.Len())
 
 	// writing at offset 1MB in block 1
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(_1MB), Data: data[0:100]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(_1MB), Data: data[:100]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 100)
 	suite.assert.True(h.Dirty())
@@ -1844,7 +1855,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWriteValidation() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testBlockUploadValidation"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -1862,7 +1873,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWriteValidation() {
 	}(fh)
 
 	// write at offset 0 in block 0
-	n, err := fh.WriteAt(data[0:10], 0)
+	n, err := fh.WriteAt(data[:10], 0)
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 10)
 
@@ -1877,7 +1888,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWriteValidation() {
 	suite.assert.Equal(n, int(_1MB))
 
 	// write at offset 3MB in block 3
-	n, err = fh.WriteAt(data[0:100], int64(3*_1MB))
+	n, err = fh.WriteAt(data[:100], int64(3*_1MB))
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 100)
 
@@ -1899,7 +1910,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWriteValidation() {
 	suite.assert.False(h.Dirty())
 
 	// writing at offset 0 in block 0
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data[0:10]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: data[:10]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 10)
 	suite.assert.True(h.Dirty())
@@ -1923,7 +1934,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelUploadAndWriteValidation() {
 	suite.assert.Equal(0, h.Buffers.Cooked.Len())
 
 	// writing at offset 3MB in block 3
-	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(3 * _1MB), Data: data[0:100]})
+	n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(3 * _1MB), Data: data[:100]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, 100)
 	suite.assert.True(h.Dirty())
@@ -1970,7 +1981,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelReadAndWriteValidation() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testBlockUploadValidation"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -2068,7 +2079,7 @@ func (suite *blockCacheTestSuite) TestBlockOverwriteValidation() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testBlockUploadValidation"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 	localPath := filepath.Join(tobj.disk_cache_path, path)
 
@@ -2165,7 +2176,7 @@ func (suite *blockCacheTestSuite) TestBlockFailOverwrite() {
 	suite.assert.Nil(err)
 	suite.assert.NotNil(tobj.blockCache)
 
-	path := "testBlockUploadValidation"
+	path := getTestFileName(suite.T().Name())
 	storagePath := filepath.Join(tobj.fake_storage_path, path)
 
 	// write using block cache


### PR DESCRIPTION
If write request comes for a block which has been staged (uncommitted) and deleted from the buffer list, then
- Stage the existing dirty blocks
- Commit the staged blocks via PutBlockList
- Download the given block for which the write request has come