### PR TITLE
Don't count offline MVs towards usable MVs

### DIFF
--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -1847,7 +1847,12 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 	// TODO: See if we need delete-mv workflow to clean those up.
 	//
 
+	numUsableMVs := 0
 	for mvName, mv := range existingMVMap {
+		if mv.State != dcache.StateOffline {
+			numUsableMVs++
+		}
+
 		if mv.State != dcache.StateDegraded {
 			continue
 		}
@@ -1881,14 +1886,30 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 
 		// New MV will need at least NumReplicas distinct nodes.
 		if len(nodeToRvs) < NumReplicas {
+			log.Debug("ClusterManager::updateMVList: len(nodeToRvs) [%d] < NumReplicas [%d]",
+				len(nodeToRvs), NumReplicas)
 			break
 		}
 
-		// With rvMap and MvsPerRv and NumReplicas, we cannot have more than maxMVsPossible MVs.
+		//
+		// With rvMap and MvsPerRv and NumReplicas, we cannot have more than maxMVsPossible usable MVs.
+		// Note that we are talking of online or degraded/syncing MVs. Offline MVs have all component RVs
+		// offline and they don't consume any RV slot.
+		//
+		// Q: Why do we need to limit numUsableMVs to maxMVsPossible?
+		//    IOW, why is the the above check "len(nodeToRvs) < NumReplicas" not suffcient.
+		// A: "len(nodeToRvs) < NumReplicas" check will try to create as many MVs as we can with the available
+		//    RVs, but it might create more than maxMVsPossible if some of the MVs have offline RVs (fixMV() would
+		//    have attempted to replace offline RVs for all degraded MVs but if joinMV() fails or any other error
+		//    we can have some component RVs as offline). We don't want to create more MVs leaving some MVs with
+		//    no replacement RVs available.
+		//
 		maxMVsPossible := (len(rvMap) * MvsPerRv) / NumReplicas
-		common.Assert(len(existingMVMap) <= maxMVsPossible, len(existingMVMap), maxMVsPossible)
+		common.Assert(numUsableMVs <= maxMVsPossible, numUsableMVs, maxMVsPossible)
 
-		if len(existingMVMap) == maxMVsPossible {
+		if numUsableMVs == maxMVsPossible {
+			log.Debug("ClusterManager::updateMVList: numUsableMVs [%d] == maxMVsPossible [%d]",
+				numUsableMVs, maxMVsPossible)
 			break
 		}
 
@@ -1954,6 +1975,8 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 			}
 		}
 
+		common.Assert(len(existingMVMap[mvName].RVs) <= NumReplicas, mvName, len(existingMVMap[mvName].RVs))
+
 		//
 		// Call joinMV() and check if all component RVs are able to join successfully.
 		// reserveBytes is 0 for a new-mv workflow.
@@ -1966,9 +1989,17 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 		if err == nil {
 			log.Info("ClusterManager::updateMVList: Successfully joined all component RVs %+v to MV %s",
 				existingMVMap[mvName].RVs, mvName)
+
 			for rvName := range existingMVMap[mvName].RVs {
+				// All component RVs added by the new-mv workflow must be online.
+				common.Assert(existingMVMap[mvName].RVs[rvName] == dcache.StateOnline,
+					rvName, mvName, existingMVMap[mvName].RVs[rvName])
 				consumeRVSlot(mvName, rvName)
 			}
+
+			// One more usable MV added to existingMVMap.
+			numUsableMVs++
+			common.Assert(numUsableMVs <= len(existingMVMap), numUsableMVs, len(existingMVMap))
 		} else {
 			// TODO: Give up reallocating RVs after a few failed attempts.
 			log.Err("ClusterManager::updateMVList: Error joining RV %s with MV %s: %v",

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -70,6 +70,16 @@ func GetActiveMVs() map[string]dcache.MirroredVolume {
 	return clusterMap.getActiveMVs()
 }
 
+// It will return degraded MVs Map <mvName, MV> as per local cache copy of cluster map.
+func GetDegradedMVs() map[string]dcache.MirroredVolume {
+	return clusterMap.getDegradedMVs()
+}
+
+// It will return offline MVs Map <mvName, MV> as per local cache copy of cluster map.
+func GetOfflineMVs() map[string]dcache.MirroredVolume {
+	return clusterMap.getOfflineMVs()
+}
+
 // It will return the cache config as per local cache copy of cluster map.
 func GetCacheConfig() *dcache.DCacheConfig {
 	return clusterMap.getCacheConfig()
@@ -78,11 +88,6 @@ func GetCacheConfig() *dcache.DCacheConfig {
 // It will return the clustermap per local cache copy of it.
 func GetClusterMap() dcache.ClusterMap {
 	return clusterMap.getClusterMap()
-}
-
-// It will return degraded MVs Map <mvName, MV> as per local cache copy of cluster map.
-func GetDegradedMVs() map[string]dcache.MirroredVolume {
-	return clusterMap.getDegradedMVs()
 }
 
 // It will return all the RVs Map <rvName, RV> for this particular node as per local cache copy of cluster map.
@@ -282,6 +287,30 @@ func (c *ClusterMap) getActiveMVNames() []string {
 	return activeMVNames[:i]
 }
 
+func (c *ClusterMap) getDegradedMVs() map[string]dcache.MirroredVolume {
+	common.Assert(c.localMap != nil)
+
+	degradedMVs := make(map[string]dcache.MirroredVolume)
+	for mvName, mv := range c.localMap.MVMap {
+		if mv.State == dcache.StateDegraded {
+			degradedMVs[mvName] = mv
+		}
+	}
+	return degradedMVs
+}
+
+func (c *ClusterMap) getOfflineMVs() map[string]dcache.MirroredVolume {
+	common.Assert(c.localMap != nil)
+
+	offlineMVs := make(map[string]dcache.MirroredVolume)
+	for mvName, mv := range c.localMap.MVMap {
+		if mv.State == dcache.StateOffline {
+			offlineMVs[mvName] = mv
+		}
+	}
+	return offlineMVs
+}
+
 // Scan through the RV list and return the set of all nodes which have contributed at least one RV.
 func (c *ClusterMap) getAllNodes() map[string]struct{} {
 	common.Assert(c.localMap != nil)
@@ -310,18 +339,6 @@ func (c *ClusterMap) getCacheConfig() *dcache.DCacheConfig {
 func (c *ClusterMap) getClusterMap() dcache.ClusterMap {
 	common.Assert(c.localMap != nil)
 	return *c.localMap
-}
-
-func (c *ClusterMap) getDegradedMVs() map[string]dcache.MirroredVolume {
-	common.Assert(c.localMap != nil)
-
-	degradedMVs := make(map[string]dcache.MirroredVolume)
-	for mvName, mv := range c.localMap.MVMap {
-		if mv.State == dcache.StateDegraded {
-			degradedMVs[mvName] = mv
-		}
-	}
-	return degradedMVs
 }
 
 // Get RVs belonging to this node.


### PR DESCRIPTION
Currentl we are limiting total MVs by this calculation

maxMVsPossible := (len(rvMap) * MvsPerRv) / NumReplicas

We are also counting offline MVs, which do not consume any RVs, so we are limiting our MVs to a smaller value.
This changes fixes it to only count usable MVs (which are not offline)

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->