### PR TITLE
Reading an uncommitted block which has been deleted from buffer cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Bug Fixes**
 - Flush shall only sync the blocks to storage and not delete them from local cache.
 - Random write has been re-enabled in block cache.
-- Writing to an uncommitted block which has been deleted from the in-memory cache.
+- Reading or writing to an uncommitted block which has been deleted from the in-memory cache.
 - Check download status of a block before updating and return error if it failed to download.
 
 ## 2.3.1 (Unreleased)

--- a/azure-pipeline-templates/verbose-tests.yml
+++ b/azure-pipeline-templates/verbose-tests.yml
@@ -177,7 +177,7 @@ steps:
       distro_name: ${{ parameters.distro_name }}
       quick_test: false
       verbose_log: ${{ parameters.verbose_log }}
-      clone: true
+      clone: false
 
   - ${{ if eq(parameters.test_sas_credential, true) }}:
     - template: e2e-tests.yml

--- a/cmd/health-monitor.go
+++ b/cmd/health-monitor.go
@@ -132,7 +132,7 @@ func validateHMonOptions() error {
 	}
 
 	if len(errMsg) != 0 {
-		return fmt.Errorf(errMsg)
+		return fmt.Errorf("%s", errMsg)
 	}
 
 	return nil

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -754,5 +754,5 @@ func init() {
 
 func Destroy(message string) error {
 	_ = log.Destroy()
-	return fmt.Errorf(message)
+	return fmt.Errorf("%s", message)
 }

--- a/component/azstorage/azauthmsi.go
+++ b/component/azstorage/azauthmsi.go
@@ -97,7 +97,7 @@ func (azmsi *azAuthMSI) getTokenCredentialUsingCLI() (azcore.TokenCredential, er
 		if msg == "" {
 			msg = err.Error()
 		}
-		return nil, fmt.Errorf(msg)
+		return nil, fmt.Errorf("%s", msg)
 	}
 
 	log.Info("azAuthMSI::getTokenCredentialUsingCLI : Successfully logged in using Azure CLI")

--- a/component/block_cache/block.go
+++ b/component/block_cache/block.go
@@ -51,6 +51,14 @@ const (
 	BlockFlagFailed             // Block upload/download has failed
 )
 
+// Flags to denote the status of upload/download of a block
+const (
+	BlockStatusDownloaded     int = iota + 1 // Download of this block is complete
+	BlockStatusUploaded                      // Upload of this block is complete
+	BlockStatusDownloadFailed                // Download of this block has failed
+	BlockStatusUploadFailed                  // Upload of this block has failed
+)
+
 // Block is a memory mapped buffer with its state to hold data
 type Block struct {
 	offset   uint64          // Start offset of the data this block holds
@@ -127,9 +135,9 @@ func (b *Block) Uploading() {
 }
 
 // Ready marks this Block is now ready for reading by its first reader (data download completed)
-func (b *Block) Ready() {
+func (b *Block) Ready(val int) {
 	select {
-	case b.state <- 1:
+	case b.state <- val:
 		break
 	default:
 		break

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -335,12 +335,12 @@ func (bc *BlockCache) OpenFile(options internal.OpenFileOptions) (*handlemap.Han
 
 	bc.prepareHandleForBlockCache(handle)
 
-	if options.Flags&os.O_TRUNC != 0 || options.Flags&os.O_WRONLY != 0 {
+	if options.Flags&os.O_TRUNC != 0 || (options.Flags&os.O_WRONLY != 0 && options.Flags&os.O_APPEND == 0) {
 		// If file is opened in truncate or wronly mode then we need to wipe out the data consider current file size as 0
 		log.Debug("BlockCache::OpenFile : Truncate %v to 0", options.Name)
 		handle.Size = 0
 		handle.Flags.Set(handlemap.HandleFlagDirty)
-	} else if options.Flags&os.O_RDWR != 0 && handle.Size != 0 {
+	} else if handle.Size != 0 && (options.Flags&os.O_RDWR != 0 || options.Flags&os.O_APPEND != 0) {
 		// File is not opened in read-only mode so we need to get the list of blocks and validate the size
 		// As there can be a potential write on this file, currently configured block size and block size of the file in container
 		// has to match otherwise it will corrupt the file. Fail the open call if this is not the case.

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -1111,7 +1111,6 @@ func (bc *BlockCache) getOrCreateBlock(handle *handlemap.Handle, offset uint64) 
 		// If the block was staged earlier then we are overwriting it here so move it back to cooking queue
 		if block.flags.IsSet(BlockFlagSynced) {
 			log.Debug("BlockCache::getOrCreateBlock : Overwriting back to staged block %v for %v=>%s", block.id, handle.ID, handle.Path)
-			bc.addToCooking(handle, block)
 
 		} else if block.flags.IsSet(BlockFlagDownloading) {
 			log.Debug("BlockCache::getOrCreateBlock : Waiting for download to finish for committed block %v for %v=>%s", block.id, handle.ID, handle.Path)
@@ -1132,9 +1131,9 @@ func (bc *BlockCache) getOrCreateBlock(handle *handlemap.Handle, offset uint64) 
 			log.Debug("BlockCache::getOrCreateBlock : Waiting for the block %v to upload for %v=>%s", block.id, handle.ID, handle.Path)
 			<-block.state
 			block.Unblock()
-
-			bc.addToCooking(handle, block)
 		}
+
+		bc.addToCooking(handle, block)
 
 		block.flags.Clear(BlockFlagUploading)
 		block.flags.Clear(BlockFlagDownloading)
@@ -1295,7 +1294,6 @@ func (bc *BlockCache) waitAndFreeUploadedBlocks(handle *handlemap.Handle, cnt in
 			_, ok := <-block.state
 			block.flags.Clear(BlockFlagDownloading)
 			block.flags.Clear(BlockFlagUploading)
-			block.flags.Clear(BlockFlagSynced)
 
 			if ok {
 				block.Unblock()

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -2480,7 +2480,6 @@ func (suite *blockCacheTestSuite) TestReadUncommittedPrefetchedBlock() {
 	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[:_1MB]})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
-	suite.assert.Equal(n, int(_1MB))
 	suite.assert.True(h.Dirty())
 
 	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
@@ -2504,7 +2503,7 @@ func (suite *blockCacheTestSuite) TestReadUncommittedPrefetchedBlock() {
 
 	suite.assert.Equal(h.Buffers.Cooking.Len()+h.Buffers.Cooked.Len(), prefetch)
 
-	// read blocks 0, 1 and 2 which prefetched blocks 1 and 2 are uncommmitted
+	// read blocks 0, 1 and 2 where prefetched blocks 1 and 2 are uncommmitted
 	data := make([]byte, 2*_1MB)
 	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
 	suite.assert.Nil(err)
@@ -2518,6 +2517,76 @@ func (suite *blockCacheTestSuite) TestReadUncommittedPrefetchedBlock() {
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 	suite.assert.Equal(data[:], dataBuff[4*_1MB:5*_1MB])
+	suite.assert.False(h.Dirty())
+
+	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
+	suite.assert.Nil(err)
+
+	fs, err := os.Stat(storagePath)
+	suite.assert.Nil(err)
+	suite.assert.Equal(fs.Size(), int64(62*_1MB))
+}
+
+func (suite *blockCacheTestSuite) TestReadWriteBlockInParallel() {
+	prefetch := 12
+	cfg := fmt.Sprintf("block_cache:\n  block-size-mb: 1\n  mem-size-mb: 20\n  prefetch: %v\n  parallelism: 1", prefetch)
+	tobj, err := setupPipeline(cfg)
+	defer tobj.cleanupPipeline()
+
+	suite.assert.Nil(err)
+	suite.assert.NotNil(tobj.blockCache)
+
+	path := getTestFileName(suite.T().Name())
+	storagePath := filepath.Join(tobj.fake_storage_path, path)
+
+	// write using block cache
+	options := internal.CreateFileOptions{Name: path, Mode: 0777}
+	h, err := tobj.blockCache.CreateFile(options)
+	suite.assert.Nil(err)
+	suite.assert.NotNil(h)
+	suite.assert.Equal(h.Size, int64(0))
+	suite.assert.False(h.Dirty())
+
+	n, err := tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: 0, Data: dataBuff[:]})
+	suite.assert.Nil(err)
+	suite.assert.Equal(n, int(5*_1MB))
+	suite.assert.True(h.Dirty())
+
+	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
+	suite.assert.Nil(err)
+	suite.assert.False(h.Dirty())
+
+	h, err = tobj.blockCache.OpenFile(internal.OpenFileOptions{Name: path, Flags: os.O_RDWR})
+	suite.assert.Nil(err)
+	suite.assert.NotNil(h)
+	suite.assert.Equal(h.Size, int64(5*_1MB))
+	suite.assert.False(h.Dirty())
+
+	ind := uint64(0)
+	for i := 5; i < prefetch+50; i++ {
+		n, err = tobj.blockCache.WriteFile(internal.WriteFileOptions{Handle: h, Offset: int64(i * int(_1MB)), Data: dataBuff[ind*_1MB : (ind+1)*_1MB]})
+		suite.assert.Nil(err)
+		suite.assert.Equal(n, int(_1MB))
+		suite.assert.True(h.Dirty())
+		ind = (ind + 1) % 5
+	}
+
+	suite.assert.Equal(h.Buffers.Cooking.Len()+h.Buffers.Cooked.Len(), prefetch)
+
+	// read blocks 0, 1 and 2
+	data := make([]byte, 2*_1MB)
+	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
+	suite.assert.Nil(err)
+	suite.assert.Equal(n, int(2*_1MB))
+	suite.assert.Equal(data[:], dataBuff[512:2*_1MB+512])
+	suite.assert.True(h.Dirty())
+
+	// read blocks 4 and 5
+	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(4 * _1MB), Data: data})
+	suite.assert.Nil(err)
+	suite.assert.Equal(n, int(2*_1MB))
+	suite.assert.Equal(data[:_1MB], dataBuff[4*_1MB:])
+	suite.assert.Equal(data[_1MB:], dataBuff[:_1MB])
 	suite.assert.False(h.Dirty())
 
 	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})

--- a/component/block_cache/block_test.go
+++ b/component/block_cache/block_test.go
@@ -143,7 +143,7 @@ func (suite *blockTestSuite) TestReady() {
 	b.ReUse()
 	suite.assert.NotNil(b.state)
 
-	b.Ready()
+	b.Ready(BlockStatusDownloaded)
 	suite.assert.Equal(len(b.state), 1)
 
 	<-b.state
@@ -167,7 +167,7 @@ func (suite *blockTestSuite) TestUnBlock() {
 	suite.assert.NotNil(b.state)
 	suite.assert.Nil(b.node)
 
-	b.Ready()
+	b.Ready(BlockStatusDownloaded)
 	suite.assert.Equal(len(b.state), 1)
 
 	<-b.state
@@ -201,7 +201,7 @@ func (suite *blockTestSuite) TestWriter() {
 	suite.assert.Equal(b.id, int64(-1))
 	suite.assert.False(b.IsDirty())
 
-	b.Ready()
+	b.Ready(BlockStatusDownloaded)
 	suite.assert.Equal(len(b.state), 1)
 
 	<-b.state
@@ -223,7 +223,7 @@ func (suite *blockTestSuite) TestWriter() {
 	b.NoMoreDirty()
 	suite.assert.False(b.IsDirty())
 
-	b.Ready()
+	b.Ready(BlockStatusUploaded)
 	suite.assert.Equal(len(b.state), 1)
 
 	<-b.state


### PR DESCRIPTION
If read request comes for a block which has been staged (uncommitted) and deleted from the buffer list, then

- Stage the existing dirty blocks
- Commit the staged blocks via PutBlockList
- Download the given block for which the read request has come

This also applies during prefetching a block which is uncommitted and has been cleared from the buffer list.