### PR TITLE
After an ungraceful unmount, mount shall cleanup temp-cache only if flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Create block pool only in the child process.
 - Prevent the block cache to truncate the file size to zero when the file is opened in O_WRONLY mode when writebackcache is disabled.
 - Correct statFS results to reflect block-cache in memory cache status.
+- Do not wipeout temp-cache on start after a un-graceful unmount, if `cleanup-on-start` is not configured in file-cache.
 
 **Other Changes**
 - Optimized listing operation on HNS account to support symlinks.

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -127,7 +127,7 @@ func (opt *mountOptions) validate(skipNonEmptyMount bool) error {
 			var cleanupOnStart bool
 			_ = config.UnmarshalKey("file_cache.cleanup-on-start", &cleanupOnStart)
 
-			if tempCachePath != "" && !cleanupOnStart {
+			if tempCachePath != "" && cleanupOnStart {
 				if err = common.TempCacheCleanup(tempCachePath); err != nil {
 					return fmt.Errorf("failed to cleanup file cache [%s]", err.Error())
 				}


### PR DESCRIPTION
## ✅ What
 
File-cache as a flag `cleanup-on-start`. After an ungraceful unmount, next mount shall wipeout the cache only if this flag is set otherwise cache shall be reused.
 
## 🤔 Why
 
Flag is checked incorrectly and it wipes out cache even when flag is set to false.
 
## 👩‍🔬 How to validate if applicable
 
Mount, read a file, crash, restart and the tempcache shall not cleanup on mount,
 
## 🔖 Related links
 
NA
