### PR TITLE
Fix for an assert that fired as fixMV()->joinMV() used cm.RVNameToNod…

### DIFF
--- a/internal/dcache/rpc/client/client_pool.go
+++ b/internal/dcache/rpc/client/client_pool.go
@@ -95,7 +95,16 @@ func (cp *clientPool) getRPCClientNoLock(nodeID string) (*rpcClient, error) {
 		}
 
 		ncPool = &nodeClientPool{nodeID: nodeID}
-		ncPool.createRPCClients(cp.maxPerNode)
+		//
+		// Note that createRPCClients() can fail to create any client if the remote blobfuse process
+		// is not running or the node is down.
+		//
+		err := ncPool.createRPCClients(cp.maxPerNode)
+		if err != nil {
+			log.Err("clientPool::getRPCClientNoLock: createRPCClients(%s) failed: %v", nodeID, err)
+			return nil, err
+		}
+
 		cp.clients[nodeID] = ncPool
 	}
 
@@ -437,31 +446,81 @@ type nodeClientPool struct {
 }
 
 // createRPCClients creates a channel of RPC clients of size numClients for the specified node ID
-func (ncPool *nodeClientPool) createRPCClients(numClients uint32) {
-	log.Debug("nodeClientPool::createRPCClients: Creating %d RPC clients for node %s", numClients, ncPool.nodeID)
+func (ncPool *nodeClientPool) createRPCClients(numClients uint32) error {
+	log.Debug("nodeClientPool::createRPCClients: Creating %d RPC clients for node %s",
+		numClients, ncPool.nodeID)
+
+	common.Assert(ncPool.clientChan == nil)
+	common.Assert(ncPool.numActive.Load() == 0, ncPool.numActive.Load())
+	common.Assert(common.IsValidUUID(ncPool.nodeID))
 
 	ncPool.clientChan = make(chan *rpcClient, numClients)
 	ncPool.lastUsed = time.Now()
 
-	// Create RPC clients and add them to the channel
+	var err error
+
+	// Create RPC clients and add them to the channel.
 	for i := 0; i < int(numClients); i++ {
 		client, err := newRPCClient(ncPool.nodeID, rpc.GetNodeAddressFromID(ncPool.nodeID))
 		if err != nil {
-			log.Err("nodeClientPool::createRPCClients: Failed to create RPC client for node %s [%v]", ncPool.nodeID, err.Error())
-			continue // skip this client
+			log.Err("nodeClientPool::createRPCClients: Failed to create RPC client for node %s [%v]",
+				ncPool.nodeID, err)
+			//
+			// Only valid reason could be connection refused as the blobfuse process is not running
+			// on the remote node or a timeout if the node is down.
+			// There is no point in retrying in that case.
+			//
+			common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
+			break
 		}
 		ncPool.clientChan <- client
 	}
 
-	common.Assert(len(ncPool.clientChan) == int(numClients), "client channel is not full after creating RPC clients", len(ncPool.clientChan), numClients)
+	//
+	// If we are not able to create all requested connections there's something seriously wrong
+	// so clean up and fail. One possibility is that the remote node went down after creating
+	// first few connections.
+	// What is more likely is that we could not create any connection. This can happen f.e., when
+	// clustermap has a component RV for an MV but the RV just went down, if user attempts reading
+	// a file that has data on that MV and ReadMV() picks that RV. If there are no existing connections
+	// to that node, createRPCClients() will be called which will fail to create any connection.
+	//
+	if len(ncPool.clientChan) == 0 {
+		return fmt.Errorf("could not create any client for node %s: %v", ncPool.nodeID, err)
+	} else if len(ncPool.clientChan) != int(numClients) {
+		log.Err("nodeClientPool::createRPCClients: Created %d of %d clients for node %s, cleaning up",
+			len(ncPool.clientChan), numClients, ncPool.nodeID)
+
+		for client := range ncPool.clientChan {
+			err1 := client.close()
+			// close() should not fail, even if it does there's nothing left to do.
+			common.Assert(err1 == nil, err1)
+		}
+		// All error paths must ensure this.
+		common.Assert(len(ncPool.clientChan) == 0, len(ncPool.clientChan))
+		return fmt.Errorf("could not create all requested clients for node %s: %v", ncPool.nodeID, err)
+	}
+
+	// We just got started, cannot have active clients.
+	common.Assert(ncPool.numActive.Load() == 0, ncPool.numActive.Load())
+	return nil
 }
 
 // closeRPCClients closes all RPC clients in the channel for the specified node ID
 func (ncPool *nodeClientPool) closeRPCClients() error {
-	log.Debug("nodeClientPool::closeRPCClients: Closing RPC clients for node %s", ncPool.nodeID)
+	log.Debug("nodeClientPool::closeRPCClients: Closing %d RPC clients for node %s",
+		len(ncPool.clientChan), ncPool.nodeID)
 
-	// check that the length of the channel is maxPerNode, so that all clients are released back
-	common.Assert(len(ncPool.clientChan) == int(cp.maxPerNode), "client channel is not full before closing RPC clients", len(ncPool.clientChan), cp.maxPerNode)
+	// We should not be closing all clients when there are active clients.
+	common.Assert(ncPool.numActive.Load() == 0,
+		ncPool.numActive.Load(), len(ncPool.clientChan), cp.maxPerNode)
+
+	//
+	// We never have a partially allocated client pool and we only clean up a client pool when all
+	// previously allocated clients have been released back to the pool
+	//
+	common.Assert(len(ncPool.clientChan) == int(cp.maxPerNode), len(ncPool.clientChan), cp.maxPerNode)
+
 	close(ncPool.clientChan)
 
 	for client := range ncPool.clientChan {
@@ -472,6 +531,8 @@ func (ncPool *nodeClientPool) closeRPCClients() error {
 		}
 	}
 
-	common.Assert(len(ncPool.clientChan) == 0, "client channel is not empty after closing all RPC clients")
+	// All clients must have been closed.
+	common.Assert(len(ncPool.clientChan) == 0, len(ncPool.clientChan))
+
 	return nil
 }

--- a/internal/dcache/rpc/client/client_pool.go
+++ b/internal/dcache/rpc/client/client_pool.go
@@ -289,8 +289,11 @@ func (cp *clientPool) resetAllRPCClients(client *rpcClient) error {
 		err = fmt.Errorf("failed to reset RPC client to %s node %s: %v",
 			client.nodeAddress, client.nodeID, err)
 		log.Err("clientPool::resetAllRPCClients: %v", err)
-		// Connection refused is the only viable error. Assert to know if anything else happens.
-		common.Assert(rpc.IsConnectionRefused(err))
+		//
+		// Connection refused and timeout are the only viable errors.
+		// Assert to know if anything else happens.
+		//
+		common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 		return err
 	}
 

--- a/internal/dcache/rpc/client/functions.go
+++ b/internal/dcache/rpc/client/functions.go
@@ -94,14 +94,26 @@ func Hello(ctx context.Context, targetNodeID string, req *models.HelloRequest) (
 				if err1 != nil {
 					log.Err("rpc_client::Hello: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry Hello once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -159,12 +171,26 @@ func GetChunk(ctx context.Context, targetNodeID string, req *models.GetChunkRequ
 				if err1 != nil {
 					log.Err("rpc_client::GetChunk: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry GetChunk once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -222,14 +248,26 @@ func PutChunk(ctx context.Context, targetNodeID string, req *models.PutChunkRequ
 				if err1 != nil {
 					log.Err("rpc_client::PutChunk: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry PutChunk once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -287,14 +325,26 @@ func RemoveChunk(ctx context.Context, targetNodeID string, req *models.RemoveChu
 				if err1 != nil {
 					log.Err("rpc_client::RemoveChunk: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry RemoveChunk once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -352,14 +402,26 @@ func JoinMV(ctx context.Context, targetNodeID string, req *models.JoinMVRequest)
 				if err1 != nil {
 					log.Err("rpc_client::JoinMV: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry JoinMV once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -417,14 +479,26 @@ func UpdateMV(ctx context.Context, targetNodeID string, req *models.UpdateMVRequ
 				if err1 != nil {
 					log.Err("rpc_client::UpdateMV: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry UpdateMV once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -482,14 +556,26 @@ func LeaveMV(ctx context.Context, targetNodeID string, req *models.LeaveMVReques
 				if err1 != nil {
 					log.Err("rpc_client::LeaveMV: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry LeaveMV once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -547,14 +633,26 @@ func StartSync(ctx context.Context, targetNodeID string, req *models.StartSyncRe
 				if err1 != nil {
 					log.Err("rpc_client::StartSync: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry StartSync once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil
@@ -612,14 +710,26 @@ func EndSync(ctx context.Context, targetNodeID string, req *models.EndSyncReques
 				if err1 != nil {
 					log.Err("rpc_client::EndSync: resetAllRPCClients failed for node %s: %v",
 						targetNodeID, err1)
-					// resetAllRPCClients() may fail but unlikely, so assert.
-					common.Assert(false, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
 					return nil, err
 				}
 
 				// Retry EndSync once more with fresh connection.
 				continue
 			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil

--- a/internal/dcache/rpc/client/functions.go
+++ b/internal/dcache/rpc/client/functions.go
@@ -85,7 +85,7 @@ func Hello(ctx context.Context, targetNodeID string, req *models.HelloRequest) (
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				//
 				// Note: In case of multiple contexts contesting, we may have those contexts
 				//	 reset "good" connections too. See if we need to worry about that.
@@ -154,7 +154,7 @@ func GetChunk(ctx context.Context, targetNodeID string, req *models.GetChunkRequ
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::GetChunk: resetAllRPCClients failed for node %s: %v",
@@ -217,7 +217,7 @@ func PutChunk(ctx context.Context, targetNodeID string, req *models.PutChunkRequ
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::PutChunk: resetAllRPCClients failed for node %s: %v",
@@ -282,7 +282,7 @@ func RemoveChunk(ctx context.Context, targetNodeID string, req *models.RemoveChu
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::RemoveChunk: resetAllRPCClients failed for node %s: %v",
@@ -347,7 +347,7 @@ func JoinMV(ctx context.Context, targetNodeID string, req *models.JoinMVRequest)
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::JoinMV: resetAllRPCClients failed for node %s: %v",
@@ -412,7 +412,7 @@ func UpdateMV(ctx context.Context, targetNodeID string, req *models.UpdateMVRequ
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::UpdateMV: resetAllRPCClients failed for node %s: %v",
@@ -477,7 +477,7 @@ func LeaveMV(ctx context.Context, targetNodeID string, req *models.LeaveMVReques
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::LeaveMV: resetAllRPCClients failed for node %s: %v",
@@ -542,7 +542,7 @@ func StartSync(ctx context.Context, targetNodeID string, req *models.StartSyncRe
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::StartSync: resetAllRPCClients failed for node %s: %v",
@@ -607,7 +607,7 @@ func EndSync(ctx context.Context, targetNodeID string, req *models.EndSyncReques
 			// If the failure is due to a stale connection to a node that has restarted, reset the connections
 			// and retry once more.
 			//
-			if rpc.IsConnectionClosed(err) {
+			if rpc.IsConnectionTerminated(err) {
 				err1 := cp.resetAllRPCClients(client)
 				if err1 != nil {
 					log.Err("rpc_client::EndSync: resetAllRPCClients failed for node %s: %v",

--- a/internal/dcache/rpc/response_error.go
+++ b/internal/dcache/rpc/response_error.go
@@ -66,6 +66,12 @@ func GetRPCResponseError(err error) *models.ResponseError {
 	return respErr
 }
 
+// Check if the error returned by thrift is due to the RPC server returning some error, and not due to
+// some n/w condition.
+func IsRPCError(err error) bool {
+	return (GetRPCResponseError(err) != nil)
+}
+
 // Check if the error returned by thrift indicates connection terminated/reset by server.
 // This usually happens when we setup a connection (mostly the pool of connections) with a peer node and the
 // blobfuse process on that node stops/restarts. Later when we send a request over those connections, the
@@ -132,6 +138,7 @@ func IsConnectionRefused(err error) bool {
 }
 
 // Check if the error returned by thrift indicates timeout.
+// This can happen if say the node is down or unreachable over the n/w.
 func IsTimedOut(err error) bool {
 	common.Assert(err != nil)
 

--- a/internal/dcache/rpc/response_error.go
+++ b/internal/dcache/rpc/response_error.go
@@ -41,7 +41,7 @@ import (
 	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/log"
 
-	//"github.com/apache/thrift/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/Azure/azure-storage-fuse/v2/internal/dcache/rpc/gen-go/dcache/models"
 )
@@ -66,13 +66,18 @@ func GetRPCResponseError(err error) *models.ResponseError {
 	return respErr
 }
 
-// Check if the error returned by thrift indicates connection closed by server.
-func IsConnectionClosed(err error) bool {
+// Check if the error returned by thrift indicates connection terminated/reset by server.
+// This usually happens when we setup a connection (mostly the pool of connections) with a peer node and the
+// blobfuse process on that node stops/restarts. Later when we send a request over those connections, the
+// peer TCP will respond with a TCP RST and thrift call will fail with EPIPE.
+// If the blobfuse process has stopped (and not restared), a reconnect attempt will fail with
+// IsConnectionRefused() error, else it'll succeed and the new connection can be used to send the RPC requests.
+func IsConnectionTerminated(err error) bool {
 	common.Assert(err != nil)
 
 	// RPC error, cannot be a connection reset error.
 	if GetRPCResponseError(err) != nil {
-		log.Debug("IsConnectionClosed: is RPC error: %v", err)
+		log.Debug("IsConnectionTerminated: is RPC error: %v", err)
 		return false
 	}
 
@@ -83,7 +88,26 @@ func IsConnectionClosed(err error) bool {
 	return errors.Is(err, syscall.EPIPE)
 }
 
-// Check if the error returned by thrift indicates connection refused by server.
+// When client sends a thrift RPC over a connection and before the server could send the response, the process
+// stops or crashes, then the client will get an eof and IsConnectionClosed() should return true.
+func IsConnectionClosed(err error) bool {
+	common.Assert(err != nil)
+
+	// RPC error, cannot be a connection closed error.
+	if GetRPCResponseError(err) != nil {
+		log.Debug("IsConnectionClosed: is RPC error: %v", err)
+		return false
+	}
+
+	te := thrift.NewTTransportExceptionFromError(err)
+	log.Debug("IsConnectionClosed: err: %v, err: %T, te.TypeId(): %d", err, err, te.TypeId())
+
+	// TODO: See which one of these works.
+	return te.TypeId() == thrift.END_OF_FILE || err.Error() == "EOF"
+}
+
+// Check if the error returned by thrift indicates connect attempt being refused by the peer node.
+// This indicates that blobfuse process is not running on the peer node.
 func IsConnectionRefused(err error) bool {
 	common.Assert(err != nil)
 
@@ -117,9 +141,10 @@ func IsTimedOut(err error) bool {
 		return false
 	}
 
-	// TODO: This is untested, see whether this works or the ETIMEDOUT check works!
-	//te := thrift.NewTTransportExceptionFromError(err)
-	//return te.TypeId() == thrift.TIMED_OUT
+	te := thrift.NewTTransportExceptionFromError(err)
+	log.Debug("IsTimedOut: err: %v, err: %T, te.TypeId(): %d, Is syscall.ETIMEDOUT: %v",
+		err, err, te.TypeId(), errors.Is(err, syscall.ETIMEDOUT))
 
-	return errors.Is(err, syscall.ETIMEDOUT)
+	// TODO: See which one of these works.
+	return te.TypeId() == thrift.TIMED_OUT || errors.Is(err, syscall.ETIMEDOUT)
 }


### PR DESCRIPTION
…eId()

and cached clustermap didn't have the RV yet

    updateStorageClusterMapIfRequired() fetches the global clustermap and calls
    updateMVList() passing the RV and MV list from the fetched clustermap.
    Later down updateMVList() calls fixMV(), which calls joinMV() and that
    calls a clustermap method RVNameToNodeId() to convert a given rv name to
    nodeid. If this is the first time this rv is being seen in the RV list,
    it won't be present in the clustermap cached copy and hence
    cm.RVNameToNodeId() fails an assert.

    The fix is to update local clustermap copy everytime we download
    clustermap. This renames the older
    cmi.updateClusterMapLocalCopyIfRequired to
    cmi.fetchAndUpdateLocalClusterMap, refactoring a bit to return the
    unmarshalled clustermap and the etag.
    Anyone wanting the clustermap must use fetchAndUpdateLocalClusterMap()
    instead of directly calls the getClusterMap().

sample stack trace

panic: Assertion failed: [rv3]

goroutine 196 [running]:
log.Panicf({0x12743e4?, 0x1?}, {0xc0007a14d0?, 0x820365?, 0x10?})
        /usr/local/go/src/log/log.go:439 +0x65
github.com/Azure/azure-storage-fuse/v2/common.Assert(0x0, {0xc00089f610, 0x1, 0x1})
        /home/dcacheuser/azure-storage-fuse/common/assert.go:57 +0x99
github.com/Azure/azure-storage-fuse/v2/internal/dcache/clustermap.(*ClusterMap).rVNameToNodeId(0x1a0ff60, {0xc000 25ab18, 0x3})
        /home/dcacheuser/azure-storage-fuse/internal/dcache/clustermap/clustermap.go:422 +0x1e5
github.com/Azure/azure-storage-fuse/v2/internal/dcache/clustermap.RVNameToNodeId(...)
        /home/dcacheuser/azure-storage-fuse/internal/dcache/clustermap/clustermap.go:130
github.com/Azure/azure-storage-fuse/v2/internal/dcache/cluster_manager.(*ClusterManager).joinMV(0xc0001f47e0, {0x c00025acf0, 0x3}, {{0x1263010, 0x6}, 0xc0002f9cb0}, 0x0)
        /home/dcacheuser/azure-storage-fuse/internal/dcache/cluster_manager/cluster_manager.go:2083 +0x105a
github.com/Azure/azure-storage-fuse/v2/internal/dcache/cluster_manager.(*ClusterManager).updateMVList(0xc0001f47e 0, 0xc00027f7d0, 0xc00027f800)
        /home/dcacheuser/azure-storage-fuse/internal/dcache/cluster_manager/cluster_manager.go:1953 +0x1550
github.com/Azure/azure-storage-fuse/v2/internal/dcache/cluster_manager.(*ClusterManager).updateStorageClusterMapI fRequired(0xc0001f47e0)
        /home/dcacheuser/azure-storage-fuse/internal/dcache/cluster_manager/cluster_manager.go:1163 +0xeb4
github.com/Azure/azure-storage-fuse/v2/internal/dcache/cluster_manager.(*ClusterManager).start.func2()
        /home/dcacheuser/azure-storage-fuse/internal/dcache/cluster_manager/cluster_manager.go:231 +0x9f
created by github.com/Azure/azure-storage-fuse/v2/internal/dcache/cluster_manager.(*ClusterManager).start in goro utine 1
        /home/dcacheuser/azure-storage-fuse/internal/dcache/cluster_manager/cluster_manager.go:225 +0xb5b

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->