### PR TITLE
Fix typo in 'mount directory does not exist'

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -105,7 +105,7 @@ func (opt *mountOptions) validate(skipNonEmptyMount bool) error {
 	}
 
 	if _, err := os.Stat(opt.MountPath); os.IsNotExist(err) {
-		return fmt.Errorf("mount directory does not exists")
+		return fmt.Errorf("mount directory does not exist")
 	} else if common.IsDirectoryMounted(opt.MountPath) {
 		// Try to cleanup the stale mount
 		log.Info("Mount::validate : Mount directory is already mounted, trying to cleanup")
@@ -271,7 +271,7 @@ var mountCmd = &cobra.Command{
 		if options.ConfigFile == "" {
 			// Config file is not set in cli parameters
 			// Blobfuse2 defaults to config.yaml in current directory
-			// If the file does not exists then user might have configured required things in env variables
+			// If the file does not exist then user might have configured required things in env variables
 			// Fall back to defaults and let components fail if all required env variables are not set.
 			_, err := os.Stat(common.DefaultConfigFilePath)
 			if err != nil && os.IsNotExist(err) {

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -121,18 +121,18 @@ func (suite *mountTestSuite) cleanupTest() {
 	common.DefaultLogFilePath = filepath.Join(common.DefaultWorkDir, "blobfuse2.log")
 }
 
-// mount failure test where the mount directory does not exists
+// mount failure test where the mount directory does not exist
 func (suite *mountTestSuite) TestMountDirNotExists() {
 	defer suite.cleanupTest()
 
 	tempDir := randomString(8)
 	op, err := executeCommandC(rootCmd, "mount", tempDir, fmt.Sprintf("--config-file=%s", confFileMntTest))
 	suite.assert.NotNil(err)
-	suite.assert.Contains(op, "mount directory does not exists")
+	suite.assert.Contains(op, "mount directory does not exist")
 
 	op, err = executeCommandC(rootCmd, "mount", "all", tempDir, fmt.Sprintf("--config-file=%s", confFileMntTest))
 	suite.assert.NotNil(err)
-	suite.assert.Contains(op, "mount directory does not exists")
+	suite.assert.Contains(op, "mount directory does not exist")
 }
 
 // mount failure test where the mount directory is not empty

--- a/cmd/unmount_test.go
+++ b/cmd/unmount_test.go
@@ -87,7 +87,7 @@ func (suite *unmountTestSuite) cleanupTest() {
 	time.Sleep(2 * time.Second)
 }
 
-// mount failure test where the mount directory does not exists
+// mount failure test where the mount directory does not exist
 func (suite *unmountTestSuite) TestUnmountCmd() {
 	defer suite.cleanupTest()
 

--- a/internal/handlemap/handle_map_test.go
+++ b/internal/handlemap/handle_map_test.go
@@ -50,7 +50,7 @@ func (suite *HandleMapSuite) SetupTest() {
 	suite.assert = assert.New(suite.T())
 }
 
-// mount failure test where the mount directory does not exists
+// mount failure test where the mount directory does not exist
 func (suite *HandleMapSuite) TestNewHandle() {
 	h := NewHandle("abc")
 	suite.assert.NotNil(h)

--- a/test/mount_test/mount_test.go
+++ b/test/mount_test/mount_test.go
@@ -119,7 +119,7 @@ func (suite *mountSuite) TestMountCmd() {
 	blobfuseUnmount(suite, mntDir)
 }
 
-// mount failure test where the mount directory does not exists
+// mount failure test where the mount directory does not exist
 func (suite *mountSuite) TestMountDirNotExists() {
 	tempDir := filepath.Join(mntDir, "tempdir")
 	mountCmd := exec.Command(blobfuseBinary, "mount", tempDir, "--config-file="+configFile)
@@ -129,7 +129,7 @@ func (suite *mountSuite) TestMountDirNotExists() {
 	suite.NotEqual(nil, err)
 	fmt.Println(errb.String())
 	suite.NotEqual(0, len(errb.String()))
-	suite.Contains(errb.String(), "mount directory does not exists")
+	suite.Contains(errb.String(), "mount directory does not exist")
 
 	// list blobfuse mounted directories
 	cliOut := listBlobfuseMounts(suite)


### PR DESCRIPTION
## ✅ What
 
Fixes typos in comments and error messages about mount directory not existing.
 
## 🤔 Why
 
Fixes typos.
 
## 👩‍🔬 How to validate if applicable
 
N/A