### PR TITLE
Check download status before overwriting a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Flush shall only sync the blocks to storage and not delete them from local cache.
 - Random write has been re-enabled in block cache.
 - Writing to an uncommitted block which has been deleted from the in-memory cache.
+- Return failure if download of a block failed which is to be updated.
 
 ## 2.3.1 (Unreleased)
 **NOTICE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Flush shall only sync the blocks to storage and not delete them from local cache.
 - Random write has been re-enabled in block cache.
 - Writing to an uncommitted block which has been deleted from the in-memory cache.
-- Return failure if download of a block failed which is to be updated.
+- Check download status of a block before updating and return error if it failed to download.
 
 ## 2.3.1 (Unreleased)
 **NOTICE**


### PR DESCRIPTION
Return error if a block which is to be overwritten, fails to download.