### PR TITLE
Create block pool only once in child process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1 (Unreleased)
+**Bug Fixes**
+- Create block pool only once in the child process.
+
 ## 2.4.0 (Unreleased)
 **Features**
 - Entry cache to hold directory listing results in cache for a given timeout. This will reduce REST calls going to storage while listing the blobs in parallel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.1 (Unreleased)
 **Bug Fixes**
-- Create block pool only once in the child process.
+- Create block pool only in the child process.
 
 ## 2.4.0 (Unreleased)
 **Features**

--- a/common/types.go
+++ b/common/types.go
@@ -47,7 +47,7 @@ import (
 
 // Standard config default values
 const (
-	blobfuse2Version_ = "2.4.0"
+	blobfuse2Version_ = "2.4.1"
 
 	DefaultMaxLogFileSize = 512
 	DefaultLogFileCount   = 10

--- a/component/azstorage/azauth.go
+++ b/component/azstorage/azauth.go
@@ -59,11 +59,11 @@ type azAuthConfig struct {
 	ObjectID      string
 
 	// SPN config
-	TenantID           string
-	ClientID           string
-	ClientSecret       string
-	OAuthTokenFilePath string
-	WorkloadIdentityToken string
+	TenantID                string
+	ClientID                string
+	ClientSecret            string
+	OAuthTokenFilePath      string
+	WorkloadIdentityToken   string
 	ActiveDirectoryEndpoint string
 
 	Endpoint     string

--- a/component/azstorage/config_test.go
+++ b/component/azstorage/config_test.go
@@ -340,13 +340,13 @@ func (s *configTestSuite) TestAuthModeSPN() {
 	err := ParseAndValidateConfig(az, opt)
 	assert.NotNil(err)
 	assert.Equal(az.stConfig.authConfig.AuthMode, EAuthType.SPN())
-	assert.Contains(err.Error(), "Client ID, Tenant ID or Client Secret not provided")
+	assert.Contains(err.Error(), "Client ID, Tenant ID or Client Secret, OAuthTokenFilePath, WorkloadIdentityToken not provided")
 
 	opt.ClientID = "abc"
 	err = ParseAndValidateConfig(az, opt)
 	assert.NotNil(err)
 	assert.Equal(az.stConfig.authConfig.AuthMode, EAuthType.SPN())
-	assert.Contains(err.Error(), "Client ID, Tenant ID or Client Secret not provided")
+	assert.Contains(err.Error(), "Client ID, Tenant ID or Client Secret, OAuthTokenFilePath, WorkloadIdentityToken not provided")
 
 	opt.ClientSecret = "123"
 	opt.TenantID = "xyz"

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -135,6 +135,18 @@ func (bc *BlockCache) SetNextComponent(nc internal.Component) {
 func (bc *BlockCache) Start(ctx context.Context) error {
 	log.Trace("BlockCache::Start : Starting component %s", bc.Name())
 
+	bc.blockPool = NewBlockPool(bc.blockSize, bc.memSize)
+	if bc.blockPool == nil {
+		log.Err("BlockCache::Start : failed to init block pool")
+		return fmt.Errorf("config error in %s [failed to init block pool]", bc.Name())
+	}
+
+	bc.threadPool = newThreadPool(bc.workers, bc.download, bc.upload)
+	if bc.threadPool == nil {
+		log.Err("BlockCache::Start : failed to init thread pool")
+		return fmt.Errorf("config error in %s [failed to init thread pool]", bc.Name())
+	}
+
 	// Start the thread pool and keep it ready for download
 	bc.threadPool.Start()
 
@@ -308,18 +320,6 @@ func (bc *BlockCache) Configure(_ bool) error {
 	if (uint64(bc.prefetch) * uint64(bc.blockSize)) > bc.memSize {
 		log.Err("BlockCache::Configure : config error [memory limit too low for configured prefetch]")
 		return fmt.Errorf("config error in %s [memory limit too low for configured prefetch]", bc.Name())
-	}
-
-	bc.blockPool = NewBlockPool(bc.blockSize, bc.memSize)
-	if bc.blockPool == nil {
-		log.Err("BlockCache::Configure : fail to init Block pool")
-		return fmt.Errorf("config error in %s [fail to init block pool]", bc.Name())
-	}
-
-	bc.threadPool = newThreadPool(bc.workers, bc.download, bc.upload)
-	if bc.threadPool == nil {
-		log.Err("BlockCache::Configure : fail to init thread pool")
-		return fmt.Errorf("config error in %s [fail to init thread pool]", bc.Name())
 	}
 
 	if bc.tmpPath != "" {

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -135,14 +135,12 @@ func (bc *BlockCache) SetNextComponent(nc internal.Component) {
 func (bc *BlockCache) Start(ctx context.Context) error {
 	log.Trace("BlockCache::Start : Starting component %s", bc.Name())
 
-	log.Debug("BlockCache::Start : Creating block pool")
 	bc.blockPool = NewBlockPool(bc.blockSize, bc.memSize)
 	if bc.blockPool == nil {
 		log.Err("BlockCache::Start : failed to init block pool")
 		return fmt.Errorf("config error in %s [failed to init block pool]", bc.Name())
 	}
 
-	log.Debug("BlockCache::Start : Creating thread pool")
 	bc.threadPool = newThreadPool(bc.workers, bc.download, bc.upload)
 	if bc.threadPool == nil {
 		log.Err("BlockCache::Start : failed to init thread pool")

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -135,12 +135,14 @@ func (bc *BlockCache) SetNextComponent(nc internal.Component) {
 func (bc *BlockCache) Start(ctx context.Context) error {
 	log.Trace("BlockCache::Start : Starting component %s", bc.Name())
 
+	log.Debug("BlockCache::Start : Creating block pool")
 	bc.blockPool = NewBlockPool(bc.blockSize, bc.memSize)
 	if bc.blockPool == nil {
 		log.Err("BlockCache::Start : failed to init block pool")
 		return fmt.Errorf("config error in %s [failed to init block pool]", bc.Name())
 	}
 
+	log.Debug("BlockCache::Start : Creating thread pool")
 	bc.threadPool = newThreadPool(bc.workers, bc.download, bc.upload)
 	if bc.threadPool == nil {
 		log.Err("BlockCache::Start : failed to init thread pool")
@@ -148,6 +150,7 @@ func (bc *BlockCache) Start(ctx context.Context) error {
 	}
 
 	// Start the thread pool and keep it ready for download
+	log.Debug("BlockCache::Start : Starting thread pool")
 	bc.threadPool.Start()
 
 	// If disk caching is enabled then start the disk eviction policy

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -277,12 +277,12 @@ func (suite *blockCacheTestSuite) TestSomeInvalidConfigs() {
 	cfg := "read-only: true\n\nblock_cache:\n  block-size-mb: 8\n  mem-size-mb: 800\n  prefetch: 12\n  parallelism: 0\n"
 	_, err := setupPipeline(cfg)
 	suite.assert.NotNil(err)
-	suite.assert.Contains(err.Error(), "fail to init thread pool")
+	suite.assert.Contains(err.Error(), "failed to init thread pool")
 
 	cfg = "read-only: true\n\nblock_cache:\n  block-size-mb: 1024000\n  mem-size-mb: 20240000\n  prefetch: 12\n  parallelism: 1\n"
 	_, err = setupPipeline(cfg)
 	suite.assert.NotNil(err)
-	suite.assert.Contains(err.Error(), "fail to init block pool")
+	suite.assert.Contains(err.Error(), "failed to init block pool")
 
 	cfg = "read-only: true\n\nblock_cache:\n  block-size-mb: 8\n  mem-size-mb: 800\n  prefetch: 12\n  parallelism: 5\n  path: ./bctemp \n  disk-size-mb: 100\n  disk-timeout-sec: 0"
 	_, err = setupPipeline(cfg)


### PR DESCRIPTION
## ✅ What
 
Moved the block pool and thread pool creation code from `Configure()` to `Start()` method, so that it is created only once in the child process.
 
## 🤔 Why
 
`Configure()` method is called twice both in parent and child process. As a result of this block pool and thread pool were created twice resulting in higher memory utilization. So, moved the code to `Start()` method which is called only once in the child process.
 
## 👩‍🔬 How to validate if applicable
 
Can be verified from the logs.
