### PR TITLE
Fix logs using up all the space of /tmp folder

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -474,13 +474,13 @@ var mountCmd = &cobra.Command{
 			}
 		}
 
+		common.ForegroundMount = options.Foreground
+
 		pipeline, err = internal.NewPipeline(options.Components, !daemon.WasReborn())
 		if err != nil {
 			log.Err("mount : failed to initialize new pipeline [%v]", err)
 			return Destroy(fmt.Sprintf("failed to initialize new pipeline [%s]", err.Error()))
 		}
-
-		common.ForegroundMount = options.Foreground
 
 		log.Info("mount: Mounting blobfuse2 on %s", options.MountPath)
 		if !options.Foreground {

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -332,6 +332,14 @@ func (lf *Libfuse) Configure(_ bool) error {
 		return fmt.Errorf("%s config error %s", lf.Name(), err.Error())
 	}
 
+	// Disable libfuse logs if the mount is not running in foreground.
+	// Currently as of 01-05-2025, we emmit the libfuse logs only to the stdout.
+	if !common.ForegroundMount {
+		if lf.traceEnable {
+			lf.traceEnable = false
+		}
+	}
+
 	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max-fuse-threads %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v",
 		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxFuseThreads, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask)
 

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -333,7 +333,7 @@ func (lf *Libfuse) Configure(_ bool) error {
 	}
 
 	// Disable libfuse logs if the mount is not running in foreground.
-	// Currently as of 01-05-2025, we emmit the libfuse logs only to the stdout.
+	// Currently as of 01-05-2025, we emit the libfuse logs only to the stdout.
 	if !common.ForegroundMount {
 		if lf.traceEnable {
 			lf.traceEnable = false

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -70,7 +70,8 @@ func (suite *libfuseTestSuite) TestConfig() {
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
 	suite.assert.Empty(suite.libfuse.mountPath)
 	suite.assert.True(suite.libfuse.readOnly)
-	suite.assert.True(suite.libfuse.traceEnable)
+	// trace should only be enabled when mounted in foreground otherwise we don't honor the option
+	suite.assert.False(suite.libfuse.traceEnable)
 	suite.assert.True(suite.libfuse.disableWritebackCache)
 	suite.assert.False(suite.libfuse.ignoreOpenFlags)
 	suite.assert.True(suite.libfuse.allowOther)
@@ -92,7 +93,8 @@ func (suite *libfuseTestSuite) TestConfigZero() {
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
 	suite.assert.Empty(suite.libfuse.mountPath)
 	suite.assert.True(suite.libfuse.readOnly)
-	suite.assert.True(suite.libfuse.traceEnable)
+	// trace should only be enabled when mounted in foreground otherwise we don't honor the option
+	suite.assert.False(suite.libfuse.traceEnable)
 	suite.assert.False(suite.libfuse.allowOther)
 	suite.assert.False(suite.libfuse.allowRoot)
 	suite.assert.Equal(suite.libfuse.dirPermission, uint(fs.FileMode(0775)))
@@ -112,7 +114,8 @@ func (suite *libfuseTestSuite) TestConfigDefaultPermission() {
 	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
 	suite.assert.Empty(suite.libfuse.mountPath)
 	suite.assert.True(suite.libfuse.readOnly)
-	suite.assert.True(suite.libfuse.traceEnable)
+	// trace should only be enabled when mounted in foreground otherwise we don't honor the option
+	suite.assert.False(suite.libfuse.traceEnable)
 	suite.assert.False(suite.libfuse.allowOther)
 	suite.assert.False(suite.libfuse.allowRoot)
 	suite.assert.Equal(suite.libfuse.dirPermission, uint(fs.FileMode(0555)))
@@ -121,6 +124,23 @@ func (suite *libfuseTestSuite) TestConfigDefaultPermission() {
 	suite.assert.Equal(suite.libfuse.attributeExpiration, uint32(0))
 	suite.assert.Equal(suite.libfuse.negativeTimeout, uint32(0))
 	suite.assert.True(suite.libfuse.directIO)
+}
+
+func (suite *libfuseTestSuite) TestConfigFuseTraceEnable() {
+	defer suite.cleanupTest()
+	suite.cleanupTest() // clean up the default libfuse generated
+	config := "foreground: true\nlibfuse:\n  fuse-trace: true\n"
+
+	// Foreground mount option is global config option which is exported to others using a global variable.
+	// Hence setting the option before starting the test.
+	common.ForegroundMount = true
+	suite.setupTestHelper(config) // setup a new libfuse with a custom config (clean up will occur after the test as usual)
+
+	suite.assert.Equal(suite.libfuse.Name(), "libfuse")
+	suite.assert.Empty(suite.libfuse.mountPath)
+	// Fuse trace should work as we are mouting using foregroud option.
+	suite.assert.True(suite.libfuse.traceEnable)
+	common.ForegroundMount = false
 }
 
 func (suite *libfuseTestSuite) TestDisableWritebackCache() {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Bug Fix**: (Brief description of the feature or issue being addressed)
 /tmp folder is getting full due to the space used by the deleted file /tmp/blobfuse2.pid when the fuse-trace option is enabled and mounted without foreground option. 
 **Reason:**
 Currently we use stdout for emitting the libfuse logs. Now when user don't use foreground option while mounting, generally the mounted process have its stdout and stderr linked to the file /tmp/blobfuse2.log so these logs are redirected to that file. But this file is deleted by the parent process after the mount become successful. so now this is a deleted file with an open file descriptor. Size of this file gets bigger and bigger until user unmounts. sad part is user cannot delete this file as it's already deleted by the parent process of our mount. space taken by this /tmp/blobfuse2.pid file is released when user unmounts.
 
 **Output:** "lsof | grep 'deleted' "when fuse logs are enabled and blobfuse is mounted as daemon.
blobfuse2 2938722 2938730 blobfuse2          fantom    2w      REG                8,1       598       1739 /tmp/blobfuse2.2938713 (deleted)
blobfuse2 2938722 2938738 blobfuse2          fantom    1w      REG                8,1      1505       1739 /tmp/blobfuse2.2938713 (deleted)

You can see in the output that the size of the file is getting increased as we do operations on mountpoint.

Fix : Disable fuse-trace option when user mounts as daemon.

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<https://github.com/Azure/azure-storage-fuse/issues/1662>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->