### PR TITLE
RPC: Added GetMVSize() API

### DIFF
--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -1057,8 +1057,8 @@ func GetMVSize(mvName string) (int64, error) {
 			// Success.
 			common.Assert(resp != nil, rpc.GetMVSizeRequestToString(req))
 			mvSize = resp.MvSize
-			log.Debug("ReplicationManager::GetMVSize: GetMVSize successful RPC response: MV size = %d",
-				resp.MvSize)
+			log.Debug("ReplicationManager::GetMVSize: GetMVSize successful for %s, RPC response: MV size = %d",
+				rpc.GetMVSizeRequestToString(req), resp.MvSize)
 			break
 		}
 

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -51,7 +51,6 @@ import (
 	"github.com/Azure/azure-storage-fuse/v2/internal/dcache/rpc"
 	rpc_client "github.com/Azure/azure-storage-fuse/v2/internal/dcache/rpc/client"
 	"github.com/Azure/azure-storage-fuse/v2/internal/dcache/rpc/gen-go/dcache/models"
-	rpc_server "github.com/Azure/azure-storage-fuse/v2/internal/dcache/rpc/server"
 )
 
 type replicationMgr struct {
@@ -495,10 +494,10 @@ func syncMV(mvName string, mvInfo dcache.MirroredVolume) {
 	// %age progress. Note that JoinMV carries the reservedSpace parameter which is the more critical one
 	// to decide if an RV can host a new MV replica or not.
 	//
-	// TODO: Make sure GetDiskUsageOfMV() correctly returns the to-be-synced data, i.e., data in the regular
-	//       MV folder.
+	// TODO: Make sure GetMVSize() correctly returns the to-be-synced data, i.e., data in the regular
+	//       MV folder. Remove .sync folder dependency, all chunks will be written to the regular MV folder.
 	//
-	syncSize, err := rpc_server.GetMyMVSize(mvName, lioRV)
+	syncSize, err := GetMVSize(mvName)
 	if err != nil {
 		err = fmt.Errorf("failed to get disk usage of %s/%s [%v]", lioRV, mvName, err)
 		log.Err("ReplicationManager::syncMV: %v", err)
@@ -980,4 +979,77 @@ func sendEndSyncRequest(rvName string, targetNodeID string, req *models.EndSyncR
 		rvName, req.MV, *resp)
 
 	return nil
+}
+
+func GetMVSize(mvName string) (int64, error) {
+	common.Assert(cm.IsValidMVName(mvName), mvName)
+
+	log.Debug("ReplicationManager::GetMVSize: MV = %s", mvName)
+
+	var mvSize int64
+	var err error
+
+	componentRVs := getComponentRVsForMV(mvName)
+
+	log.Debug("ReplicationManager::GetMVSize: Component RVs for %s are: %v",
+		mvName, rpc.ComponentRVsToString(componentRVs))
+
+	//
+	// Get the most suitable RV from the list of component RVs,
+	// from which we should get the size of the MV. Selecting most
+	// suitable RV is mostly a heuristical process which might
+	// pick the most suitable RV based on one or more of the
+	// following criteria:
+	// - Local RV must be preferred.
+	// - Prefer a node that has recently responded successfully to any of our RPCs.
+	// - Pick a random one.
+	//
+	// excludeRVs is the list of component RVs to omit, used when retrying after prev attempts to read from
+	// certain RV(s) failed. Those RVs are added to excludeRVs list.
+	//
+	var excludeRVs []string
+
+	for {
+		readerRV := getReaderRV(componentRVs, excludeRVs)
+		if readerRV == nil {
+			err = fmt.Errorf("no suitable RV found for MV %s", mvName)
+			log.Err("ReplicationManager::GetMVSize: %v", err)
+			return 0, err
+		}
+
+		common.Assert(!slices.Contains(excludeRVs, readerRV.Name), readerRV.Name, excludeRVs)
+
+		targetNodeID := getNodeIDFromRVName(readerRV.Name)
+		common.Assert(common.IsValidUUID(targetNodeID))
+
+		log.Debug("ReplicationManager::GetMVSize: Selected %s for %s, hosted by node %s",
+			readerRV.Name, mvName, targetNodeID)
+
+		req := &models.GetMVSizeRequest{
+			MV:     mvName,
+			RVName: readerRV.Name,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), RPCClientTimeout*time.Second)
+		defer cancel()
+
+		resp, err := rpc_client.GetMVSize(ctx, targetNodeID, req)
+
+		// Exclude this RV from further iterations (if any).
+		excludeRVs = append(excludeRVs, readerRV.Name)
+
+		if err == nil {
+			// Success.
+			common.Assert(resp != nil, rpc.GetMVSizeRequestToString(req))
+			mvSize = resp.MvSize
+			log.Debug("ReplicationManager::GetMVSize: GetMVSize successful RPC response: MV size = %d",
+				resp.MvSize)
+			break
+		}
+
+		log.Err("ReplicationManager::GetMVSize: Failed to get MV size from node %s for request %v [%v]",
+			targetNodeID, rpc.GetMVSizeRequestToString(req), err)
+	}
+
+	return mvSize, nil
 }

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -498,7 +498,7 @@ func syncMV(mvName string, mvInfo dcache.MirroredVolume) {
 	// TODO: Make sure GetDiskUsageOfMV() correctly returns the to-be-synced data, i.e., data in the regular
 	//       MV folder.
 	//
-	syncSize, err := rpc_server.GetDiskUsageOfMV(mvName, lioRV)
+	syncSize, err := rpc_server.GetMyMVSize(mvName, lioRV)
 	if err != nil {
 		err = fmt.Errorf("failed to get disk usage of %s/%s [%v]", lioRV, mvName, err)
 		log.Err("ReplicationManager::syncMV: %v", err)

--- a/internal/dcache/rpc/client/functions.go
+++ b/internal/dcache/rpc/client/functions.go
@@ -804,7 +804,7 @@ func GetMVSize(ctx context.Context, targetNodeID string, req *models.GetMVSizeRe
 					// Connection refused and timeout are the only viable errors.
 					// Assert to know if anything else happens.
 					//
-					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
+					common.Assert(rpc.IsConnectionRefused(err1) || rpc.IsTimedOut(err1), err1)
 					return nil, err
 				}
 
@@ -816,13 +816,10 @@ func GetMVSize(ctx context.Context, targetNodeID string, req *models.GetMVSizeRe
 			// Only other possible errors:
 			// - Actual RPC error returned by the server.
 			// - Connection closed by the server (maybe it restarted before it could respond).
-			// - Connection refused (if the blobfuse process is not running on the peer node).
 			// - Time out (either node is down or cannot be reached over the n/w).
 			//
-			common.Assert(rpc.IsRPCError(err) ||
-				rpc.IsConnectionClosed(err) ||
-				rpc.IsConnectionRefused(err) ||
-				rpc.IsTimedOut(err), err)
+			common.Assert(rpc.IsRPCError(err) || rpc.IsConnectionClosed(err) || rpc.IsTimedOut(err),
+				err)
 
 			// Fall through to release the RPC client.
 			resp = nil

--- a/internal/dcache/rpc/client/functions.go
+++ b/internal/dcache/rpc/client/functions.go
@@ -756,6 +756,97 @@ func EndSync(ctx context.Context, targetNodeID string, req *models.EndSyncReques
 		targetNodeID, reqStr)
 }
 
+func GetMVSize(ctx context.Context, targetNodeID string, req *models.GetMVSizeRequest) (*models.GetMVSizeResponse, error) {
+	common.Assert(req != nil)
+
+	// Caller must not set SenderNodeID, catch misbehaving callers.
+	common.Assert(len(req.SenderNodeID) == 0, req.SenderNodeID)
+	// TODO: add this after the PR adding sender node id is merged
+	// req.SenderNodeID = myNodeId
+
+	reqStr := rpc.GetMVSizeRequestToString(req)
+	log.Debug("rpc_client::GetMVSize: Sending GetMVSize request to node %s: %v", targetNodeID, reqStr)
+
+	//
+	// We retry once after resetting bad connections.
+	//
+	for i := 0; i < 2; i++ {
+		// Get RPC client from the client pool.
+		client, err := cp.getRPCClient(targetNodeID)
+		if err != nil {
+			log.Err("rpc_client::GetMVSize: Failed to get RPC client for node %s %v: %v",
+				targetNodeID, reqStr, err)
+			return nil, err
+		}
+
+		// Call the rpc method.
+		resp, err := client.svcClient.GetMVSize(ctx, req)
+		if err != nil {
+			log.Err("rpc_client::GetMVSize: GetMVSize failed to node %s %v: %v",
+				targetNodeID, reqStr, err)
+
+			//
+			// If the failure is due to a stale connection to a node that has restarted, reset the connections
+			// and retry once more.
+			//
+			if rpc.IsConnectionTerminated(err) {
+				//
+				// Note: In case of multiple contexts contesting, we may have those contexts
+				//	 reset "good" connections too. See if we need to worry about that.
+				//
+				err1 := cp.resetAllRPCClients(client)
+				if err1 != nil {
+					log.Err("rpc_client::GetMVSize: resetAllRPCClients failed for node %s: %v",
+						targetNodeID, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err) || rpc.IsTimedOut(err), err)
+					return nil, err
+				}
+
+				// Retry GetMVSize once more with fresh connection.
+				continue
+			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Connection refused (if the blobfuse process is not running on the peer node).
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) ||
+				rpc.IsConnectionClosed(err) ||
+				rpc.IsConnectionRefused(err) ||
+				rpc.IsTimedOut(err), err)
+
+			// Fall through to release the RPC client.
+			resp = nil
+		}
+
+		// Release RPC client back to the pool.
+		err1 := cp.releaseRPCClient(client)
+		if err1 != nil {
+			log.Err("rpc_client::GetMVSize: Failed to release RPC client for node %s %v: %v",
+				targetNodeID, reqStr, err1)
+			// Assert, but not fail the GetMVSize call.
+			common.Assert(false, err1)
+		}
+
+		return resp, err
+	}
+
+	//
+	// We come here when we could not succeed even after resetting stale connections and retrying.
+	// This is unexpected, but can happen if the target node goes offline or restarts more than once in
+	// quick succession.
+	//
+	return nil, fmt.Errorf("rpc_client::GetMVSize: Could not find a valid RPC client for node %s %v",
+		targetNodeID, reqStr)
+}
+
 // cleanup closes all the RPC node client pools
 func Cleanup() error {
 	log.Info("rpc_client::Cleanup: Closing all node client pools")

--- a/internal/dcache/rpc/client/functions.go
+++ b/internal/dcache/rpc/client/functions.go
@@ -756,6 +756,8 @@ func EndSync(ctx context.Context, targetNodeID string, req *models.EndSyncReques
 		targetNodeID, reqStr)
 }
 
+// TODO:: integration : use this API in the fix-mv workflow to get the size of the MV
+// while making JoinMV calls to new online RVs
 func GetMVSize(ctx context.Context, targetNodeID string, req *models.GetMVSizeRequest) (*models.GetMVSizeResponse, error) {
 	common.Assert(req != nil)
 

--- a/internal/dcache/rpc/gen-go/dcache/models/models.go
+++ b/internal/dcache/rpc/gen-go/dcache/models/models.go
@@ -4599,6 +4599,316 @@ func (p *EndSyncResponse) String() string {
 }
 
 // Attributes:
+//   - SenderNodeID
+//   - MV
+//   - RVName
+type GetMVSizeRequest struct {
+	SenderNodeID string `thrift:"senderNodeID,1" db:"senderNodeID" json:"senderNodeID"`
+	MV           string `thrift:"MV,2" db:"MV" json:"MV"`
+	RVName       string `thrift:"RVName,3" db:"RVName" json:"RVName"`
+}
+
+func NewGetMVSizeRequest() *GetMVSizeRequest {
+	return &GetMVSizeRequest{}
+}
+
+func (p *GetMVSizeRequest) GetSenderNodeID() string {
+	return p.SenderNodeID
+}
+
+func (p *GetMVSizeRequest) GetMV() string {
+	return p.MV
+}
+
+func (p *GetMVSizeRequest) GetRVName() string {
+	return p.RVName
+}
+func (p *GetMVSizeRequest) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRING {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				if err := p.ReadField2(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				if err := p.ReadField3(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *GetMVSizeRequest) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(ctx); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		p.SenderNodeID = v
+	}
+	return nil
+}
+
+func (p *GetMVSizeRequest) ReadField2(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(ctx); err != nil {
+		return thrift.PrependError("error reading field 2: ", err)
+	} else {
+		p.MV = v
+	}
+	return nil
+}
+
+func (p *GetMVSizeRequest) ReadField3(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(ctx); err != nil {
+		return thrift.PrependError("error reading field 3: ", err)
+	} else {
+		p.RVName = v
+	}
+	return nil
+}
+
+func (p *GetMVSizeRequest) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "GetMVSizeRequest"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField2(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField3(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *GetMVSizeRequest) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "senderNodeID", thrift.STRING, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:senderNodeID: ", p), err)
+	}
+	if err := oprot.WriteString(ctx, string(p.SenderNodeID)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.senderNodeID (1) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:senderNodeID: ", p), err)
+	}
+	return err
+}
+
+func (p *GetMVSizeRequest) writeField2(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "MV", thrift.STRING, 2); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:MV: ", p), err)
+	}
+	if err := oprot.WriteString(ctx, string(p.MV)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.MV (2) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:MV: ", p), err)
+	}
+	return err
+}
+
+func (p *GetMVSizeRequest) writeField3(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "RVName", thrift.STRING, 3); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:RVName: ", p), err)
+	}
+	if err := oprot.WriteString(ctx, string(p.RVName)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.RVName (3) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:RVName: ", p), err)
+	}
+	return err
+}
+
+func (p *GetMVSizeRequest) Equals(other *GetMVSizeRequest) bool {
+	if p == other {
+		return true
+	} else if p == nil || other == nil {
+		return false
+	}
+	if p.SenderNodeID != other.SenderNodeID {
+		return false
+	}
+	if p.MV != other.MV {
+		return false
+	}
+	if p.RVName != other.RVName {
+		return false
+	}
+	return true
+}
+
+func (p *GetMVSizeRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("GetMVSizeRequest(%+v)", *p)
+}
+
+// Attributes:
+//   - MvSize
+type GetMVSizeResponse struct {
+	MvSize int64 `thrift:"mvSize,1" db:"mvSize" json:"mvSize"`
+}
+
+func NewGetMVSizeResponse() *GetMVSizeResponse {
+	return &GetMVSizeResponse{}
+}
+
+func (p *GetMVSizeResponse) GetMvSize() int64 {
+	return p.MvSize
+}
+func (p *GetMVSizeResponse) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.I64 {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *GetMVSizeResponse) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI64(ctx); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		p.MvSize = v
+	}
+	return nil
+}
+
+func (p *GetMVSizeResponse) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "GetMVSizeResponse"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *GetMVSizeResponse) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "mvSize", thrift.I64, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:mvSize: ", p), err)
+	}
+	if err := oprot.WriteI64(ctx, int64(p.MvSize)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.mvSize (1) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:mvSize: ", p), err)
+	}
+	return err
+}
+
+func (p *GetMVSizeResponse) Equals(other *GetMVSizeResponse) bool {
+	if p == other {
+		return true
+	} else if p == nil || other == nil {
+		return false
+	}
+	if p.MvSize != other.MvSize {
+		return false
+	}
+	return true
+}
+
+func (p *GetMVSizeResponse) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("GetMVSizeResponse(%+v)", *p)
+}
+
+// Attributes:
 //   - Code
 //   - Message
 type ResponseError struct {

--- a/internal/dcache/rpc/gen-go/dcache/service/chunk_service-remote/chunk_service-remote.go
+++ b/internal/dcache/rpc/gen-go/dcache/service/chunk_service-remote/chunk_service-remote.go
@@ -66,6 +66,7 @@ func Usage() {
 	fmt.Fprintln(os.Stderr, "  LeaveMVResponse LeaveMV(LeaveMVRequest request)")
 	fmt.Fprintln(os.Stderr, "  StartSyncResponse StartSync(StartSyncRequest request)")
 	fmt.Fprintln(os.Stderr, "  EndSyncResponse EndSync(EndSyncRequest request)")
+	fmt.Fprintln(os.Stderr, "  GetMVSizeResponse GetMVSize(GetMVSizeRequest request)")
 	fmt.Fprintln(os.Stderr)
 	os.Exit(0)
 }
@@ -193,19 +194,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "Hello requires 1 args")
 			flag.Usage()
 		}
