### PR TITLE
File Cache failed to upload if Read perm is not given 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Random write has been re-enabled in block cache.
 - Writing to an uncommitted block which has been deleted from the in-memory cache.
 - Check download status of a block before updating and return error if it failed to download.
-- File Cache will add 'Read' permissions, if not already set, before upload and reset them afterward.
+- Fixed an issue in File-Cache that caused upload to fail due to insufficient permissions.
 
 ## 2.3.1 (Unreleased)
 **NOTICE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Random write has been re-enabled in block cache.
 - Writing to an uncommitted block which has been deleted from the in-memory cache.
 - Check download status of a block before updating and return error if it failed to download.
+- File Cache will add 'Read' permissions, if not already set, before upload and reset them afterward.
 
 ## 2.3.1 (Unreleased)
 **NOTICE**

--- a/cmd/health-monitor.go
+++ b/cmd/health-monitor.go
@@ -132,7 +132,7 @@ func validateHMonOptions() error {
 	}
 
 	if len(errMsg) != 0 {
-		return fmt.Errorf(errMsg)
+		return fmt.Errorf("%s", errMsg)
 	}
 
 	return nil

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -754,5 +754,5 @@ func init() {
 
 func Destroy(message string) error {
 	_ = log.Destroy()
-	return fmt.Errorf(message)
+	return fmt.Errorf("%s", message)
 }

--- a/component/azstorage/azauthmsi.go
+++ b/component/azstorage/azauthmsi.go
@@ -97,7 +97,7 @@ func (azmsi *azAuthMSI) getTokenCredentialUsingCLI() (azcore.TokenCredential, er
 		if msg == "" {
 			msg = err.Error()
 		}
-		return nil, fmt.Errorf(msg)
+		return nil, fmt.Errorf("%s", msg)
 	}
 
 	log.Info("azAuthMSI::getTokenCredentialUsingCLI : Successfully logged in using Azure CLI")

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1234,7 +1234,8 @@ func (fc *FileCache) FlushFile(options internal.FlushFileOptions) error {
 			if os.IsPermission(err) {
 				info, _ := os.Stat(localPath)
 				orgMode = info.Mode()
-				err = os.Chmod(localPath, os.FileMode(0666))
+				newMode := orgMode | 0444
+				err = os.Chmod(localPath, newMode)
 				if err == nil {
 					modeChanged = true
 					uploadHandle, err = os.Open(localPath)

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1226,12 +1226,27 @@ func (fc *FileCache) FlushFile(options internal.FlushFileOptions) error {
 		// Write to storage
 		// Create a new handle for the SDK to use to upload (read local file)
 		// The local handle can still be used for read and write.
+		var orgMode fs.FileMode
+		modeChanged := false
+
 		uploadHandle, err := os.Open(localPath)
 		if err != nil {
-			log.Err("FileCache::FlushFile : error [unable to open upload handle] %s [%s]", options.Handle.Path, err.Error())
-			return nil
-		}
+			if os.IsPermission(err) {
+				info, _ := os.Stat(localPath)
+				orgMode = info.Mode()
+				err = os.Chmod(localPath, os.FileMode(0666))
+				if err == nil {
+					modeChanged = true
+					uploadHandle, err = os.Open(localPath)
+					log.Info("FileCache::FlushFile : read mode added to file %s", options.Handle.Path)
+				}
+			}
 
+			if err != nil {
+				log.Err("FileCache::FlushFile : error [unable to open upload handle] %s [%s]", options.Handle.Path, err.Error())
+				return err
+			}
+		}
 		err = fc.NextComponent().CopyFromFile(
 			internal.CopyFromFileOptions{
 				Name: options.Handle.Path,
@@ -1243,7 +1258,9 @@ func (fc *FileCache) FlushFile(options internal.FlushFileOptions) error {
 			log.Err("FileCache::FlushFile : %s upload failed [%s]", options.Handle.Path, err.Error())
 			return err
 		}
-
+		if modeChanged {
+			_ = os.Chmod(localPath, orgMode)
+		}
 		options.Handle.Flags.Clear(handlemap.HandleFlagDirty)
 
 		// If chmod was done on the file before it was uploaded to container then setting up mode would have been missed

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -37,6 +37,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"math"
 	"math/rand"
 	"os"
@@ -635,6 +636,50 @@ func (suite *fileCacheTestSuite) TestCreateFile() {
 	// Path should not be in fake storage
 	_, err = os.Stat(suite.fake_storage_path + "/" + path)
 	suite.assert.True(os.IsNotExist(err))
+}
+
+func (suite *fileCacheTestSuite) TestCreateFileWithNoPerm() {
+	defer suite.cleanupTest()
+	// Default is to not create empty files on create file to support immutable storage.
+	path := "file1"
+	options := internal.CreateFileOptions{Name: path, Mode: 0000}
+	f, err := suite.fileCache.CreateFile(options)
+	suite.assert.Nil(err)
+	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in storage
+
+	// Path should be added to the file cache
+	_, err = os.Stat(suite.cache_path + "/" + path)
+	suite.assert.True(err == nil || os.IsExist(err))
+	// Path should not be in fake storage
+	_, err = os.Stat(suite.fake_storage_path + "/" + path)
+	suite.assert.True(os.IsNotExist(err))
+	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
+	suite.assert.Nil(err)
+	info, _ := os.Stat(suite.cache_path + "/" + path)
+	suite.assert.Equal(info.Mode(), os.FileMode(0000))
+}
+
+func (suite *fileCacheTestSuite) TestCreateFileWithWritePerm() {
+	defer suite.cleanupTest()
+	// Default is to not create empty files on create file to support immutable storage.
+	path := "file1"
+	options := internal.CreateFileOptions{Name: path, Mode: 0222}
+	f, err := suite.fileCache.CreateFile(options)
+	suite.assert.Nil(err)
+	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in storage
+
+	os.Chmod(suite.cache_path+"/"+path, 0762)
+
+	// Path should be added to the file cache
+	_, err = os.Stat(suite.cache_path + "/" + path)
+	suite.assert.True(err == nil || os.IsExist(err))
+	// Path should not be in fake storage
+	_, err = os.Stat(suite.fake_storage_path + "/" + path)
+	suite.assert.True(os.IsNotExist(err))
+	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
+	suite.assert.Nil(err)
+	info, _ := os.Stat(suite.cache_path + "/" + path)
+	suite.assert.Equal(info.Mode(), fs.FileMode(0762))
 }
 
 func (suite *fileCacheTestSuite) TestCreateFileInDir() {

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -668,7 +668,7 @@ func (suite *fileCacheTestSuite) TestCreateFileWithWritePerm() {
 	suite.assert.Nil(err)
 	suite.assert.True(f.Dirty()) // Handle should be dirty since it was not created in storage
 
-	os.Chmod(suite.cache_path+"/"+path, 0762)
+	os.Chmod(suite.cache_path+"/"+path, 0331)
 
 	// Path should be added to the file cache
 	_, err = os.Stat(suite.cache_path + "/" + path)
@@ -679,7 +679,7 @@ func (suite *fileCacheTestSuite) TestCreateFileWithWritePerm() {
 	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
 	suite.assert.Nil(err)
 	info, _ := os.Stat(suite.cache_path + "/" + path)
-	suite.assert.Equal(info.Mode(), fs.FileMode(0762))
+	suite.assert.Equal(info.Mode(), fs.FileMode(0331))
 }
 
 func (suite *fileCacheTestSuite) TestCreateFileInDir() {


### PR DESCRIPTION
Fixed File Cache failed to upload if Read perm is not given by changing file perm to read and resetting it after upload.