### PR TITLE
truncate logic correction in filecache

### DIFF
--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1496,9 +1496,6 @@ func (fc *FileCache) RenameFile(options internal.RenameFileOptions) error {
 func (fc *FileCache) TruncateFile(options internal.TruncateFileOptions) error {
 	log.Trace("FileCache::TruncateFile : name=%s, size=%d", options.Name, options.Size)
 
-	// If you call truncate CLI command from shell it always sends an open call first followed by truncate
-	// But if you call the truncate method from a C/C++ code then open is not hit and only truncate comes
-
 	if fc.diskHighWaterMark != 0 {
 		currSize, err := common.GetUsage(fc.tmpPath)
 		if err != nil {
@@ -1511,42 +1508,33 @@ func (fc *FileCache) TruncateFile(options internal.TruncateFileOptions) error {
 		}
 	}
 
-	var h *handlemap.Handle = nil
-	var err error = nil
+	flock := fc.fileLocks.Get(options.Name)
+	flock.Lock()
+	defer flock.Unlock()
 
-	if options.Size == 0 {
-		// If size is 0 then no need to download any file we can just create an empty file
-		h, err = fc.CreateFile(internal.CreateFileOptions{Name: options.Name, Mode: fc.defaultPermission})
-		if err != nil {
-			log.Err("FileCache::TruncateFile : Error creating file %s [%s]", options.Name, err.Error())
-			return err
-		}
-	} else {
-		// If size is not 0 then we need to open the file and then truncate it
-		// Open will force download if file was not present in local system
-		h, err = fc.OpenFile(internal.OpenFileOptions{Name: options.Name, Flags: os.O_RDWR, Mode: fc.defaultPermission})
-		if err != nil {
-			log.Err("FileCache::TruncateFile : Error opening file %s [%s]", options.Name, err.Error())
-			return err
-		}
+	err := fc.NextComponent().TruncateFile(options)
+	err = fc.validateStorageError(options.Name, err, "TruncateFile", true)
+	if err != nil {
+		log.Err("FileCache::TruncateFile : %s failed to truncate [%s]", options.Name, err.Error())
+		return err
 	}
 
 	// Update the size of the file in the local cache
 	localPath := filepath.Join(fc.tmpPath, options.Name)
-	fc.policy.CacheValid(localPath)
+	info, err := os.Stat(localPath)
+	if err == nil || os.IsExist(err) {
+		fc.policy.CacheValid(localPath)
 
-	// Truncate the file created in local system
-	err = os.Truncate(localPath, options.Size)
-	if err != nil {
-		log.Err("FileCache::TruncateFile : error truncating cached file %s [%s]", localPath, err.Error())
-		_ = fc.CloseFile(internal.CloseFileOptions{Handle: h})
-		return err
+		if info.Size() != options.Size {
+			err = os.Truncate(localPath, options.Size)
+			if err != nil {
+				log.Err("FileCache::TruncateFile : error truncating cached file %s [%s]", localPath, err.Error())
+				return err
+			}
+		}
 	}
 
-	// Mark the handle as dirty so that close of this file will force an upload
-	h.Flags.Set(handlemap.HandleFlagDirty)
-
-	return fc.CloseFile(internal.CloseFileOptions{Handle: h})
+	return nil
 }
 
 // Chmod : Update the file with its new permissions


### PR DESCRIPTION
## ✅ What
Modifying the truncate logic in filecache to prevent uploading the entire file.
 
<!-- A brief description of the changes in this PR. -->
 
## 🤔 Why
 
<!-- A brief description of the reason for these changes. -->
 Current truncate op implemenation in filecache:
open, truncate, close ->which is causing a download, truncate then upload. If size to which we are truncating is large. this is causing network issue. 

Current changes:
Pass the call to the next component to handle the truncate operation. This will prevent uploading entire file on the network.
 
## 🔖 Related links
 
- [Issues](https://github.com/Azure/azure-storage-fuse/issues/1547)