-		arg38 := flag.Arg(1)
-		mbTrans39 := thrift.NewTMemoryBufferLen(len(arg38))
-		defer mbTrans39.Close()
-		_, err40 := mbTrans39.WriteString(arg38)
-		if err40 != nil {
+		arg42 := flag.Arg(1)
+		mbTrans43 := thrift.NewTMemoryBufferLen(len(arg42))
+		defer mbTrans43.Close()
+		_, err44 := mbTrans43.WriteString(arg42)
+		if err44 != nil {
 			Usage()
 			return
 		}
-		factory41 := thrift.NewTJSONProtocolFactory()
-		jsProt42 := factory41.GetProtocol(mbTrans39)
+		factory45 := thrift.NewTJSONProtocolFactory()
+		jsProt46 := factory45.GetProtocol(mbTrans43)
 		argvalue0 := models.NewHelloRequest()
-		err43 := argvalue0.Read(context.Background(), jsProt42)
-		if err43 != nil {
+		err47 := argvalue0.Read(context.Background(), jsProt46)
+		if err47 != nil {
 			Usage()
 			return
 		}
@@ -218,19 +219,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetChunk requires 1 args")
 			flag.Usage()
 		}
-		arg44 := flag.Arg(1)
-		mbTrans45 := thrift.NewTMemoryBufferLen(len(arg44))
-		defer mbTrans45.Close()
-		_, err46 := mbTrans45.WriteString(arg44)
-		if err46 != nil {
+		arg48 := flag.Arg(1)
+		mbTrans49 := thrift.NewTMemoryBufferLen(len(arg48))
+		defer mbTrans49.Close()
+		_, err50 := mbTrans49.WriteString(arg48)
+		if err50 != nil {
 			Usage()
 			return
 		}
-		factory47 := thrift.NewTJSONProtocolFactory()
-		jsProt48 := factory47.GetProtocol(mbTrans45)
+		factory51 := thrift.NewTJSONProtocolFactory()
+		jsProt52 := factory51.GetProtocol(mbTrans49)
 		argvalue0 := models.NewGetChunkRequest()
-		err49 := argvalue0.Read(context.Background(), jsProt48)
-		if err49 != nil {
+		err53 := argvalue0.Read(context.Background(), jsProt52)
+		if err53 != nil {
 			Usage()
 			return
 		}
@@ -243,19 +244,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PutChunk requires 1 args")
 			flag.Usage()
 		}
-		arg50 := flag.Arg(1)
-		mbTrans51 := thrift.NewTMemoryBufferLen(len(arg50))
-		defer mbTrans51.Close()
-		_, err52 := mbTrans51.WriteString(arg50)
-		if err52 != nil {
+		arg54 := flag.Arg(1)
+		mbTrans55 := thrift.NewTMemoryBufferLen(len(arg54))
+		defer mbTrans55.Close()
+		_, err56 := mbTrans55.WriteString(arg54)
+		if err56 != nil {
 			Usage()
 			return
 		}
-		factory53 := thrift.NewTJSONProtocolFactory()
-		jsProt54 := factory53.GetProtocol(mbTrans51)
+		factory57 := thrift.NewTJSONProtocolFactory()
+		jsProt58 := factory57.GetProtocol(mbTrans55)
 		argvalue0 := models.NewPutChunkRequest()
-		err55 := argvalue0.Read(context.Background(), jsProt54)
-		if err55 != nil {
+		err59 := argvalue0.Read(context.Background(), jsProt58)
+		if err59 != nil {
 			Usage()
 			return
 		}
@@ -268,19 +269,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "RemoveChunk requires 1 args")
 			flag.Usage()
 		}
-		arg56 := flag.Arg(1)
-		mbTrans57 := thrift.NewTMemoryBufferLen(len(arg56))
-		defer mbTrans57.Close()
-		_, err58 := mbTrans57.WriteString(arg56)
-		if err58 != nil {
+		arg60 := flag.Arg(1)
+		mbTrans61 := thrift.NewTMemoryBufferLen(len(arg60))
+		defer mbTrans61.Close()
+		_, err62 := mbTrans61.WriteString(arg60)
+		if err62 != nil {
 			Usage()
 			return
 		}
-		factory59 := thrift.NewTJSONProtocolFactory()
-		jsProt60 := factory59.GetProtocol(mbTrans57)
+		factory63 := thrift.NewTJSONProtocolFactory()
+		jsProt64 := factory63.GetProtocol(mbTrans61)
 		argvalue0 := models.NewRemoveChunkRequest()
-		err61 := argvalue0.Read(context.Background(), jsProt60)
-		if err61 != nil {
+		err65 := argvalue0.Read(context.Background(), jsProt64)
+		if err65 != nil {
 			Usage()
 			return
 		}
@@ -293,19 +294,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "JoinMV requires 1 args")
 			flag.Usage()
 		}
-		arg62 := flag.Arg(1)
-		mbTrans63 := thrift.NewTMemoryBufferLen(len(arg62))
-		defer mbTrans63.Close()
-		_, err64 := mbTrans63.WriteString(arg62)
-		if err64 != nil {
+		arg66 := flag.Arg(1)
+		mbTrans67 := thrift.NewTMemoryBufferLen(len(arg66))
+		defer mbTrans67.Close()
+		_, err68 := mbTrans67.WriteString(arg66)
+		if err68 != nil {
 			Usage()
 			return
 		}
-		factory65 := thrift.NewTJSONProtocolFactory()
-		jsProt66 := factory65.GetProtocol(mbTrans63)
+		factory69 := thrift.NewTJSONProtocolFactory()
+		jsProt70 := factory69.GetProtocol(mbTrans67)
 		argvalue0 := models.NewJoinMVRequest()
-		err67 := argvalue0.Read(context.Background(), jsProt66)
-		if err67 != nil {
+		err71 := argvalue0.Read(context.Background(), jsProt70)
+		if err71 != nil {
 			Usage()
 			return
 		}
@@ -318,19 +319,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "UpdateMV requires 1 args")
 			flag.Usage()
 		}
-		arg68 := flag.Arg(1)
-		mbTrans69 := thrift.NewTMemoryBufferLen(len(arg68))
-		defer mbTrans69.Close()
-		_, err70 := mbTrans69.WriteString(arg68)
-		if err70 != nil {
+		arg72 := flag.Arg(1)
+		mbTrans73 := thrift.NewTMemoryBufferLen(len(arg72))
+		defer mbTrans73.Close()
+		_, err74 := mbTrans73.WriteString(arg72)
+		if err74 != nil {
 			Usage()
 			return
 		}
-		factory71 := thrift.NewTJSONProtocolFactory()
-		jsProt72 := factory71.GetProtocol(mbTrans69)
+		factory75 := thrift.NewTJSONProtocolFactory()
+		jsProt76 := factory75.GetProtocol(mbTrans73)
 		argvalue0 := models.NewUpdateMVRequest()
-		err73 := argvalue0.Read(context.Background(), jsProt72)
-		if err73 != nil {
+		err77 := argvalue0.Read(context.Background(), jsProt76)
+		if err77 != nil {
 			Usage()
 			return
 		}
@@ -343,19 +344,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "LeaveMV requires 1 args")
 			flag.Usage()
 		}
-		arg74 := flag.Arg(1)
-		mbTrans75 := thrift.NewTMemoryBufferLen(len(arg74))
-		defer mbTrans75.Close()
-		_, err76 := mbTrans75.WriteString(arg74)
-		if err76 != nil {
+		arg78 := flag.Arg(1)
+		mbTrans79 := thrift.NewTMemoryBufferLen(len(arg78))
+		defer mbTrans79.Close()
+		_, err80 := mbTrans79.WriteString(arg78)
+		if err80 != nil {
 			Usage()
 			return
 		}
-		factory77 := thrift.NewTJSONProtocolFactory()
-		jsProt78 := factory77.GetProtocol(mbTrans75)
+		factory81 := thrift.NewTJSONProtocolFactory()
+		jsProt82 := factory81.GetProtocol(mbTrans79)
 		argvalue0 := models.NewLeaveMVRequest()
-		err79 := argvalue0.Read(context.Background(), jsProt78)
-		if err79 != nil {
+		err83 := argvalue0.Read(context.Background(), jsProt82)
+		if err83 != nil {
 			Usage()
 			return
 		}
@@ -368,19 +369,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "StartSync requires 1 args")
 			flag.Usage()
 		}
-		arg80 := flag.Arg(1)
-		mbTrans81 := thrift.NewTMemoryBufferLen(len(arg80))
-		defer mbTrans81.Close()
-		_, err82 := mbTrans81.WriteString(arg80)
-		if err82 != nil {
+		arg84 := flag.Arg(1)
+		mbTrans85 := thrift.NewTMemoryBufferLen(len(arg84))
+		defer mbTrans85.Close()
+		_, err86 := mbTrans85.WriteString(arg84)
+		if err86 != nil {
 			Usage()
 			return
 		}
-		factory83 := thrift.NewTJSONProtocolFactory()
-		jsProt84 := factory83.GetProtocol(mbTrans81)
+		factory87 := thrift.NewTJSONProtocolFactory()
+		jsProt88 := factory87.GetProtocol(mbTrans85)
 		argvalue0 := models.NewStartSyncRequest()
-		err85 := argvalue0.Read(context.Background(), jsProt84)
-		if err85 != nil {
+		err89 := argvalue0.Read(context.Background(), jsProt88)
+		if err89 != nil {
 			Usage()
 			return
 		}
@@ -393,24 +394,49 @@ func main() {
 			fmt.Fprintln(os.Stderr, "EndSync requires 1 args")
 			flag.Usage()
 		}
-		arg86 := flag.Arg(1)
-		mbTrans87 := thrift.NewTMemoryBufferLen(len(arg86))
-		defer mbTrans87.Close()
-		_, err88 := mbTrans87.WriteString(arg86)
-		if err88 != nil {
+		arg90 := flag.Arg(1)
+		mbTrans91 := thrift.NewTMemoryBufferLen(len(arg90))
+		defer mbTrans91.Close()
+		_, err92 := mbTrans91.WriteString(arg90)
+		if err92 != nil {
 			Usage()
 			return
 		}
-		factory89 := thrift.NewTJSONProtocolFactory()
-		jsProt90 := factory89.GetProtocol(mbTrans87)
+		factory93 := thrift.NewTJSONProtocolFactory()
+		jsProt94 := factory93.GetProtocol(mbTrans91)
 		argvalue0 := models.NewEndSyncRequest()
-		err91 := argvalue0.Read(context.Background(), jsProt90)
-		if err91 != nil {
+		err95 := argvalue0.Read(context.Background(), jsProt94)
+		if err95 != nil {
 			Usage()
 			return
 		}
 		value0 := argvalue0
 		fmt.Print(client.EndSync(context.Background(), value0))
+		fmt.Print("\n")
+		break
+	case "GetMVSize":
+		if flag.NArg()-1 != 1 {
+			fmt.Fprintln(os.Stderr, "GetMVSize requires 1 args")
+			flag.Usage()
+		}
+		arg96 := flag.Arg(1)
+		mbTrans97 := thrift.NewTMemoryBufferLen(len(arg96))
+		defer mbTrans97.Close()
+		_, err98 := mbTrans97.WriteString(arg96)
+		if err98 != nil {
+			Usage()
+			return
+		}
+		factory99 := thrift.NewTJSONProtocolFactory()
+		jsProt100 := factory99.GetProtocol(mbTrans97)
+		argvalue0 := models.NewGetMVSizeRequest()
+		err101 := argvalue0.Read(context.Background(), jsProt100)
+		if err101 != nil {
+			Usage()
+			return
+		}
+		value0 := argvalue0
+		fmt.Print(client.GetMVSize(context.Background(), value0))
 		fmt.Print("\n")
 		break
 	case "":

--- a/internal/dcache/rpc/gen-go/dcache/service/service.go
+++ b/internal/dcache/rpc/gen-go/dcache/service/service.go
@@ -81,6 +81,9 @@ type ChunkService interface {
 	// Parameters:
 	//  - Request
 	EndSync(ctx context.Context, request *models.EndSyncRequest) (_r *models.EndSyncResponse, _err error)
+	// Parameters:
+	//  - Request
+	GetMVSize(ctx context.Context, request *models.GetMVSizeRequest) (_r *models.GetMVSizeResponse, _err error)
 }
 
 type ChunkServiceClient struct {
@@ -325,6 +328,29 @@ func (p *ChunkServiceClient) EndSync(ctx context.Context, request *models.EndSyn
 	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "EndSync failed: unknown result")
 }
 
+// Parameters:
+//   - Request
+func (p *ChunkServiceClient) GetMVSize(ctx context.Context, request *models.GetMVSizeRequest) (_r *models.GetMVSizeResponse, _err error) {
+	var _args36 ChunkServiceGetMVSizeArgs
+	_args36.Request = request
+	var _result38 ChunkServiceGetMVSizeResult
+	var _meta37 thrift.ResponseMeta
+	_meta37, _err = p.Client_().Call(ctx, "GetMVSize", &_args36, &_result38)
+	p.SetLastResponseMeta_(_meta37)
+	if _err != nil {
+		return
+	}
+	switch {
+	case _result38.Err != nil:
+		return _r, _result38.Err
+	}
+
+	if _ret39 := _result38.GetSuccess(); _ret39 != nil {
+		return _ret39, nil
+	}
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "GetMVSize failed: unknown result")
+}
+
 type ChunkServiceProcessor struct {
 	processorMap map[string]thrift.TProcessorFunction
 	handler      ChunkService
@@ -345,17 +371,18 @@ func (p *ChunkServiceProcessor) ProcessorMap() map[string]thrift.TProcessorFunct
 
 func NewChunkServiceProcessor(handler ChunkService) *ChunkServiceProcessor {
 
-	self36 := &ChunkServiceProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self36.processorMap["Hello"] = &chunkServiceProcessorHello{handler: handler}
-	self36.processorMap["GetChunk"] = &chunkServiceProcessorGetChunk{handler: handler}
-	self36.processorMap["PutChunk"] = &chunkServiceProcessorPutChunk{handler: handler}
-	self36.processorMap["RemoveChunk"] = &chunkServiceProcessorRemoveChunk{handler: handler}
-	self36.processorMap["JoinMV"] = &chunkServiceProcessorJoinMV{handler: handler}
-	self36.processorMap["UpdateMV"] = &chunkServiceProcessorUpdateMV{handler: handler}
-	self36.processorMap["LeaveMV"] = &chunkServiceProcessorLeaveMV{handler: handler}
-	self36.processorMap["StartSync"] = &chunkServiceProcessorStartSync{handler: handler}
-	self36.processorMap["EndSync"] = &chunkServiceProcessorEndSync{handler: handler}
-	return self36
+	self40 := &ChunkServiceProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
+	self40.processorMap["Hello"] = &chunkServiceProcessorHello{handler: handler}
+	self40.processorMap["GetChunk"] = &chunkServiceProcessorGetChunk{handler: handler}
+	self40.processorMap["PutChunk"] = &chunkServiceProcessorPutChunk{handler: handler}
+	self40.processorMap["RemoveChunk"] = &chunkServiceProcessorRemoveChunk{handler: handler}
+	self40.processorMap["JoinMV"] = &chunkServiceProcessorJoinMV{handler: handler}
+	self40.processorMap["UpdateMV"] = &chunkServiceProcessorUpdateMV{handler: handler}
+	self40.processorMap["LeaveMV"] = &chunkServiceProcessorLeaveMV{handler: handler}
+	self40.processorMap["StartSync"] = &chunkServiceProcessorStartSync{handler: handler}
+	self40.processorMap["EndSync"] = &chunkServiceProcessorEndSync{handler: handler}
+	self40.processorMap["GetMVSize"] = &chunkServiceProcessorGetMVSize{handler: handler}
+	return self40
 }
 
 func (p *ChunkServiceProcessor) Process(ctx context.Context, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
@@ -368,12 +395,12 @@ func (p *ChunkServiceProcessor) Process(ctx context.Context, iprot, oprot thrift
 	}
 	iprot.Skip(ctx, thrift.STRUCT)
 	iprot.ReadMessageEnd(ctx)
-	x37 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
+	x41 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
 	oprot.WriteMessageBegin(ctx, name, thrift.EXCEPTION, seqId)
-	x37.Write(ctx, oprot)
+	x41.Write(ctx, oprot)
 	oprot.WriteMessageEnd(ctx)
 	oprot.Flush(ctx)
-	return false, x37
+	return false, x41
 
 }
 
@@ -1116,6 +1143,90 @@ func (p *chunkServiceProcessorEndSync) Process(ctx context.Context, seqId int32,
 	}
 	tickerCancel()
 	if err2 = oprot.WriteMessageBegin(ctx, "EndSync", thrift.REPLY, seqId); err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err2 = result.Write(ctx, oprot); err == nil && err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err2 = oprot.WriteMessageEnd(ctx); err == nil && err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err2 = oprot.Flush(ctx); err == nil && err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err != nil {
+		return
+	}
+	return true, err
+}
+
+type chunkServiceProcessorGetMVSize struct {
+	handler ChunkService
+}
+
+func (p *chunkServiceProcessorGetMVSize) Process(ctx context.Context, seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+	args := ChunkServiceGetMVSizeArgs{}
+	var err2 error
+	if err2 = args.Read(ctx, iprot); err2 != nil {
+		iprot.ReadMessageEnd(ctx)
+		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err2.Error())
+		oprot.WriteMessageBegin(ctx, "GetMVSize", thrift.EXCEPTION, seqId)
+		x.Write(ctx, oprot)
+		oprot.WriteMessageEnd(ctx)
+		oprot.Flush(ctx)
+		return false, thrift.WrapTException(err2)
+	}
+	iprot.ReadMessageEnd(ctx)
+
+	tickerCancel := func() {}
+	// Start a goroutine to do server side connectivity check.
+	if thrift.ServerConnectivityCheckInterval > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
+		var tickerCtx context.Context
+		tickerCtx, tickerCancel = context.WithCancel(context.Background())
+		defer tickerCancel()
+		go func(ctx context.Context, cancel context.CancelFunc) {
+			ticker := time.NewTicker(thrift.ServerConnectivityCheckInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if !iprot.Transport().IsOpen() {
+						cancel()
+						return
+					}
+				}
+			}
+		}(tickerCtx, cancel)
+	}
+
+	result := ChunkServiceGetMVSizeResult{}
+	var retval *models.GetMVSizeResponse
+	if retval, err2 = p.handler.GetMVSize(ctx, args.Request); err2 != nil {
+		tickerCancel()
+		switch v := err2.(type) {
+		case *models.ResponseError:
+			result.Err = v
+		default:
+			if err2 == thrift.ErrAbandonRequest {
+				return false, thrift.WrapTException(err2)
+			}
+			x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing GetMVSize: "+err2.Error())
+			oprot.WriteMessageBegin(ctx, "GetMVSize", thrift.EXCEPTION, seqId)
+			x.Write(ctx, oprot)
+			oprot.WriteMessageEnd(ctx)
+			oprot.Flush(ctx)
+			return true, thrift.WrapTException(err2)
+		}
+	} else {
+		result.Success = retval
+	}
+	tickerCancel()
+	if err2 = oprot.WriteMessageBegin(ctx, "GetMVSize", thrift.REPLY, seqId); err2 != nil {
 		err = thrift.WrapTException(err2)
 	}
 	if err2 = result.Write(ctx, oprot); err == nil && err2 != nil {
@@ -3536,4 +3647,271 @@ func (p *ChunkServiceEndSyncResult) String() string {
 		return "<nil>"
 	}
 	return fmt.Sprintf("ChunkServiceEndSyncResult(%+v)", *p)
+}
+
+// Attributes:
+//   - Request
+type ChunkServiceGetMVSizeArgs struct {
+	Request *models.GetMVSizeRequest `thrift:"request,1" db:"request" json:"request"`
+}
+
+func NewChunkServiceGetMVSizeArgs() *ChunkServiceGetMVSizeArgs {
+	return &ChunkServiceGetMVSizeArgs{}
+}
+
+var ChunkServiceGetMVSizeArgs_Request_DEFAULT *models.GetMVSizeRequest
+
+func (p *ChunkServiceGetMVSizeArgs) GetRequest() *models.GetMVSizeRequest {
+	if !p.IsSetRequest() {
+		return ChunkServiceGetMVSizeArgs_Request_DEFAULT
+	}
+	return p.Request
+}
+func (p *ChunkServiceGetMVSizeArgs) IsSetRequest() bool {
+	return p.Request != nil
+}
+
+func (p *ChunkServiceGetMVSizeArgs) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *ChunkServiceGetMVSizeArgs) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Request = &models.GetMVSizeRequest{}
+	if err := p.Request.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Request), err)
+	}
+	return nil
+}
+
+func (p *ChunkServiceGetMVSizeArgs) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "GetMVSize_args"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *ChunkServiceGetMVSizeArgs) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "request", thrift.STRUCT, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:request: ", p), err)
+	}
+	if err := p.Request.Write(ctx, oprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Request), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:request: ", p), err)
+	}
+	return err
+}
+
+func (p *ChunkServiceGetMVSizeArgs) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("ChunkServiceGetMVSizeArgs(%+v)", *p)
+}
+
+// Attributes:
+//   - Success
+//   - Err
+type ChunkServiceGetMVSizeResult struct {
+	Success *models.GetMVSizeResponse `thrift:"success,0" db:"success" json:"success,omitempty"`
+	Err     *models.ResponseError     `thrift:"err,1" db:"err" json:"err,omitempty"`
+}
+
+func NewChunkServiceGetMVSizeResult() *ChunkServiceGetMVSizeResult {
+	return &ChunkServiceGetMVSizeResult{}
+}
+
+var ChunkServiceGetMVSizeResult_Success_DEFAULT *models.GetMVSizeResponse
+
+func (p *ChunkServiceGetMVSizeResult) GetSuccess() *models.GetMVSizeResponse {
+	if !p.IsSetSuccess() {
+		return ChunkServiceGetMVSizeResult_Success_DEFAULT
+	}
+	return p.Success
+}
+
+var ChunkServiceGetMVSizeResult_Err_DEFAULT *models.ResponseError
+
+func (p *ChunkServiceGetMVSizeResult) GetErr() *models.ResponseError {
+	if !p.IsSetErr() {
+		return ChunkServiceGetMVSizeResult_Err_DEFAULT
+	}
+	return p.Err
+}
+func (p *ChunkServiceGetMVSizeResult) IsSetSuccess() bool {
+	return p.Success != nil
+}
+
+func (p *ChunkServiceGetMVSizeResult) IsSetErr() bool {
+	return p.Err != nil
+}
+
+func (p *ChunkServiceGetMVSizeResult) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField0(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *ChunkServiceGetMVSizeResult) ReadField0(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Success = &models.GetMVSizeResponse{}
+	if err := p.Success.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Success), err)
+	}
+	return nil
+}
+
+func (p *ChunkServiceGetMVSizeResult) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Err = &models.ResponseError{}
+	if err := p.Err.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Err), err)
+	}
+	return nil
+}
+
+func (p *ChunkServiceGetMVSizeResult) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "GetMVSize_result"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField0(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *ChunkServiceGetMVSizeResult) writeField0(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if p.IsSetSuccess() {
+		if err := oprot.WriteFieldBegin(ctx, "success", thrift.STRUCT, 0); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 0:success: ", p), err)
+		}
+		if err := p.Success.Write(ctx, oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Success), err)
+		}
+		if err := oprot.WriteFieldEnd(ctx); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 0:success: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *ChunkServiceGetMVSizeResult) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if p.IsSetErr() {
+		if err := oprot.WriteFieldBegin(ctx, "err", thrift.STRUCT, 1); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:err: ", p), err)
+		}
+		if err := p.Err.Write(ctx, oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Err), err)
+		}
+		if err := oprot.WriteFieldEnd(ctx); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:err: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *ChunkServiceGetMVSizeResult) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("ChunkServiceGetMVSizeResult(%+v)", *p)
 }

