### PR TITLE
Feature: Lazy unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.0~preview.1 (Unreleased)
 **Features**
 - Preload feature added to download entire dataset on mount, to accelerate model training.
+- Added `lazy` flag to unmount command which passes the lazy flag to fusermount when unmounting.
 
 ## 2.4.2 (2025-04-08)
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.5.0~preview.1 (Unreleased)
 **Features**
 - Preload feature added to download entire dataset on mount, to accelerate model training.
-- Added `lazy` flag to unmount command which passes the lazy flag to fusermount when unmounting.
+- Added support for lazy unmounts. If device is busy when unmount was executed, it will wait for device to be free and unmount automatically.
 
 ## 2.4.2 (2025-04-08)
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.5.0~preview.1 (Unreleased)
 **Features**
 - Preload feature added to download entire dataset on mount, to accelerate model training.
-- Added support for lazy unmounts. If device is busy when unmount was executed, it will wait for device to be free and unmount automatically.
+- Added support for lazy unmounts. Lazy unmount will wait for device to be free and unmount automatically, instead of giving "device or resource busy" on executing unmount.
 
 ## 2.4.2 (2025-04-08)
 **Bug Fixes**

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -117,7 +117,7 @@ func (opt *mountOptions) validate(skipNonEmptyMount bool) error {
 		} else {
 			// Previous mount is in stale state so lets cleanup the state
 			log.Info("Mount::validate : Cleaning up stale mount")
-			if err = unmountBlobfuse2(opt.MountPath); err != nil {
+			if err = unmountBlobfuse2(opt.MountPath, true); err != nil {
 				return fmt.Errorf("directory is already mounted, unmount manually before remount [%v]", err.Error())
 			}
 

--- a/cmd/mountv1_test.go
+++ b/cmd/mountv1_test.go
@@ -92,6 +92,7 @@ func resetCLIFlags(cmd cobra.Command) {
 	// reset all CLI flags before next test
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		f.Changed = false
+		f.Value.Set(f.DefValue)
 	})
 	viper.Reset()
 }

