### PR TITLE
Remove sync MV directory

### DIFF
--- a/internal/dcache/replication_manager/models.go
+++ b/internal/dcache/replication_manager/models.go
@@ -222,6 +222,13 @@ type syncJob struct {
 	destSyncID   string                   // sync ID of the StartSync() RPC call made to the node hosting the destination RV
 	syncSize     int64                    // total number of bytes to be synced
 	componentRVs []*models.RVNameAndState // list of component RVs for the MV
+
+	// Time when the target RV's state is updated to syncing state from outofsync.
+	// This is used to determine which chunks need to be synced/copied to the target RV.
+	// The chunks created before this time are copied to the target RV via the sync PutChunk RPC calls.
+	// Whereas the chunks created after this time are not copied to the target RV, as these would have
+	// already been written to the target RV by the client PutChunk RPC calls.
+	syncStartTime int64
 }
 
 // Helper method which can be used for logging the syncJob.

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -871,13 +871,19 @@ func copyOutOfSyncChunks(job *syncJob) error {
 		if info.ModTime().UnixMicro() > job.syncStartTime {
 			// This chunk is created after the sync start time, so it will be written to both source and target
 			// RVs by the client PutChunk() RPC calls, so we can skip it here.
-			log.Debug("ReplicationManager::copyOutOfSyncChunks: Skipping chunk %s/%s, Mtime (%d) > syncStartTime (%d)",
-				sourceMVPath, entry.Name(), info.ModTime().UnixMicro(), job.syncStartTime)
+			log.Debug("ReplicationManager::copyOutOfSyncChunks: Skipping chunk %s/%s, "+
+				"Mtime (%d) > syncStartTime (%d) [%d usecs after sync start]",
+				sourceMVPath, entry.Name(), info.ModTime().UnixMicro(), job.syncStartTime,
+				info.ModTime().UnixMicro()-job.syncStartTime)
 			continue
 		}
 
 		log.Debug("ReplicationManager::copyOutOfSyncChunks: Copying chunk %s/%s, Mtime (%d) <= syncStartTime (%d)",
 			sourceMVPath, entry.Name(), info.ModTime().UnixMicro(), job.syncStartTime)
+		log.Debug("ReplicationManager::copyOutOfSyncChunks: Copying chunk %s/%s, "+
+			"Mtime (%d) <= syncStartTime (%d) [%d usecs before sync start]",
+			sourceMVPath, entry.Name(), info.ModTime().UnixMicro(), job.syncStartTime,
+			job.syncStartTime-info.ModTime().UnixMicro())
 
 		//
 		// chunks are stored in MV as,

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -367,6 +367,13 @@ retry:
 						return nil, err
 					}
 
