### PR TITLE
Return correct permission and times in stat for clustermap proc file

### DIFF
--- a/internal/dcache/debug/callbacks.go
+++ b/internal/dcache/debug/callbacks.go
@@ -35,9 +35,11 @@ package debug
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/log"
+	"github.com/Azure/azure-storage-fuse/v2/internal"
 	cm "github.com/Azure/azure-storage-fuse/v2/internal/dcache/clustermap"
 )
 
@@ -57,4 +59,13 @@ func readClusterMapCallback(pFile *procFile) error {
 	}
 
 	return nil
+}
+
+func getAttrClusterMapCallback(pFile *procFile, attr *internal.ObjAttr) {
+	localCMap := cm.GetClusterMap()
+	lmt := localCMap.LastUpdatedAt
+	common.Assert(lmt > 0)
+	attr.Mtime = time.Unix(lmt, 0)
+	attr.Ctime = attr.Mtime
+	attr.Atime = attr.Mtime
 }

--- a/internal/dcache/debug/callbacks.go
+++ b/internal/dcache/debug/callbacks.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/log"
-	"github.com/Azure/azure-storage-fuse/v2/internal"
 	cm "github.com/Azure/azure-storage-fuse/v2/internal/dcache/clustermap"
 )
 
@@ -49,9 +48,9 @@ import (
 // proc file: clustermap
 func readClusterMapCallback(pFile *procFile) error {
 	var err error
-	localCMap := cm.GetClusterMap()
-	exportedCMap := cm.ExportClusterMap(&localCMap)
-	pFile.buf, err = json.MarshalIndent(exportedCMap, "", "    ")
+	clusterMap := cm.GetClusterMap()
+	exportedClusterMap := cm.ExportClusterMap(&clusterMap)
+	pFile.buf, err = json.MarshalIndent(exportedClusterMap, "", "    ")
 
 	if err != nil {
 		log.Err("DebugFS::readclusterMapCallback, err: %v", err)
@@ -61,11 +60,11 @@ func readClusterMapCallback(pFile *procFile) error {
 	return nil
 }
 
-func getAttrClusterMapCallback(pFile *procFile, attr *internal.ObjAttr) {
-	localCMap := cm.GetClusterMap()
-	lmt := localCMap.LastUpdatedAt
+func getAttrClusterMapCallback(pFile *procFile) {
+	clusterMap := cm.GetClusterMap()
+	lmt := clusterMap.LastUpdatedAt
 	common.Assert(lmt > 0)
-	attr.Mtime = time.Unix(lmt, 0)
-	attr.Ctime = attr.Mtime
-	attr.Atime = attr.Mtime
+	pFile.attr.Mtime = time.Unix(lmt, 0)
+	pFile.attr.Ctime = pFile.attr.Mtime
+	pFile.attr.Atime = pFile.attr.Mtime
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

This will return the last-updated-at field in clusetermap as atime, mtime, ctime and also file perm as 0444