### PR TITLE
Fix ReadPanic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.3.3 (Unreleased)
+## 2.4.0 (Unreleased)
 **Bug Fixes**
+- [#1426](https://github.com/Azure/azure-storage-fuse/issues/1426) Read panic in block-cache due to boundary conditions.
 
 ## 2.3.2 (2024-09-03)
 **Bug Fixes**

--- a/azure-pipeline-templates/e2e-tests-block-cache-data-integrity.yml
+++ b/azure-pipeline-templates/e2e-tests-block-cache-data-integrity.yml
@@ -149,6 +149,10 @@ steps:
       VERBOSE_LOG: ${{ parameters.verbose_log }}
     continueOnError: false
 
+  - script: |
+     if [ -d "block_cache" ]; then ls -l block_cache; rm -rf block_cache; mkdir block_cache  ; fi
+    displayName: 'Clear Temp Cache for Block Cache before mounting'
+
   - template: 'mount.yml'
     parameters:
       working_dir: $(WORK_DIR)

--- a/component/block_cache/block.go
+++ b/component/block_cache/block.go
@@ -61,13 +61,12 @@ const (
 
 // Block is a memory mapped buffer with its state to hold data
 type Block struct {
-	offset   uint64          // Start offset of the data this block holds
-	id       int64           // Id of the block i.e. (offset / block size)
-	endIndex uint64          // Length of the data this block holds
-	state    chan int        // Channel depicting data has been read for this block or not
-	flags    common.BitMap16 // Various states of the block
-	data     []byte          // Data read from blob
-	node     *list.Element   // node representation of this block in the list inside handle
+	offset uint64          // Start offset of the data this block holds
+	id     int64           // Id of the block i.e. (offset / block size)
+	state  chan int        // Channel depicting data has been read for this block or not
+	flags  common.BitMap16 // Various states of the block
+	data   []byte          // Data read from blob
+	node   *list.Element   // node representation of this block in the list inside handle
 }
 
 type blockInfo struct {
@@ -123,7 +122,6 @@ func (b *Block) Delete() error {
 func (b *Block) ReUse() {
 	b.id = -1
 	b.offset = 0
-	b.endIndex = 0
 	b.flags.Reset()
 	b.flags.Set(BlockFlagFresh)
 	b.state = make(chan int, 1)

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -496,6 +496,10 @@ func (bc *BlockCache) closeFileInternal(options internal.CloseFileOptions) error
 	return nil
 }
 
+func (bc *BlockCache) getBlockSize(fileSize uint64, block *Block) uint64 {
+	return min(bc.blockSize, fileSize-block.offset)
+}
+
 // ReadInBuffer: Read the file into a buffer
 func (bc *BlockCache) ReadInBuffer(options internal.ReadInBufferOptions) (int, error) {
 	if options.Offset >= options.Handle.Size {
@@ -522,7 +526,9 @@ func (bc *BlockCache) ReadInBuffer(options internal.ReadInBufferOptions) (int, e
 
 		// Copy data from this block to user buffer
 		readOffset := uint64(options.Offset) - block.offset
-		bytesRead := copy(options.Data[dataRead:], block.data[readOffset:(block.endIndex-block.offset)])
+		blockSize := bc.getBlockSize(uint64(options.Handle.Size), block)
+
+		bytesRead := copy(options.Data[dataRead:], block.data[readOffset:blockSize])
 
 		// Move offset forward in case we need to copy more data
 		options.Offset += int64(bytesRead)
@@ -920,18 +926,19 @@ func (bc *BlockCache) download(item *workItem) {
 					_ = os.Remove(localPath)
 				}
 
+				if n != int(bc.blockSize) && item.block.offset+uint64(n) != uint64(item.handle.Size) {
+					log.Err("BlockCache::download : Local data retrieved from disk size mismatch, Expected %v, OnDisk %v", bc.blockSize, n)
+				}
+
 				f.Close()
 				// We have read the data from disk so there is no need to go over network
 				// Just mark the block that download is complete
-
-				item.block.endIndex = item.block.offset + uint64(n)
 				item.block.Ready(BlockStatusDownloaded)
 				return
 			}
 		}
 	}
 
-	item.block.endIndex = item.block.offset
 	// If file does not exists then download the block from the container
 	n, err := bc.NextComponent().ReadInBuffer(internal.ReadInBufferOptions{
 		Handle: item.handle,
@@ -961,7 +968,9 @@ func (bc *BlockCache) download(item *workItem) {
 		return
 	}
 
-	item.block.endIndex = item.block.offset + uint64(n)
+	if n != int(bc.blockSize) && item.block.offset+uint64(n) != uint64(item.handle.Size) {
+		log.Err("BlockCache::download : Downloaded data size mismatch expected %v, Dowloaded %v", bc.blockSize, n)
+	}
 
 	if bc.tmpPath != "" {
 		err := os.MkdirAll(filepath.Dir(localPath), 0777)
@@ -1020,10 +1029,6 @@ func (bc *BlockCache) WriteFile(options internal.WriteFileOptions) (int, error) 
 		// Move offset forward in case we need to copy more data
 		options.Offset += int64(bytesWritten)
 		dataWritten += bytesWritten
-
-		if block.endIndex < uint64(options.Offset) {
-			block.endIndex = uint64(options.Offset)
-		}
 
 		if options.Handle.Size < options.Offset {
 			options.Handle.Size = options.Offset
@@ -1247,28 +1252,15 @@ func shouldCommitAndDownload(blockID int64, handle *handlemap.Handle) (bool, boo
 
 // lineupUpload : Create a work item and schedule the upload
 func (bc *BlockCache) lineupUpload(handle *handlemap.Handle, block *Block, listMap map[int64]*blockInfo) {
-	// if a block has data less than block size and is not the last block,
-	// add null at the end and upload the full block
-	// bc.printCooking(handle)
-	if block.endIndex < uint64(handle.Size) {
-		log.Debug("BlockCache::lineupUpload : Appending null for block %v, size %v for %v=>%s", block.id, (block.endIndex - block.offset), handle.ID, handle.Path)
-		block.endIndex = block.offset + bc.blockSize
-	} else if block.endIndex == uint64(handle.Size) {
-		// TODO: random write scenario where this block is not the last block
-		log.Debug("BlockCache::lineupUpload : Last block %v, size %v for %v=>%s", block.id, (block.endIndex - block.offset), handle.ID, handle.Path)
-	}
 
-	// id := listMap[block.id]
-	// if id == "" {
 	id := base64.StdEncoding.EncodeToString(common.NewUUIDWithLength(16))
 	listMap[block.id] = &blockInfo{
 		id:        id,
 		committed: false,
-		size:      block.endIndex - block.offset,
+		size:      bc.getBlockSize(uint64(handle.Size), block),
 	}
-	//}
 
-	log.Debug("BlockCache::lineupUpload : block %v, size %v for %v=>%s, blockId %v", block.id, (block.endIndex - block.offset), handle.ID, handle.Path, id)
+	log.Debug("BlockCache::lineupUpload : block %v, size %v for %v=>%s, blockId %v", block.id, bc.getBlockSize(uint64(handle.Size), block), handle.ID, handle.Path, id)
 	item := &workItem{
 		handle:   handle,
 		block:    block,
@@ -1277,8 +1269,6 @@ func (bc *BlockCache) lineupUpload(handle *handlemap.Handle, block *Block, listM
 		upload:   true,
 		blockId:  id,
 	}
-
-	// log.Debug("BlockCache::lineupUpload : Upload block %v=>%s (index %v, offset %v, data %v)", handle.ID, handle.Path, block.id, block.offset, (block.endIndex - block.offset))
 
 	block.Uploading()
 	block.flags.Clear(BlockFlagFailed)
@@ -1346,12 +1336,11 @@ func (bc *BlockCache) upload(item *workItem) {
 	flock := bc.fileLocks.Get(fileName)
 	flock.Lock()
 	defer flock.Unlock()
-	// log.Debug("BlockCache::Upload : block %v, size %v for %v=>%s, blockId %v", item.block.id, (item.block.endIndex - item.block.offset), item.handle.ID, item.handle.Path, item.blockId)
-
+	blockSize := bc.getBlockSize(uint64(item.handle.Size), item.block)
 	// This block is updated so we need to stage it now
 	err := bc.NextComponent().StageData(internal.StageDataOptions{
 		Name: item.handle.Path,
-		Data: item.block.data[0 : item.block.endIndex-item.block.offset],
+		Data: item.block.data[0:blockSize],
 		Id:   item.blockId})
 	if err != nil {
 		// Fail to write the data so just reschedule this request
@@ -1382,7 +1371,7 @@ func (bc *BlockCache) upload(item *workItem) {
 		// Dump this block to local disk cache
 		f, err := os.Create(localPath)
 		if err == nil {
-			_, err := f.Write(item.block.data[0 : item.block.endIndex-item.block.offset])
+			_, err := f.Write(item.block.data[0:blockSize])
 			if err != nil {
 				log.Err("BlockCache::upload : Failed to write %s to disk [%v]", localPath, err.Error())
 				_ = os.Remove(localPath)

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -951,7 +951,6 @@ func (bc *BlockCache) download(item *workItem) {
 		Offset: int64(item.block.offset),
 		Data:   item.block.data,
 	})
-	log.Debug("BlockCache::download : handle size %v, Downloaded size %v", item.handle.Size, n)
 
 	if item.failCnt > MAX_FAIL_CNT {
 		// If we failed to read the data 3 times then just give up
@@ -974,8 +973,6 @@ func (bc *BlockCache) download(item *workItem) {
 		bc.threadPool.Schedule(false, item)
 		return
 	}
-
-	log.Debug("BlockCache::download : Downloaded %v data, Requested %v data, from %v offset and file size %v", n, bc.getBlockSize(uint64(item.handle.Size), item.block), item.block.offset, item.handle.Size)
 
 	if bc.tmpPath != "" {
 		err := os.MkdirAll(filepath.Dir(localPath), 0777)

--- a/component/block_cache/block_test.go
+++ b/component/block_cache/block_test.go
@@ -197,7 +197,6 @@ func (suite *blockTestSuite) TestWriter() {
 	suite.assert.NotNil(b.state)
 	suite.assert.Nil(b.node)
 	suite.assert.Zero(b.offset)
-	suite.assert.Zero(b.endIndex)
 	suite.assert.Equal(b.id, int64(-1))
 	suite.assert.False(b.IsDirty())
 

--- a/test/e2e_tests/data_validation_test.go
+++ b/test/e2e_tests/data_validation_test.go
@@ -215,6 +215,17 @@ func generateFileWithRandomData(suite *dataValidationTestSuite, filePath string,
 	closeFileHandles(suite, fh)
 }
 
+func compareReadOperInLocalAndRemote(suite *dataValidationTestSuite, lfh, rfh *os.File, offset int64) {
+	buffer1 := make([]byte, 4*int(_1MB))
+	buffer2 := make([]byte, 4*int(_1MB))
+
+	bytes_read_local, err1 := lfh.ReadAt(buffer1, offset)
+	bytes_read_remote, err2 := rfh.ReadAt(buffer2, offset)
+	suite.Equal(err1, err2)
+	suite.Equal(bytes_read_local, bytes_read_remote)
+	suite.Equal(buffer1[:bytes_read_local], buffer2[:bytes_read_remote])
+}
+
 // -------------- Data Validation Tests -------------------
 
 // Test correct overwrite of file using echo command
@@ -717,6 +728,34 @@ func (suite *dataValidationTestSuite) TestPanicOnReadingFileInRandReadMode() {
 	}
 
 	closeFileHandles(suite, rfh)
+}
+
+func (suite *dataValidationTestSuite) TestReadDataAtBlockBoundaries() {
+	fileName := "testReadDataAtBlockBoundaries"
+	localFilePath, remoteFilePath := convertFileNameToFilePath(fileName)
+	generateFileWithRandomData(suite, localFilePath, 35*int(_1MB))
+	suite.copyToMountDir(localFilePath, remoteFilePath)
+	suite.validateData(localFilePath, remoteFilePath)
+
+	lfh, rfh := createFileHandleInLocalAndRemote(suite, localFilePath, remoteFilePath)
+	var offset int64 = 0
+	//tests run in 16MB block size config.
+	//Data in File 35MB(3blocks)
+	//block1->16MB, block2->16MB, block3->3MB
+
+	//getting 4MB data from 1st block
+	compareReadOperInLocalAndRemote(suite, lfh, rfh, offset)
+	//getting 4MB data from overlapping blocks
+	offset = int64(15 * int(_1MB))
+	compareReadOperInLocalAndRemote(suite, lfh, rfh, offset)
+	//getting 4MB data from last block
+	offset = int64(32 * int(_1MB))
+	compareReadOperInLocalAndRemote(suite, lfh, rfh, offset)
+	//getting 4MB data from overlapping block with last block
+	offset = int64(30 * int(_1MB))
+	compareReadOperInLocalAndRemote(suite, lfh, rfh, offset)
+
+	closeFileHandles(suite, lfh, rfh)
 }
 
 // -------------- Main Method -------------------


### PR DESCRIPTION
https://github.com/Azure/azure-storage-fuse/issues/1426

Read is getting panicked due to block.endIndex being incorrectly modified.

**Fix:**
Removed block.endIndex field and added a simple way to find the block size.