+					// TODO: retry till the next epoch, till the clustermap is refreshed.
+					// Case: StartSync() RPC calls are successful, but before the state of the target RV
+					// is updated to "syncing" in clustermap, some other node calls WriteMV() with the outdated
+					// clustermap, which results in the component RVs rejecting the request with
+					// NeedToRefreshClusterMap error. Even after the clustermap is refreshed, it may get the same
+					// state of the target RV as "outofsync" as the clustermap update by the source (or lio) RV
+					// may not have completed yet, so the target RV may not be in "syncing" state.
 					err = cm.RefreshClusterMapSync()
 					if err != nil {
 						err = fmt.Errorf("RefreshClusterMapSync() failed, failing write %s",

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -615,7 +615,7 @@ func syncComponentRV(mvName string, lioRV string, targetRVName string, syncSize 
 	// The chunks written to the MV after this point will be written to the target RV as well,
 	// since the target RV is now in syncing state.
 	//
-	syncStartTime := time.Now().UnixMicro()
+	syncStartTime := time.Now().UnixMicro() + NTPClockSkewMargin
 
 	//
 	// Update the state of target RV from outofsync to syncing in local component RVs list.
@@ -849,13 +849,13 @@ func copyOutOfSyncChunks(job *syncJob) error {
 		if info.ModTime().UnixMicro() > job.syncStartTime {
 			// This chunk is created after the sync start time, so it will be written to both source and target
 			// RVs by the client PutChunk() RPC calls, so we can skip it here.
-			log.Debug("ReplicationManager::copyOutOfSyncChunks: Skipping chunk %s/%s, created after sync start time %d",
-				sourceMVPath, entry.Name(), job.syncStartTime)
+			log.Debug("ReplicationManager::copyOutOfSyncChunks: Skipping chunk %s/%s, Mtime (%d) > syncStartTime (%d)",
+				sourceMVPath, entry.Name(), info.ModTime().UnixMicro(), job.syncStartTime)
 			continue
 		}
 
-		log.Debug("ReplicationManager::copyOutOfSyncChunks: Copying chunk %s/%s, created before sync start time %d",
-			sourceMVPath, entry.Name(), job.syncStartTime)
+		log.Debug("ReplicationManager::copyOutOfSyncChunks: Copying chunk %s/%s, Mtime (%d) <= syncStartTime (%d)",
+			sourceMVPath, entry.Name(), info.ModTime().UnixMicro(), job.syncStartTime)
 
 		//
 		// chunks are stored in MV as,

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -510,9 +510,6 @@ func syncMV(mvName string, mvInfo dcache.MirroredVolume) {
 	// %age progress. Note that JoinMV carries the reservedSpace parameter which is the more critical one
 	// to decide if an RV can host a new MV replica or not.
 	//
-	// TODO: Make sure GetMVSize() correctly returns the to-be-synced data, i.e., data in the regular
-	//       MV folder. Remove .sync folder dependency, all chunks will be written to the regular MV folder.
-	//
 	syncSize, err := GetMVSize(mvName)
 	if err != nil {
 		err = fmt.Errorf("failed to get disk usage of %s/%s [%v]", lioRV, mvName, err)

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -604,6 +604,9 @@ func syncComponentRV(mvName string, lioRV string, targetRVName string, syncSize 
 		return
 	}
 
+	// TODO:: discuss: if some other node is writing to this MV, its WriteMV() workflow will not have the updated
+	// component RVs list with the target RV in syncing state. So, it might skip writing the chunk to
+	// the target RV, thinking that it is still outofsync.
 	//
 	// Now that the target RV state is updated to syncing from outofsync, the WriteMV() workflow will
 	// consider the target RV as valid candidate for client PutChunk() calls.

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -626,9 +626,6 @@ func syncComponentRV(mvName string, lioRV string, targetRVName string, syncSize 
 		return
 	}
 
-	// TODO:: discuss: if some other node is writing to this MV, its WriteMV() workflow will not have the updated
-	// component RVs list with the target RV in syncing state. So, it might skip writing the chunk to
-	// the target RV, thinking that it is still outofsync.
 	//
 	// Now that the target RV state is updated to syncing from outofsync, the WriteMV() workflow will
 	// consider the target RV as valid candidate for client PutChunk() calls.

--- a/internal/dcache/replication_manager/utils.go
+++ b/internal/dcache/replication_manager/utils.go
@@ -56,6 +56,9 @@ const (
 
 	// Time interval in seconds for resyncing degraded MVs.
 	ResyncInterval = 10
+
+	// Time in microseconds to add to the sync start time to account for clock skew
+	NTPClockSkewMargin = 5 * 1e6
 )
 
 func getReaderRV(componentRVs []*models.RVNameAndState, excludeRVs []string) *models.RVNameAndState {

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -179,13 +179,6 @@ type syncJob struct {
 	// This is returned in the StartSync response and EndSync should carry this.
 	syncID string
 
-	// Time in microseconds(UnixMicro) when the StartSync call came. This is used in component RV resync workflow, when deciding
-	// the chunks that must be copied to the target RV of the sync. The source RV (lio RV) enumerates
-	// its RV/MV directory and only sends sync PutChunk requests for chunks that were created
-	// before the this time. The chunks that were created after this, are written to
-	// both the source and target RVs, so they are ignored in the sync PutChunk calls.
-	syncStartTime int64
-
 	// Source and target RVs for this sync job.
 	// An MV Replica can either act as source or target in a sync job, so one and only one of these will be set.
 	// If sourceRVName is set that means this MV Replica is the target of this sync job, while if
@@ -359,10 +352,9 @@ func (mv *mvInfo) addSyncJob(sourceRVName string, targetRVName string) string {
 	common.Assert(!ok, fmt.Sprintf("%s already has syncJob with syncID %s: %+v", mv.mvName, syncID, mv.syncJobs))
 
 	mv.syncJobs[syncID] = syncJob{
-		syncID:        syncID,
-		syncStartTime: time.Now().UnixMicro(),
-		sourceRVName:  sourceRVName,
-		targetRVName:  targetRVName,
+		syncID:       syncID,
+		sourceRVName: sourceRVName,
+		targetRVName: targetRVName,
 	}
 
 	return syncID

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1404,6 +1404,11 @@ refreshFromClustermapAndRetry:
 		return nil, rpc.NewResponseError(models.ErrorCode_InternalServerError, errStr)
 	}
 
+	// TODO: see if this is needed -> store max mtime of chunk written by client write.
+	// Needed for start sync time optimization in the sync component RV workflow. ON basis of this time,
+	// we can decide chunks which need to be synced to the target RV. The chunks having mtime less than this,
+	// should be synced to the target RV.
+
 	// TODO: should we also consider the hash file size in the total chunk bytes
 	//       For accurate accounting we can, but we should not do an extra stat() call for the hash file
 	//       but instead use a hardcoded value which will be true for a given hash algo.

--- a/internal/dcache/rpc/server/utils.go
+++ b/internal/dcache/rpc/server/utils.go
@@ -35,48 +35,24 @@ package rpc_server
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/log"
 	"github.com/Azure/azure-storage-fuse/v2/internal/dcache"
-	"github.com/Azure/azure-storage-fuse/v2/internal/dcache/clustermap"
+	cm "github.com/Azure/azure-storage-fuse/v2/internal/dcache/clustermap"
 	"github.com/Azure/azure-storage-fuse/v2/internal/dcache/rpc"
 	"github.com/Azure/azure-storage-fuse/v2/internal/dcache/rpc/gen-go/dcache/models"
 )
 
-// returns the chunk path and hash path for the given fileID and offsetInMB from the regular MV directory
-// If not present, return the path of the sync MV directory
+// returns the chunk and hash path for the given fileID and offsetInMB from RV/MV directory as,
+// <cache dir>/<mvName>/<fileID>.<offsetInMB>.data and
+// <cache dir>/<mvName>/<fileID>.<offsetInMB>.hash
 func getChunkAndHashPath(cacheDir string, mvName string, fileID string, offsetInMB int64) (string, string) {
-	chunkPath, hashPath := getRegularMVPath(cacheDir, mvName, fileID, offsetInMB)
-	_, err := os.Stat(chunkPath)
-	if err != nil {
-		log.Debug("utils::getChunkAndHashPath: chunk file %s does not exist, returning .sync directory path", chunkPath)
-		return getSyncMVPath(cacheDir, mvName, fileID, offsetInMB)
-	}
-
-	return chunkPath, hashPath
-}
-
-// returns the chunk path and hash path for the given fileID and offsetInMB from regular MV directory
-func getRegularMVPath(cacheDir string, mvName string, fileID string, offsetInMB int64) (string, string) {
 	chunkPath := filepath.Join(cacheDir, mvName, fmt.Sprintf("%v.%v.data", fileID, offsetInMB))
 	hashPath := filepath.Join(cacheDir, mvName, fmt.Sprintf("%v.%v.hash", fileID, offsetInMB))
 	return chunkPath, hashPath
-}
-
-// returns the chunk path and hash path for the given fileID and offsetInMB from MV.sync directory
-func getSyncMVPath(cacheDir string, mvName string, fileID string, offsetInMB int64) (string, string) {
-	chunkPath := filepath.Join(cacheDir, mvName+".sync", fmt.Sprintf("%v.%v.data", fileID, offsetInMB))
-	hashPath := filepath.Join(cacheDir, mvName+".sync", fmt.Sprintf("%v.%v.hash", fileID, offsetInMB))
-	return chunkPath, hashPath
-}
-
-// return the chunk address in the format <fileID>-<rvID>-<mvName>-<offsetInMB>
-func getChunkAddress(fileID string, rvID string, mvName string, offsetInMB int64) string {
-	return fmt.Sprintf("%v-%v-%v-%v", fileID, rvID, mvName, offsetInMB)
 }
 
 // sort the component RVs in the MV
@@ -143,44 +119,6 @@ func isRVPresentInMV(rvs []*models.RVNameAndState, rvName string) bool {
 	return false
 }
 
-// end sync operation will call this method to move all the chunks from the sync MV path to the regular MV path
-func moveChunksToRegularMVPath(syncMvPath string, regMvPath string) error {
-	entries, err := os.ReadDir(syncMvPath)
-	if err != nil {
-		log.Err("utils::moveChunksToRegularMVPath: Failed to read directory %s [%v]", syncMvPath, err)
-		return err
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			log.Warn("utils::moveChunksToRegularMVPath: Skipping directory %s", entry.Name())
-			// We only save chunks in the .sync folder.
-			common.Assert(false)
-			continue
-		}
-
-		// TODO: Check and assert that all entries are valid chunk names.
-
-		src := filepath.Join(syncMvPath, entry.Name())
-		dest := filepath.Join(regMvPath, entry.Name())
-
-		err = os.Rename(src, dest)
-		if err != nil {
-			log.Err("utils::moveChunksToRegularMVPath: Failed to move chunk %s -> %s [%v]",
-				src, dest, err.Error())
-			return err
-		}
-
-		log.Debug("utils::moveChunksToRegularMVPath: Moved chunk %s -> %s", src, dest)
-	}
-
-	return nil
-}
-
-// TODO: apart from just populating the rv related info, it should also update the mvinfo.
-// For that it'll need to find the mv folders inside the rv, enumerate and stat all chunks
-// to find the totalChunkBytes, etc. This is needed when a node with data, restarts
-
 // create the rvID map from RVs present in the current node
 func getRvIDMap(rvs map[string]dcache.RawVolume) map[string]*rvInfo {
 	rvIDMap := make(map[string]*rvInfo)
@@ -200,7 +138,61 @@ func getRvIDMap(rvs map[string]dcache.RawVolume) map[string]*rvInfo {
 
 // return mvs-per-rv from dcache config
 func getMVsPerRV() int64 {
-	return int64(clustermap.GetCacheConfig().MvsPerRv)
+	return int64(cm.GetCacheConfig().MvsPerRv)
+}
+
+// Source RV or lio RV can call this method to get the sync start time for the given syncID.
+// This is useful when the source RV wants to know when the sync started for a given syncID.
+// This helps in finding which chunks need to be synced to the target RV.
+// The chunks created before this time are copied to the target RV via the sync PutChunk RPC call.
+// The chunks created after this time are not copied to the target RV, as these would have
+// already been written to the target RV by the client PutChunk RPC calls.
+func GetSyncStartTime(rvName string, mvName string, syncID string) (int64, error) {
+	common.Assert(handler != nil)
+
+	common.Assert(cm.IsValidRVName(rvName), rvName)
+	common.Assert(cm.IsValidMVName(mvName), mvName)
+	common.Assert(common.IsValidUUID(syncID), syncID)
+
+	rvInfo := handler.getRVInfoFromRVName(rvName)
+	if rvInfo == nil {
+		errStr := fmt.Sprintf("node %s does not host %s", rpc.GetMyNodeUUID(), rvName)
+		log.Err("utils::GetSyncStartTime: %s", errStr)
+		common.Assert(false, errStr)
+		return 0, rpc.NewResponseError(models.ErrorCode_InvalidRV, errStr)
+	}
+
+	mvInfo := rvInfo.getMVInfo(mvName)
+	if mvInfo == nil {
+		errStr := fmt.Sprintf("%s is not part of %s", rvName, mvName)
+		log.Err("utils::GetSyncStartTime: %s", errStr)
+		common.Assert(false, errStr)
+		return 0, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
+	}
+
+	// TODO: discuss should we take opMutex lock here to access syncJobs map?
+
+	//
+	// Q: Why refreshFromClustermap() cannot help this?
+	// A: GetSyncStartTime() call can only be sent after a successful StartSync response from
+	//    us and when we would have responded we would have added the syncJob. This call is
+	//    made when the source RV (or lio RV) is syncing chunks to the outofsync target RV.
+	//
+	syncJob, ok := mvInfo.syncJobs[syncID]
+	if !ok {
+		errStr := fmt.Sprintf("syncID %s not valid for %s/%s [NeedToRefreshClusterMap]",
+			syncID, rvName, mvName)
+		log.Err("utils::GetSyncStartTime: %s", errStr)
+		common.Assert(false, errStr)
+		return 0, rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
+	}
+
+	// This call can only be made by the source RV (or lio RV) which is syncing chunks to the target RV.
+	// Check if this call is indeed made by the source RV.
+	common.Assert(syncJob.sourceRVName == "")
+	common.Assert(syncJob.targetRVName != "")
+
+	return syncJob.syncStartTime, nil
 }
 
 // When an MV is in degraded state because one or more of its RV went offline,


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
Remove the sync MV directory dependency in StartSync, EndSync and PutChunk (both client and sync writes) RPC calls. All chunks will be written inside the RV/MV directory.