### PR TITLE
Rename ClientAssertion to WorkloadIdentity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.5.0 (Unreleased)
 **Features**
-- Added `Client Assertion` based authentication for containers. Configure `tenant-id, client-id, aad-application-id and security scope` with `authMode` set to `clientassertion`.
+- Added `Client Assertion` based authentication for containers. Configure `tenant-id, client-id, aad-application-id and security scope` with `authMode` set to `workloadidentity`.
 
 ## 2.5.0~preview.1 (Unreleased)
 **Features**

--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ To learn about a specific command, just include the name of the command (For exa
     * `AZURE_STORAGE_AAD_ENDPOINT`: Specifies a custom AAD endpoint to authenticate against
     * `AZURE_STORAGE_SPN_CLIENT_SECRET`: Specifies the client secret for your application registration.
     * `AZURE_STORAGE_AUTH_RESOURCE` : Scope to be used while requesting for token.
+- Workload Identity auth:
+    * `AZURE_STORAGE_SPN_CLIENT_ID`: Specifies the clientid of the MI assigned to the storage account | clientid of the MI assigned as subject field on a Federated Identity Credential (FIC) on the App Registration
+    * `AZURE_STORAGE_SPN_TENANT_ID`: Specifies the tenant ID for your storage account
+    * `AZURE_STORAGE_IDENTITY_CLIENT_ID`: Specifies the application (client) ID of the App Registration or SPN
+    * `AZURE_STORAGE_AUTH_RESOURCE` : Scope to be used while requesting for token / MI Audience.
+            
+            Public Cloud: api://AzureADTokenExchange  (Default)
+
+            US Gov Cloud: api://AzureADTokenExchangeUSGov
+
+            China Cloud operated by 21Vianet: api://AzureADTokenExchangeChina
+
 - Proxy Server:
     * `http_proxy`: The proxy server address. Example: `10.1.22.4:8080`.    
     * `https_proxy`: The proxy server address when https is turned off forcing http. Example: `10.1.22.4:8080`.

--- a/blobfuse2-code-coverage.yaml
+++ b/blobfuse2-code-coverage.yaml
@@ -565,7 +565,7 @@ stages:
             - script: |
                 echo 'mode: count' > ./blobfuse2_coverage_raw.rpt
                 tail -q -n +2 ./*.cov >> ./blobfuse2_coverage_raw.rpt
-                cat ./blobfuse2_coverage_raw.rpt | grep -v mock_component | grep -v base_component | grep -v loopback | grep -v tools | grep -v "common/log" | grep -v "common/exectime" | grep -v "common/types.go" | grep -v "internal/stats_manager" | grep -v "main.go" | grep -v "component/azstorage/azauthmsi.go" | grep -v "component/azstorage/azauthspn.go" | grep -v "component/stream" | grep -v "component/custom" | grep -v "component/azstorage/azauthcli.go" | grep -v "exported/exported.go" |  grep -v "component/block_cache/stream.go"  | grep -v "component/azstorage/azauthclientassertion.go" > ./blobfuse2_coverage.rpt 
+                cat ./blobfuse2_coverage_raw.rpt | grep -v mock_component | grep -v base_component | grep -v loopback | grep -v tools | grep -v "common/log" | grep -v "common/exectime" | grep -v "common/types.go" | grep -v "internal/stats_manager" | grep -v "main.go" | grep -v "component/azstorage/azauthmsi.go" | grep -v "component/azstorage/azauthspn.go" | grep -v "component/stream" | grep -v "component/custom" | grep -v "component/azstorage/azauthcli.go" | grep -v "exported/exported.go" |  grep -v "component/block_cache/stream.go"  | grep -v "component/azstorage/azAuthWorkloadIdentity.go" > ./blobfuse2_coverage.rpt 
                 go tool cover -func blobfuse2_coverage.rpt  > ./blobfuse2_func_cover.rpt
                 go tool cover -html=./blobfuse2_coverage.rpt -o ./blobfuse2_coverage.html
                 go tool cover -html=./blobfuse2_ut.cov -o ./blobfuse2_ut.html

--- a/component/azstorage/azauth.go
+++ b/component/azstorage/azauth.go
@@ -137,9 +137,9 @@ func getAzBlobAuth(config azAuthConfig) azAuth {
 				azAuthBase: base,
 			},
 		}
-	} else if config.AuthMode == EAuthType.CLIENTASSERTION() {
-		return &azAuthBlobClientAssertion{
-			azAuthClientAssertion{
+	} else if config.AuthMode == EAuthType.WORKLOADIDENTITY() {
+		return &azAuthBlobWorkloadIdentity{
+			azAuthWorkloadIdentity{
 				azAuthBase: base,
 			},
 		}
@@ -181,9 +181,9 @@ func getAzDatalakeAuth(config azAuthConfig) azAuth {
 				azAuthBase: base,
 			},
 		}
-	} else if config.AuthMode == EAuthType.CLIENTASSERTION() {
-		return &azAuthDatalakeClientAssertion{
-			azAuthClientAssertion{
+	} else if config.AuthMode == EAuthType.WORKLOADIDENTITY() {
+		return &azAuthDatalakeWorkloadIdentity{
+			azAuthWorkloadIdentity{
 				azAuthBase: base,
 			},
 		}

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -76,7 +76,7 @@ func (AuthType) AZCLI() AuthType {
 	return AuthType(5)
 }
 
-func (AuthType) CLIENTASSERTION() AuthType {
+func (AuthType) WORKLOADIDENTITY() AuthType {
 	return AuthType(6)
 }
 
@@ -474,8 +474,8 @@ func ParseAndValidateConfig(az *AzStorage, opt AzStorageOptions) error {
 		az.stConfig.authConfig.WorkloadIdentityToken = opt.WorkloadIdentityToken
 	case EAuthType.AZCLI():
 		az.stConfig.authConfig.AuthMode = EAuthType.AZCLI()
-	case EAuthType.CLIENTASSERTION():
-		az.stConfig.authConfig.AuthMode = EAuthType.CLIENTASSERTION()
+	case EAuthType.WORKLOADIDENTITY():
+		az.stConfig.authConfig.AuthMode = EAuthType.WORKLOADIDENTITY()
 		if opt.ClientID == "" || opt.TenantID == "" || opt.ApplicationID == "" {
 			return errors.New("Client ID, Tenant ID or Application ID not provided")
 		}


### PR DESCRIPTION
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
Renaming ClientAssertion to WorkloadIdentity. Workload Identity was built initially for AKS and GitHub to get an app token using identities minted within the cluster itself. This capability has now been extended to support managed identities directly, so the name workloadidentity is a better fit.

## How Has This Been Tested?
Manual Testing

## Checklist
- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [x] Documentation update required.
- [x] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
NA