### PR TITLE
Change size property for metadata files in dcache

### DIFF
--- a/component/distributed_cache/utils.go
+++ b/component/distributed_cache/utils.go
@@ -197,7 +197,7 @@ func parseDcacheMetadata(attr *internal.ObjAttr) error {
 	var fileSize int64
 	var err error
 
-	if val, ok := attr.Metadata["cache-object-length"]; ok {
+	if val, ok := attr.Metadata["cache_object_length"]; ok {
 		fileSize, err = strconv.ParseInt(*val, 10, 64)
 		if err == nil {
 			if fileSize >= 0 {
@@ -217,7 +217,7 @@ func parseDcacheMetadata(attr *internal.ObjAttr) error {
 			common.Assert(false, err)
 		}
 	} else {
-		err = fmt.Errorf("Blob metadata for %s doesn't have cache-object-length property", attr.Name)
+		err = fmt.Errorf("Blob metadata for %s doesn't have cache_object_length property", attr.Name)
 		log.Err("DistributedCache::GetAttr: %v", err)
 		common.Assert(false, err)
 	}

--- a/internal/dcache/metadata_manager/metadata_manager_impl.go
+++ b/internal/dcache/metadata_manager/metadata_manager_impl.go
@@ -221,7 +221,7 @@ func (m *BlobMetadataManager) createFileInit(filePath string, fileMetadata []byt
 	// The size of the file is set to -1 to represent the file is not finalized.
 	sizeStr := "-1"
 	metadata := map[string]*string{
-		"cache-object-length": &sizeStr,
+		"cache_object_length": &sizeStr,
 	}
 
 	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
@@ -280,7 +280,7 @@ func (m *BlobMetadataManager) createFileFinalize(filePath string, fileMetadata [
 		common.Assert(err == nil, err)
 
 		// Extract the size from the metadata properties.
-		size, ok := prop.Metadata["cache-object-length"]
+		size, ok := prop.Metadata["cache_object_length"]
 		common.Assert(ok && *size == "-1", ok, *size)
 	}
 
@@ -289,7 +289,7 @@ func (m *BlobMetadataManager) createFileFinalize(filePath string, fileMetadata [
 	sizeStr := strconv.FormatInt(fileSize, 10)
 	metadata := map[string]*string{
 		"opencount":           &openCount,
-		"cache-object-length": &sizeStr,
+		"cache_object_length": &sizeStr,
 	}
 
 	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
@@ -336,7 +336,7 @@ func (m *BlobMetadataManager) getFile(filePath string) ([]byte, int64, error) {
 	}
 
 	// Extract the size from the metadata properties.
-	size, ok := prop.Metadata["cache-object-length"]
+	size, ok := prop.Metadata["cache_object_length"]
 	if !ok {
 		log.Err("GetFile:: size not found in metadata for path %s", path)
 		common.Assert(false, fmt.Sprintf("size not found in metadata for path %s", path))


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
The name "cache-object-length" is not compatible with naming system that is followed by azure storage for names used in the metadata fields. [See here](https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#metadata-key-and-value-names) 
Hence using cache_object_length as new metadata field.