### PR TITLE
In case of mount and mount all, if the container name has '$' do not treat it as env variable

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -322,3 +322,9 @@ func init() {
 	DefaultLogFilePath = filepath.Join(DefaultWorkDir, "blobfuse2.log")
 	StatsConfigFilePath = filepath.Join(DefaultWorkDir, "stats_monitor.cfg")
 }
+
+var azureSpecialContainers = map[string]bool{
+	"web":        true,
+	"logs":       true,
+	"changefeed": true,
+}

--- a/common/util.go
+++ b/common/util.go
@@ -334,7 +334,13 @@ func ExpandPath(path string) string {
 		path = filepath.Join(homeDir, path[2:])
 	}
 
-	path = os.ExpandEnv(path)
+	path = os.Expand(path, func(key string) string {
+		if azureSpecialContainers[key] {
+			return "$" + key // Keep it as is
+		}
+		return os.Getenv(key) // Expand normally
+	})
+
 	path, _ = filepath.Abs(path)
 	return path
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -257,6 +257,16 @@ func (suite *utilTestSuite) TestExpandPath() {
 	path = ""
 	expandedPath = ExpandPath(path)
 	suite.assert.Equal(expandedPath, path)
+
+	path = "$HOME/.blobfuse2/config_$web.yaml"
+	expandedPath = ExpandPath(path)
+	suite.assert.NotEqual(expandedPath, path)
+	suite.assert.Contains(path, "$web")
+
+	path = "$HOME/.blobfuse2/$web"
+	expandedPath = ExpandPath(path)
+	suite.assert.NotEqual(expandedPath, path)
+	suite.assert.Contains(path, "$web")
 }
 
 func (suite *utilTestSuite) TestGetUSage() {


### PR DESCRIPTION
## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
In case of mount all or while mounting Azure special container like "$web", expandPath assumes it's an enviornment variable and tries to expand it while it shall skip these special container names. As part of this change we will not expand any environment variable in any path or config file name if env variable name matches reserved Azure Container name.

## How Has This Been Tested?
UT has been added and related bug has been linked.

## Checklist
- [X] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
NA