### PR TITLE
Rocky UT fails due to insufficient memory

### DIFF
--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -2613,14 +2613,16 @@ func (suite *blockCacheTestSuite) TestReadWriteBlockInParallel() {
 
 func (suite *blockCacheTestSuite) TestZZZZZStreamToBlockCacheConfig() {
 	common.IsStream = true
-	config := "read-only: true\n\nstream:\n  block-size-mb: 16\n  max-buffers: 80\n  buffer-size-mb: 8\n"
+	config := "read-only: true\n\nstream:\n  block-size-mb: 16\n  max-buffers: 30\n  buffer-size-mb: 8\n"
 	tobj, err := setupPipeline(config)
 	defer tobj.cleanupPipeline()
 
 	suite.assert.Nil(err)
-	suite.assert.Equal(tobj.blockCache.Name(), "block_cache")
-	suite.assert.EqualValues(tobj.blockCache.blockSize, 16*_1MB)
-	suite.assert.EqualValues(tobj.blockCache.memSize, 8*_1MB*80)
+	if err == nil {
+		suite.assert.Equal(tobj.blockCache.Name(), "block_cache")
+		suite.assert.EqualValues(tobj.blockCache.blockSize, 16*_1MB)
+		suite.assert.EqualValues(tobj.blockCache.memSize, 8*_1MB*30)
+	}
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -2613,14 +2613,14 @@ func (suite *blockCacheTestSuite) TestReadWriteBlockInParallel() {
 
 func (suite *blockCacheTestSuite) TestZZZZZStreamToBlockCacheConfig() {
 	common.IsStream = true
-	config := "read-only: true\n\nstream:\n  block-size-mb: 16\n  max-buffers: 30\n  buffer-size-mb: 8\n"
+	config := "read-only: true\n\nstream:\n  block-size-mb: 2\n  max-buffers: 30\n  buffer-size-mb: 8\n"
 	tobj, err := setupPipeline(config)
 	defer tobj.cleanupPipeline()
 
 	suite.assert.Nil(err)
 	if err == nil {
 		suite.assert.Equal(tobj.blockCache.Name(), "block_cache")
-		suite.assert.EqualValues(tobj.blockCache.blockSize, 16*_1MB)
+		suite.assert.EqualValues(tobj.blockCache.blockSize, 2*_1MB)
 		suite.assert.EqualValues(tobj.blockCache.memSize, 8*_1MB*30)
 	}
 }


### PR DESCRIPTION
## ✅ What
 UT in Rocky env is failing due to insufficient memory.
 
## 🤔 Why
 Available memory on the system is low.

## 👩‍🔬 How to validate if applicable
Reduce the amount of memory needed by UT and validate it works.
 
## 🔖 Related links
NA