### PR TITLE
Misc perf fixes

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -56,6 +56,7 @@ import (
 	"syscall"
 
 	gouuid "github.com/google/uuid"
+	"github.com/prometheus/procfs"
 	"gopkg.in/ini.v1"
 )
 
@@ -463,6 +464,43 @@ func GetDiskSpaceMetricsFromStatfs(path string) (uint64, uint64, error) {
 
 	totalSpace := stat.Blocks * uint64(stat.Frsize)
 	return totalSpace, availableSpace, nil
+}
+
+// GetTotalMemoryInMB returns the total RAM of the host running blobfuse.
+func GetTotalMemoryInMB() (uint64, error) {
+	fs, err := procfs.NewDefaultFS()
+	if err != nil {
+		return 0, fmt.Errorf("GetTotalMemoryInMB: procfs.NewDefaultFS() failed: %v", err)
+	}
+
+	// Get memory info.
+	memInfo, err := fs.Meminfo()
+	if err != nil {
+		return 0, fmt.Errorf("GetTotalMemoryInMB: fs.Meminfo() failed: %v", err)
+	}
+
+	// Convert default memory unit (KB) to MB and return.
+	return *(memInfo.MemTotal) / 1024, nil
+}
+
+// GetAvailableMemoryInMB returns the available RAM of the host running blobfuse.
+// Note that available memory includes free memory and reclaimable memory, so it's a good estimate for how
+// much memory blobfuse can practically use. Obviously if other processes or the kernel use up more memory
+// the available memory will change, caller should be mindful of that.
+func GetAvailableMemoryInMB() (uint64, error) {
+	fs, err := procfs.NewDefaultFS()
+	if err != nil {
+		return 0, fmt.Errorf("GetAvailableMemoryInMB: procfs.NewDefaultFS() failed: %v", err)
+	}
+
+	// Get memory info.
+	memInfo, err := fs.Meminfo()
+	if err != nil {
+		return 0, fmt.Errorf("GetAvailableMemoryInMB: fs.Meminfo() failed: %v", err)
+	}
+
+	// Convert default memory unit (KB) to MB and return.
+	return *(memInfo.MemAvailable) / 1024, nil
 }
 
 func GetFuseMinorVersion() int {

--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -181,9 +181,11 @@ func (dc *DistributedCache) Start(ctx context.Context) error {
 
 	log.Info("DistributedCache::Start : component started successfully")
 
-	// todo : Replace the hardcoded values with user config values.
-	// todo:  Add Init function to fileIOmanager to initialize the defaults.
-	fm.NewFileIOManager(10, 4, 4, 4*1024*1024, 100)
+	err = fm.NewFileIOManager()
+	if err != nil {
+		return log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [Failed to start fileio manager : %v]", err))
+	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/apache/thrift v0.21.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/montanaflynn/stats v0.7.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+	github.com/prometheus/procfs v0.16.1
 	github.com/radovskyb/watcher v1.0.7
 	github.com/sevlyar/go-daemon v0.1.6
 	github.com/spf13/cobra v1.9.1
@@ -34,7 +36,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeD
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -73,6 +73,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
+github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
 github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=

--- a/internal/dcache/replication_manager/utils.go
+++ b/internal/dcache/replication_manager/utils.go
@@ -60,8 +60,12 @@ const (
 	// Time in microseconds to add to the sync start time to account for clock skew
 	NTPClockSkewMargin = 5 * 1e6
 
+	//
 	// Number of workers in the thread pool for sending the RPC requests.
-	MAX_WORKER_COUNT = 64
+	// Note that one worker is used for one replica IO (read or write), so we need these to be accordingly
+	// higher than the fileIOManager workers setting.
+	//
+	MAX_WORKER_COUNT = 2000
 )
 
 func getReaderRV(componentRVs []*models.RVNameAndState, excludeRVs []string) *models.RVNameAndState {


### PR DESCRIPTION
Set most of the perf config values with logical explanation. Use callers thread for the last replica write.
getRPCClientNoLock() will wait till a free client is available. Will panic if a free client is not available till 60 secs.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->