--- a/cmd/unmount.go
+++ b/cmd/unmount.go
@@ -53,7 +53,8 @@ var unmountCmd = &cobra.Command{
 	SuggestFor:        []string{"unmount", "unmnt"},
 	Args:              cobra.ExactArgs(1),
 	FlagErrorHandling: cobra.ExitOnError,
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		lazy, _ := cmd.Flags().GetBool("lazy")
 		if strings.Contains(args[0], "*") {
 			mntPathPrefix := args[0]
 
@@ -61,14 +62,14 @@ var unmountCmd = &cobra.Command{
 			for _, mntPath := range lstMnt {
 				match, _ := regexp.MatchString(mntPathPrefix, mntPath)
 				if match {
-					err := unmountBlobfuse2(mntPath)
+					err := unmountBlobfuse2(mntPath, lazy)
 					if err != nil {
 						return fmt.Errorf("failed to unmount %s [%s]", mntPath, err.Error())
 					}
 				}
 			}
 		} else {
-			err := unmountBlobfuse2(args[0])
+			err := unmountBlobfuse2(args[0], lazy)
 			if err != nil {
 				return err
 			}
@@ -86,13 +87,18 @@ var unmountCmd = &cobra.Command{
 }
 
 // Attempts to unmount the directory and returns true if the operation succeeded
-func unmountBlobfuse2(mntPath string) error {
+func unmountBlobfuse2(mntPath string, lazy bool) error {
 	unmountCmd := []string{"fusermount3", "fusermount"}
 
 	var errb bytes.Buffer
 	var err error
 	for _, umntCmd := range unmountCmd {
-		cliOut := exec.Command(umntCmd, "-u", mntPath)
+		var args []string
+		if lazy {
+			args = append(args, "-z")
+		}
+		args = append(args, "-u", mntPath)
+		cliOut := exec.Command(umntCmd, args...)
 		cliOut.Stderr = &errb
 		_, err = cliOut.Output()
 
@@ -113,4 +119,7 @@ func unmountBlobfuse2(mntPath string) error {
 func init() {
 	rootCmd.AddCommand(unmountCmd)
 	unmountCmd.AddCommand(umntAllCmd)
+
+	unmountCmd.PersistentFlags().BoolP("lazy", "z", false, "Use lazy unmount")
+	umntAllCmd.PersistentFlags().BoolP("lazy", "z", false, "Use lazy unmount")
 }

--- a/cmd/unmount.go
+++ b/cmd/unmount.go
@@ -121,5 +121,4 @@ func init() {
 	unmountCmd.AddCommand(umntAllCmd)
 
 	unmountCmd.PersistentFlags().BoolP("lazy", "z", false, "Use lazy unmount")
-	umntAllCmd.PersistentFlags().BoolP("lazy", "z", false, "Use lazy unmount")
 }

--- a/cmd/unmount_all.go
+++ b/cmd/unmount_all.go
@@ -48,7 +48,8 @@ var umntAllCmd = &cobra.Command{
 	Long:              "Unmount all instances of Blobfuse2",
 	SuggestFor:        []string{"al", "all"},
 	FlagErrorHandling: cobra.ExitOnError,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		lazy, _ := cmd.Flags().GetBool("lazy")
 		lstMnt, err := common.ListMountPoints()
 		if err != nil {
 			return fmt.Errorf("failed to list mount points [%s]", err.Error())
@@ -60,7 +61,7 @@ var umntAllCmd = &cobra.Command{
 
 		for _, mntPath := range lstMnt {
 			mountfound += 1
-			err := unmountBlobfuse2(mntPath)
+			err := unmountBlobfuse2(mntPath, lazy)
 			if err == nil {
 				unmounted += 1
 			} else {

--- a/cmd/unmount_test.go
+++ b/cmd/unmount_test.go
@@ -227,3 +227,54 @@ func TestUnMountCommand(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	suite.Run(t, new(unmountTestSuite))
 }
+
+func (suite *unmountTestSuite) TestUnmountCmdLazy() {
+	defer suite.cleanupTest()
+
+	lazyFlags := []string{"--lazy", "-z"}
+	flagBeforePath := false
+	flagAfterPath := !flagBeforePath
+	possibleFlagPositions := []bool{flagBeforePath, flagAfterPath}
+	baseCommand := "unmount"
+
+	for _, lazyFlag := range lazyFlags {
+		for _, flagPosition := range possibleFlagPositions {
+			mountDirectory6, _ := os.MkdirTemp("", "TestUnMountTemp")
+			os.MkdirAll(mountDirectory6, 0777)
+			defer os.RemoveAll(mountDirectory6)
+
+			cmd := exec.Command("../blobfuse2", "mount", mountDirectory6, fmt.Sprintf("--config-file=%s", confFileUnMntTest))
+			_, err := cmd.Output()
+			suite.assert.NoError(err)
+
+			time.Sleep(2 * time.Second)
+			// move into the mount directory to cause busy error on regular unmount
+			err = os.Chdir(mountDirectory6)
+			suite.assert.NoError(err)
+
+			// normal unmount should fail
+			_, err = executeCommandC(rootCmd, "unmount", mountDirectory6)
+			suite.assert.Error(err)
+			if err != nil {
+				suite.assert.Contains(err.Error(), "failed to unmount")
+			}
+
+			// test lazy unmount
+			args := []string{baseCommand}
+			if flagPosition == flagBeforePath {
+				args = append(args, lazyFlag, mountDirectory6)
+			} else {
+				args = append(args, mountDirectory6, lazyFlag)
+			}
+			_, err = executeCommandC(rootCmd, args...)
+			suite.assert.NoError(err)
+
+			// leave the mount directory to allow lazy unmount to complete
+			err = os.Chdir(currentDir)
+			suite.assert.NoError(err)
+
+			// clean up lazy flag
+			suite.cleanupTest()
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

This PR adds a new flag to the unmount command `lazy` which will pass the lazy flag to fusermount when unmounting. This enables unmount the mount when the device or resource is busy. fusermount will unmount once the device is no longer busy, making it easier to unmount existing mounts.

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

Added unit tests for new flag as well as manual testing of the new `lazy` flag.

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [x] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [x] License headers are included in each file.

## Related Links
- [Issues](https://github.com/Azure/azure-storage-fuse/issues/797)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->