--- a/internal/dcache/rpc/models.thrift
+++ b/internal/dcache/rpc/models.thrift
@@ -130,6 +130,16 @@ struct EndSyncResponse {
     // status will be returned in the error
 }
 
+struct GetMVSizeRequest {
+    1: string senderNodeID,
+    2: string MV,
+    3: string RVName
+}
+
+struct GetMVSizeResponse {
+    1: i64 mvSize
+}
+
 // Custom error codes returned by the ChunkServiceHandler
 enum ErrorCode {
     InvalidRequest = 1,

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1315,7 +1315,7 @@ func (h *ChunkServiceHandler) UpdateMV(ctx context.Context, req *models.UpdateMV
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
 		errStr := fmt.Sprintf("%s/%s not hosted by this node", req.RVName, req.MV)
-		log.Err("ChunkServiceHandler::LeaveMV: %s", errStr)
+		log.Err("ChunkServiceHandler::UpdateMV: %s", errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
 	}
 

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1697,7 +1697,7 @@ func (h *ChunkServiceHandler) UpdateMV(ctx context.Context, req *models.UpdateMV
 		//
 		mvInfo := rvInfo.getMVInfo(req.MV)
 		if mvInfo == nil {
-			errStr := fmt.Sprintf("%s is not part of %s", req.RVName, req.MV)
+			errStr := fmt.Sprintf("%s/%s not hosted by this node", req.RVName, req.MV)
 			log.Err("ChunkServiceHandler::UpdateMV: %s", errStr)
 			common.Assert(false, errStr)
 			return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -1768,7 +1768,7 @@ func (h *ChunkServiceHandler) LeaveMV(ctx context.Context, req *models.LeaveMVRe
 	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s is not part of %s", req.RVName, req.MV)
+		errStr := fmt.Sprintf("%s/%s not hosted by this node", req.RVName, req.MV)
 		log.Err("ChunkServiceHandler::LeaveMV: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -1812,8 +1812,7 @@ func (h *ChunkServiceHandler) StartSync(ctx context.Context, req *models.StartSy
 		!cm.IsValidRVName(req.TargetRVName) ||
 		req.SourceRVName == req.TargetRVName ||
 		len(req.ComponentRV) == 0 {
-		errStr := fmt.Sprintf("SenderNodeID (%s), MV (%s), SourceRV (%s), TargetRV (%s) or ComponentRVs (%d) invalid",
-			req.SenderNodeID, req.MV, req.SourceRVName, req.TargetRVName, len(req.ComponentRV))
+		errStr := fmt.Sprintf("Invalid StartSync request: %s", rpc.StartSyncRequestToString(req))
 		log.Err("ChunkServiceHandler::StartSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -1854,7 +1853,7 @@ func (h *ChunkServiceHandler) StartSync(ctx context.Context, req *models.StartSy
 	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s is not part of %s", rvInfo.rvName, req.MV)
+		errStr := fmt.Sprintf("%s/%s not hosted by this node", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::StartSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
@@ -1931,8 +1930,7 @@ func (h *ChunkServiceHandler) EndSync(ctx context.Context, req *models.EndSyncRe
 		!cm.IsValidRVName(req.TargetRVName) ||
 		req.SourceRVName == req.TargetRVName ||
 		len(req.ComponentRV) == 0 {
-		errStr := fmt.Sprintf("SenderNodeID (%s), SyncID (%s) MV (%s), SourceRV (%s), TargetRV (%s) or ComponentRVs (%d) invalid",
-			req.SenderNodeID, req.SyncID, req.MV, req.SourceRVName, req.TargetRVName, len(req.ComponentRV))
+		errStr := fmt.Sprintf("Invalid EndSync request: %s", rpc.EndSyncRequestToString(req))
 		log.Err("ChunkServiceHandler::EndSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -1972,7 +1970,7 @@ func (h *ChunkServiceHandler) EndSync(ctx context.Context, req *models.EndSyncRe
 	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s is not part of %s", rvInfo.rvName, req.MV)
+		errStr := fmt.Sprintf("%s/%s not hosted by this node", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::EndSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
@@ -2062,7 +2060,7 @@ func (h *ChunkServiceHandler) GetMVSize(ctx context.Context, req *models.GetMVSi
 	log.Debug("ChunkServiceHandler::GetMVSize: Received GetMVSize request: %v", rpc.GetMVSizeRequestToString(req))
 
 	if !common.IsValidUUID(req.SenderNodeID) || !cm.IsValidMVName(req.MV) || !cm.IsValidRVName(req.RVName) {
-		errStr := fmt.Sprintf("Invalid SenderNodeID, MV or RV: %v", rpc.GetMVSizeRequestToString(req))
+		errStr := fmt.Sprintf("Invalid GetMVSize request: %v", rpc.GetMVSizeRequestToString(req))
 		log.Err("ChunkServiceHandler::GetMVSize: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -2084,7 +2082,7 @@ func (h *ChunkServiceHandler) GetMVSize(ctx context.Context, req *models.GetMVSi
 	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s is not part of %s", rvInfo.rvName, req.MV)
+		errStr := fmt.Sprintf("%s/%s not hosted by this node", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::GetMVSize: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1034,6 +1034,10 @@ func (h *ChunkServiceHandler) Hello(ctx context.Context, req *models.HelloReques
 
 	log.Debug("ChunkServiceHandler::Hello: Received Hello request: %v", req.String())
 
+	// Sender and receiver node IDs must be valid.
+	common.Assert(common.IsValidUUID(req.SenderNodeID), req.SenderNodeID)
+	common.Assert(common.IsValidUUID(req.ReceiverNodeID), req.ReceiverNodeID)
+
 	// TODO: send more information in response on Hello RPC
 
 	myNodeID := rpc.GetMyNodeUUID()
@@ -1065,6 +1069,9 @@ func (h *ChunkServiceHandler) GetChunk(ctx context.Context, req *models.GetChunk
 	startTime := time.Now()
 
 	log.Debug("ChunkServiceHandler::GetChunk: Received GetChunk request: %v", rpc.GetChunkRequestToString(req))
+
+	// Sender node id must be valid.
+	common.Assert(common.IsValidUUID(req.SenderNodeID), req.SenderNodeID)
 
 	//
 	// Check if the chunk address is valid. We basically check for the following:
@@ -1209,6 +1216,9 @@ func (h *ChunkServiceHandler) PutChunk(ctx context.Context, req *models.PutChunk
 	startTime := time.Now()
 
 	log.Debug("ChunkServiceHandler::PutChunk: Received PutChunk request: %v", rpc.PutChunkRequestToString(req))
+
+	// Sender node id must be valid.
+	common.Assert(common.IsValidUUID(req.SenderNodeID), req.SenderNodeID)
 
 	// Check if the chunk address is valid.
 	err := h.checkValidChunkAddress(req.Chunk.Address)
@@ -1459,6 +1469,9 @@ func (h *ChunkServiceHandler) RemoveChunk(ctx context.Context, req *models.Remov
 
 	log.Debug("ChunkServiceHandler::RemoveChunk: Received RemoveChunk request %v", rpc.RemoveChunkRequestToString(req))
 
+	// Sender node id must be valid.
+	common.Assert(common.IsValidUUID(req.SenderNodeID), req.SenderNodeID)
+
 	// check if the chunk address is valid
 	err := h.checkValidChunkAddress(req.Address)
 	if err != nil {
@@ -1546,8 +1559,11 @@ func (h *ChunkServiceHandler) JoinMV(ctx context.Context, req *models.JoinMVRequ
 	// requires to call componentRVsToString method as it is of type []*models.RVNameAndState
 	log.Debug("ChunkServiceHandler::JoinMV: Received JoinMV request: %v", rpc.JoinMVRequestToString(req))
 
-	if !cm.IsValidMVName(req.MV) || !cm.IsValidRVName(req.RVName) || len(req.ComponentRV) == 0 {
-		errStr := fmt.Sprintf("Invalid MV, RV or ComponentRV: %v", rpc.JoinMVRequestToString(req))
+	if !common.IsValidUUID(req.SenderNodeID) ||
+		!cm.IsValidMVName(req.MV) ||
+		!cm.IsValidRVName(req.RVName) ||
+		len(req.ComponentRV) == 0 {
+		errStr := fmt.Sprintf("Invalid SenderNodeID, MV, RV or ComponentRV: %v", rpc.JoinMVRequestToString(req))
 		log.Err("ChunkServiceHandler::JoinMV: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -1653,8 +1669,11 @@ func (h *ChunkServiceHandler) UpdateMV(ctx context.Context, req *models.UpdateMV
 
 	log.Debug("ChunkServiceHandler::UpdateMV: Received UpdateMV request: %v", rpc.UpdateMVRequestToString(req))
 
-	if !cm.IsValidMVName(req.MV) || !cm.IsValidRVName(req.RVName) || len(req.ComponentRV) == 0 {
-		errStr := fmt.Sprintf("Invalid MV, RV or ComponentRV: %v", rpc.UpdateMVRequestToString(req))
+	if !common.IsValidUUID(req.SenderNodeID) ||
+		!cm.IsValidMVName(req.MV) ||
+		!cm.IsValidRVName(req.RVName) ||
+		len(req.ComponentRV) == 0 {
+		errStr := fmt.Sprintf("Invalid SenderNodeID, MV, RV or ComponentRV: %v", rpc.UpdateMVRequestToString(req))
 		log.Err("ChunkServiceHandler::UpdateMV: %s", errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
 	}
@@ -1723,9 +1742,13 @@ func (h *ChunkServiceHandler) LeaveMV(ctx context.Context, req *models.LeaveMVRe
 
 	log.Debug("ChunkServiceHandler::LeaveMV: Received LeaveMV request: %v", rpc.LeaveMVRequestToString(req))
 
-	if !cm.IsValidMVName(req.MV) || !cm.IsValidRVName(req.RVName) || len(req.ComponentRV) == 0 {
-		log.Err("ChunkServiceHandler::LeaveMV: MV, RV or ComponentRV is empty")
-		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, "MV, RV or ComponentRV is empty")
+	if !common.IsValidUUID(req.SenderNodeID) ||
+		!cm.IsValidMVName(req.MV) ||
+		!cm.IsValidRVName(req.RVName) ||
+		len(req.ComponentRV) == 0 {
+		errStr := fmt.Sprintf("Invalid SenderNodeID, MV, RV or ComponentRV: %v", rpc.LeaveMVRequestToString(req))
+		log.Err("ChunkServiceHandler::LeaveMV: %s", errStr)
+		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
 	}
 
 	rvInfo := h.getRVInfoFromRVName(req.RVName)
@@ -1736,12 +1759,19 @@ func (h *ChunkServiceHandler) LeaveMV(ctx context.Context, req *models.LeaveMVRe
 
 	cacheDir := rvInfo.cacheDir
 
-	// check if RV is part of the given MV
+	//
+	// LeaveMV() RPC is only sent to RVs which are already members of the MV, and it is sent
+	// when the membership changes (due to rebalancing workflow).
+	// Since the sender is referring to the global clustermap and this RV is part of the given MV as
+	// per the global clustermap, since an RV is added to an MV only after a successful JoinMV response
+	// from all component RVs, we *must* have the MV replica in our rvInfo.
+	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s/%s not hosted by this node", req.RVName, req.MV)
+		errStr := fmt.Sprintf("%s is not part of %s", req.RVName, req.MV)
 		log.Err("ChunkServiceHandler::LeaveMV: %s", errStr)
-		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
+		common.Assert(false, errStr)
+		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
 	}
 
 	// validate the component RVs list
@@ -1776,13 +1806,14 @@ func (h *ChunkServiceHandler) StartSync(ctx context.Context, req *models.StartSy
 	log.Debug("ChunkServiceHandler::StartSync: Received StartSync request: %s",
 		rpc.StartSyncRequestToString(req))
 
-	if !cm.IsValidMVName(req.MV) ||
+	if !common.IsValidUUID(req.SenderNodeID) ||
+		!cm.IsValidMVName(req.MV) ||
 		!cm.IsValidRVName(req.SourceRVName) ||
 		!cm.IsValidRVName(req.TargetRVName) ||
 		req.SourceRVName == req.TargetRVName ||
 		len(req.ComponentRV) == 0 {
-		errStr := fmt.Sprintf("MV (%s), SourceRV (%s), TargetRV (%s) or ComponentRVs (%d) invalid",
-			req.MV, req.SourceRVName, req.TargetRVName, len(req.ComponentRV))
+		errStr := fmt.Sprintf("SenderNodeID (%s), MV (%s), SourceRV (%s), TargetRV (%s) or ComponentRVs (%d) invalid",
+			req.SenderNodeID, req.MV, req.SourceRVName, req.TargetRVName, len(req.ComponentRV))
 		log.Err("ChunkServiceHandler::StartSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -1823,7 +1854,7 @@ func (h *ChunkServiceHandler) StartSync(ctx context.Context, req *models.StartSy
 	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s/%s not hosted by this node", rvInfo.rvName, req.MV)
+		errStr := fmt.Sprintf("%s is not part of %s", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::StartSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
@@ -1893,14 +1924,15 @@ func (h *ChunkServiceHandler) EndSync(ctx context.Context, req *models.EndSyncRe
 
 	log.Debug("ChunkServiceHandler::EndSync: Received EndSync request: %v", rpc.EndSyncRequestToString(req))
 
-	if !common.IsValidUUID(req.SyncID) ||
+	if !common.IsValidUUID(req.SenderNodeID) ||
+		!common.IsValidUUID(req.SyncID) ||
 		!cm.IsValidMVName(req.MV) ||
 		!cm.IsValidRVName(req.SourceRVName) ||
 		!cm.IsValidRVName(req.TargetRVName) ||
 		req.SourceRVName == req.TargetRVName ||
 		len(req.ComponentRV) == 0 {
-		errStr := fmt.Sprintf("SyncID (%s) MV (%s), SourceRV (%s), TargetRV (%s) or ComponentRVs (%d) invalid",
-			req.SyncID, req.MV, req.SourceRVName, req.TargetRVName, len(req.ComponentRV))
+		errStr := fmt.Sprintf("SenderNodeID (%s), SyncID (%s) MV (%s), SourceRV (%s), TargetRV (%s) or ComponentRVs (%d) invalid",
+			req.SenderNodeID, req.SyncID, req.MV, req.SourceRVName, req.TargetRVName, len(req.ComponentRV))
 		log.Err("ChunkServiceHandler::EndSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -1940,7 +1972,7 @@ func (h *ChunkServiceHandler) EndSync(ctx context.Context, req *models.EndSyncRe
 	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s/%s not hosted by this node", rvInfo.rvName, req.MV)
+		errStr := fmt.Sprintf("%s is not part of %s", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::EndSync: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
@@ -2029,8 +2061,8 @@ func (h *ChunkServiceHandler) GetMVSize(ctx context.Context, req *models.GetMVSi
 
 	log.Debug("ChunkServiceHandler::GetMVSize: Received GetMVSize request: %v", rpc.GetMVSizeRequestToString(req))
 
-	if !cm.IsValidMVName(req.MV) || !cm.IsValidRVName(req.RVName) {
-		errStr := fmt.Sprintf("MV (%s) or RV (%s) invalid", req.MV, req.RVName)
+	if !common.IsValidUUID(req.SenderNodeID) || !cm.IsValidMVName(req.MV) || !cm.IsValidRVName(req.RVName) {
+		errStr := fmt.Sprintf("Invalid SenderNodeID, MV or RV: %v", rpc.GetMVSizeRequestToString(req))
 		log.Err("ChunkServiceHandler::GetMVSize: %s", errStr)
 		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
@@ -2038,14 +2070,26 @@ func (h *ChunkServiceHandler) GetMVSize(ctx context.Context, req *models.GetMVSi
 
 	rvInfo := h.getRVInfoFromRVName(req.RVName)
 	if rvInfo == nil {
-		log.Err("ChunkServiceHandler::GetMVSize: Invalid RV %s", req.RVName)
-		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRV, fmt.Sprintf("invalid RV %s", req.RVName))
+		errStr := fmt.Sprintf("node %s does not host %s", rpc.GetMyNodeUUID(), req.RVName)
+		log.Err("ChunkServiceHandler::GetMVSize: %s", errStr)
+		common.Assert(false, errStr)
+		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRV, errStr)
 	}
 
+	//
+	// Check if we are hosting the requested MV replica.
+	//
+	// Q: Why refreshFromClustermap() cannot help this?
+	// A: An MV replica can be added to rvInfo only via a JoinMV RPC, and only when we respond successfully
+	//    to the JoinMV call will the sender persist it in the clustermap, so if the clustermap has it we
+	//    must have sent it and if we don't have it, refreshing from clustermap cannot add it.
+	//    This cannot happen unless sender is doing something wrong, hence assert.
+	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
-		errStr := fmt.Sprintf("%s/%s not hosted by this node", rvInfo.rvName, req.MV)
+		errStr := fmt.Sprintf("%s is not part of %s", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::GetMVSize: %s", errStr)
+		common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
 	}
 

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -2077,20 +2077,17 @@ func (h *ChunkServiceHandler) GetMVSize(ctx context.Context, req *models.GetMVSi
 	}
 
 	//
-	// Check if we are hosting the requested MV replica.
-	//
-	// Q: Why refreshFromClustermap() cannot help this?
-	// A: An MV replica can be added to rvInfo only via a JoinMV RPC, and only when we respond successfully
-	//    to the JoinMV call will the sender persist it in the clustermap, so if the clustermap has it we
-	//    must have sent it and if we don't have it, refreshing from clustermap cannot add it.
-	//    This cannot happen unless sender is doing something wrong, hence assert.
+	// An MV replica can be added to rvInfo only via a JoinMV RPC, and only when we respond successfully
+	// to the JoinMV call will the sender persist it in the clustermap, so if the clustermap has it we
+	// must have sent it and if we don't have it, refreshing from clustermap cannot add it.
+	// This cannot happen unless sender is doing something wrong, hence assert.
 	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
 		errStr := fmt.Sprintf("%s is not part of %s", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::GetMVSize: %s", errStr)
 		common.Assert(false, errStr)
-		return nil, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
+		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
 	}
 
 	return &models.GetMVSizeResponse{

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1766,6 +1766,10 @@ func (h *ChunkServiceHandler) LeaveMV(ctx context.Context, req *models.LeaveMVRe
 	// per the global clustermap, since an RV is added to an MV only after a successful JoinMV response
 	// from all component RVs, we *must* have the MV replica in our rvInfo.
 	//
+	// TODO: There is one scenario in which this is possible, if a node responds to LeaveMV() successfully
+	// but the sender cannot commit it to clustermap for some reason, then when LeaveMV() is retried
+	// it'll not find the MV.
+	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
 		errStr := fmt.Sprintf("%s/%s not hosted by this node", req.RVName, req.MV)

--- a/internal/dcache/rpc/server/utils.go
+++ b/internal/dcache/rpc/server/utils.go
@@ -34,7 +34,6 @@
 package rpc_server
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -202,31 +201,4 @@ func getRvIDMap(rvs map[string]dcache.RawVolume) map[string]*rvInfo {
 // return mvs-per-rv from dcache config
 func getMVsPerRV() int64 {
 	return int64(cm.GetCacheConfig().MvsPerRv)
-}
-
-// When an MV is in degraded state because one or more of its RV went offline,
-// the caller (lowest index online RV) can call this method to get the
-// size of the MV. The caller will then send JoinMV RPC call to the
-// new RVs, passing the size of the MV to them. On basis of this,
-// the new RVs will decide if they can join the MV or not.
-func GetMyMVSize(mvName string, rvName string) (int64, error) {
-	// TODO: should we block the IO operations on the MV while this is happening?
-	common.Assert(handler != nil)
-
-	// TODO: replace with IsValidMV and IsValidRV
-	common.Assert(cm.IsValidRVName(rvName), rvName)
-	common.Assert(cm.IsValidMVName(mvName), mvName)
-
-	resp, err := handler.GetMVSize(context.Background(), &models.GetMVSizeRequest{
-		SenderNodeID: rpc.GetMyNodeUUID(),
-		MV:           mvName,
-		RVName:       rvName,
-	})
-
-	if err != nil {
-		log.Err("utils::GetMyMVSize: Failed to get MV size for %s/%s [%v]", rvName, mvName, err)
-		return 0, err
-	}
-
-	return resp.MvSize, nil
 }

--- a/internal/dcache/rpc/service.thrift
+++ b/internal/dcache/rpc/service.thrift
@@ -29,4 +29,6 @@ service ChunkService {
     models.StartSyncResponse StartSync(1: models.StartSyncRequest request) throws (1:models.ResponseError err)
 
     models.EndSyncResponse EndSync(1: models.EndSyncRequest request) throws (1:models.ResponseError err)
+
+    models.GetMVSizeResponse GetMVSize(1: models.GetMVSizeRequest request) throws (1:models.ResponseError err)
 }

--- a/internal/dcache/rpc/service.thrift
+++ b/internal/dcache/rpc/service.thrift
@@ -30,5 +30,6 @@ service ChunkService {
 
     models.EndSyncResponse EndSync(1: models.EndSyncRequest request) throws (1:models.ResponseError err)
 
+    // retrieve the size of the specified MV
     models.GetMVSizeResponse GetMVSize(1: models.GetMVSizeRequest request) throws (1:models.ResponseError err)
 }

--- a/internal/dcache/rpc/utils.go
+++ b/internal/dcache/rpc/utils.go
@@ -152,3 +152,9 @@ func EndSyncRequestToString(req *models.EndSyncRequest) string {
 	return fmt.Sprintf("{SyncID %v, MV %v, SourceRVName %v, TargetRVName %v, ComponentRV %v, SyncSize %v}",
 		req.SyncID, req.MV, req.SourceRVName, req.TargetRVName, ComponentRVsToString(req.ComponentRV), req.SyncSize)
 }
+
+// convert *models.GetMVSizeRequest to string
+// used for logging
+func GetMVSizeRequestToString(req *models.GetMVSizeRequest) string {
+	return fmt.Sprintf("{MV %v, RVName %v}", req.MV, req.RVName)
+}

--- a/internal/dcache/rpc/utils.go
+++ b/internal/dcache/rpc/utils.go
@@ -156,5 +156,5 @@ func EndSyncRequestToString(req *models.EndSyncRequest) string {
 // convert *models.GetMVSizeRequest to string
 // used for logging
 func GetMVSizeRequestToString(req *models.GetMVSizeRequest) string {
-	return fmt.Sprintf("{MV %v, RVName %v}", req.MV, req.RVName)
+	return fmt.Sprintf("{SenderNodeID %v, MV %v, RVName %v}", req.SenderNodeID, req.MV, req.RVName)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
Added GetMVSize() RPC API to get the size of the MV while running the fix MV workflow.
