### PR TITLE
Add support for MinNodes config.

### DIFF
--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -146,6 +146,10 @@ func GetAllNodes() map[string]struct{} {
 	return clusterMap.getAllNodes()
 }
 
+func IsClusterReadonly() bool {
+	return clusterMap.isClusterReadonly()
+}
+
 // Refresh clustermap local copy from the metadata store synchronously.
 // The call blocks till the clustermap is refreshed.
 // Once RefreshClusterMapSync() completes successfully, any clustermap call made would return results from the
@@ -265,6 +269,12 @@ func (c *ClusterMap) getAllNodes() map[string]struct{} {
 	}
 
 	return nodesMap
+}
+
+func (c *ClusterMap) isClusterReadonly() bool {
+	common.Assert(c.localMap != nil)
+
+	return c.localMap.Readonly
 }
 
 func (c *ClusterMap) getCacheConfig() *dcache.DCacheConfig {

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -142,6 +142,10 @@ func GetActiveMVNames() []string {
 	return clusterMap.getActiveMVNames()
 }
 
+func GetAllNodes() map[string]struct{} {
+	return clusterMap.getAllNodes()
+}
+
 // Refresh clustermap local copy from the metadata store synchronously.
 // The call blocks till the clustermap is refreshed.
 // Once RefreshClusterMapSync() completes successfully, any clustermap call made would return results from the
@@ -248,6 +252,19 @@ func (c *ClusterMap) getActiveMVNames() []string {
 		}
 	}
 	return activeMVNames[:i]
+}
+
+// Scan through the RV list and return the set of all nodes which have contributed at least one RV.
+func (c *ClusterMap) getAllNodes() map[string]struct{} {
+	common.Assert(c.localMap != nil)
+
+	nodesMap := make(map[string]struct{})
+
+	for _, rv := range c.localMap.RVMap {
+		nodesMap[rv.NodeId] = struct{}{}
+	}
+
+	return nodesMap
 }
 
 func (c *ClusterMap) getCacheConfig() *dcache.DCacheConfig {


### PR DESCRIPTION
Now we clear the cluster ReadOnly status when number of nodes that have joined the cluster goes more than MinNodes config.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->