### PR TITLE
Add MaybeOverwrite field in PutChunk request

### DIFF
--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -2352,8 +2352,12 @@ func (cmi *ClusterManager) joinMV(mvName string, mv dcache.MirroredVolume) (stri
 		reserveBytes, err = rm.GetMVSize(mvName)
 		if err != nil {
 			err = fmt.Errorf("failed to get disk usage of %s [%v]", mvName, err)
-			log.Err("ClusterManager::fixMV: %v", err)
+			log.Err("ClusterManager::joinMV: %v", err)
 			common.Assert(false, err)
+			// TODO: return error. Skipping it now because the caller of joinMV() expects failed RVs
+			// along with the error. So, the error handling part of the caller must be updated to handle
+			// the error returned in this case as below.
+			// return "", err
 		}
 	}
 

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -2318,7 +2318,7 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 //
 // TODO: joinMV() should technically return more than one failed RVs.
 func (cmi *ClusterManager) joinMV(mvName string, mv dcache.MirroredVolume) (string, error) {
-	log.Debug("ClusterManagerImpl::joinMV: JoinMV(%s, %+v)", mvName, mv)
+	log.Debug("ClusterManager::joinMV: JoinMV(%s, %+v)", mvName, mv)
 
 	var componentRVs []*models.RVNameAndState
 	var numRVsOnline int
@@ -2357,11 +2357,14 @@ func (cmi *ClusterManager) joinMV(mvName string, mv dcache.MirroredVolume) (stri
 		}
 	}
 
+	log.Debug("ClusterManager::joinMV: %s, state: %s, new-mv: %v, reserve bytes: %d",
+		mvName, string(mv.State), newMV, reserveBytes)
+
 	// reserveBytes must be non-zero only for degraded MV, for new-mv it'll be 0.
 	common.Assert(reserveBytes == 0 || mv.State == dcache.StateDegraded, reserveBytes, mv.State)
 
 	for rvName, rvState := range mv.RVs {
-		log.Debug("ClusterManagerImpl::joinMV: Populating componentRVs list MV %s with RV %s", mvName, rvName)
+		log.Debug("ClusterManager::joinMV: Populating componentRVs list MV %s with RV %s", mvName, rvName)
 
 		//
 		// For new-mv all component RVs must be online, for fix-mv we can have the following component RV states:
@@ -2401,7 +2404,7 @@ func (cmi *ClusterManager) joinMV(mvName string, mv dcache.MirroredVolume) (stri
 			continue
 		}
 
-		log.Debug("ClusterManagerImpl::joinMV: Joining MV %s with RV %s", mvName, rv.Name)
+		log.Debug("ClusterManager::joinMV: Joining MV %s with RV %s", mvName, rv.Name)
 
 		joinMvReq := &models.JoinMVRequest{
 			MV:           mvName,
@@ -2442,7 +2445,7 @@ func (cmi *ClusterManager) joinMV(mvName string, mv dcache.MirroredVolume) (stri
 
 		if err != nil {
 			err = fmt.Errorf("error %s MV %s with RV %s: %v", action, mvName, rv.Name, err)
-			log.Err("ClusterManagerImpl::joinMV: %v", err)
+			log.Err("ClusterManager::joinMV: %v", err)
 			return rv.Name, err
 		}
 	}

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -348,7 +348,7 @@ retry:
 			//
 			// Set the "MaybeOverwrite" flag to true in PutChunkRequest to let the server know that this
 			// could potentially be an overwrite of a chunk that we previously wrote, so that
-			// it relaxes it's overwrite checks.
+			// it relaxes its overwrite checks.
 			// To be safe we can set MaybeOverwrite to true when retryCnt > 0.
 			//
 			rpcReq := &models.PutChunkRequest{

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -346,10 +346,10 @@ retry:
 				rv.Name, req.MvName, rvID, rv.State, targetNodeID)
 
 			//
-			// TODO: Add a boolean MaybeOverwrite to PutChunkRequest to let the server know that this
-			//       could potentially be an overwrite of a chunk that we previously wrote, so that
-			//       it relaxes it's overwrite checks.
-			//       To be safe we can set MaybeOverwrite to true when retryCnt > 0.
+			// Set the "MaybeOverwrite" flag to true in PutChunkRequest to let the server know that this
+			// could potentially be an overwrite of a chunk that we previously wrote, so that
+			// it relaxes it's overwrite checks.
+			// To be safe we can set MaybeOverwrite to true when retryCnt > 0.
 			//
 			rpcReq := &models.PutChunkRequest{
 				Chunk: &models.Chunk{
@@ -362,9 +362,10 @@ retry:
 					Data: req.Data,
 					Hash: "", // TODO: hash validation will be done later
 				},
-				Length:      int64(len(req.Data)),
-				SyncID:      "", // this is regular client write
-				ComponentRV: componentRVs,
+				Length:         int64(len(req.Data)),
+				SyncID:         "", // this is regular client write
+				ComponentRV:    componentRVs,
+				MaybeOverwrite: retryCnt > 0,
 			}
 
 			log.Debug("ReplicationManager::WriteMV: Sending PutChunk request for %s/%s to node %s: %s",

--- a/internal/dcache/rpc/gen-go/dcache/models/models.go
+++ b/internal/dcache/rpc/gen-go/dcache/models/models.go
@@ -1985,12 +1985,14 @@ func (p *GetChunkResponse) String() string {
 //   - Length
 //   - SyncID
 //   - ComponentRV
+//   - MaybeOverwrite
 type PutChunkRequest struct {
-	SenderNodeID string            `thrift:"senderNodeID,1" db:"senderNodeID" json:"senderNodeID"`
-	Chunk        *Chunk            `thrift:"chunk,2" db:"chunk" json:"chunk"`
-	Length       int64             `thrift:"length,3" db:"length" json:"length"`
-	SyncID       string            `thrift:"syncID,4" db:"syncID" json:"syncID"`
-	ComponentRV  []*RVNameAndState `thrift:"componentRV,5" db:"componentRV" json:"componentRV"`
+	SenderNodeID   string            `thrift:"senderNodeID,1" db:"senderNodeID" json:"senderNodeID"`
+	Chunk          *Chunk            `thrift:"chunk,2" db:"chunk" json:"chunk"`
+	Length         int64             `thrift:"length,3" db:"length" json:"length"`
+	SyncID         string            `thrift:"syncID,4" db:"syncID" json:"syncID"`
+	ComponentRV    []*RVNameAndState `thrift:"componentRV,5" db:"componentRV" json:"componentRV"`
+	MaybeOverwrite bool              `thrift:"maybeOverwrite,6" db:"maybeOverwrite" json:"maybeOverwrite"`
 }
 
 func NewPutChunkRequest() *PutChunkRequest {
@@ -2020,6 +2022,10 @@ func (p *PutChunkRequest) GetSyncID() string {
 
 func (p *PutChunkRequest) GetComponentRV() []*RVNameAndState {
 	return p.ComponentRV
+}
+
+func (p *PutChunkRequest) GetMaybeOverwrite() bool {
+	return p.MaybeOverwrite
 }
 func (p *PutChunkRequest) IsSetChunk() bool {
 	return p.Chunk != nil
@@ -2082,6 +2088,16 @@ func (p *PutChunkRequest) Read(ctx context.Context, iprot thrift.TProtocol) erro
 		case 5:
 			if fieldTypeId == thrift.LIST {
 				if err := p.ReadField5(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 6:
+			if fieldTypeId == thrift.BOOL {
+				if err := p.ReadField6(ctx, iprot); err != nil {
 					return err
 				}
 			} else {
@@ -2159,6 +2175,15 @@ func (p *PutChunkRequest) ReadField5(ctx context.Context, iprot thrift.TProtocol
 	return nil
 }
 
+func (p *PutChunkRequest) ReadField6(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(ctx); err != nil {
+		return thrift.PrependError("error reading field 6: ", err)
+	} else {
+		p.MaybeOverwrite = v
+	}
+	return nil
+}
+
 func (p *PutChunkRequest) Write(ctx context.Context, oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin(ctx, "PutChunkRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -2177,6 +2202,9 @@ func (p *PutChunkRequest) Write(ctx context.Context, oprot thrift.TProtocol) err
 			return err
 		}
 		if err := p.writeField5(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField6(ctx, oprot); err != nil {
 			return err
 		}
 	}
@@ -2262,6 +2290,19 @@ func (p *PutChunkRequest) writeField5(ctx context.Context, oprot thrift.TProtoco
 	return err
 }
 
+func (p *PutChunkRequest) writeField6(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "maybeOverwrite", thrift.BOOL, 6); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 6:maybeOverwrite: ", p), err)
+	}
+	if err := oprot.WriteBool(ctx, bool(p.MaybeOverwrite)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.maybeOverwrite (6) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 6:maybeOverwrite: ", p), err)
+	}
+	return err
+}
+
 func (p *PutChunkRequest) Equals(other *PutChunkRequest) bool {
 	if p == other {
 		return true
@@ -2288,6 +2329,9 @@ func (p *PutChunkRequest) Equals(other *PutChunkRequest) bool {
 		if !_tgt.Equals(_src13) {
 			return false
 		}
+	}
+	if p.MaybeOverwrite != other.MaybeOverwrite {
+		return false
 	}
 	return true
 }

--- a/internal/dcache/rpc/models.thrift
+++ b/internal/dcache/rpc/models.thrift
@@ -53,7 +53,8 @@ struct PutChunkRequest {
     2: Chunk chunk,
     3: i64 length,
     4: string syncID,
-    5: list<RVNameAndState> componentRV // used to validate the component RV for the MV
+    5: list<RVNameAndState> componentRV, // used to validate the component RV for the MV
+    6: bool maybeOverwrite
 }
 
 struct PutChunkResponse {

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -330,7 +330,7 @@ func (rv *rvInfo) incReservedSpace(bytes int64) {
 
 // Decrement the reserved space for this RV.
 func (rv *rvInfo) decReservedSpace(bytes int64) {
-	common.Assert(bytes > 0)
+	common.Assert(bytes >= 0, bytes)
 	rv.reservedSpace.Add(-bytes)
 	common.Assert(rv.reservedSpace.Load() >= 0, rv.rvName, rv.reservedSpace.Load())
 	log.Debug("rvInfo::decReservedSpace: reserved space for RV %s is %d", rv.rvName, rv.reservedSpace.Load())

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1387,6 +1387,8 @@ refreshFromClustermapAndRetry:
 				//
 				log.Debug("ChunkServiceHandler::PutChunk: syncID = %s, chunk file %s already exists, ignoring sync write",
 					req.SyncID, chunkPath)
+				common.Assert(!req.MaybeOverwrite,
+					"Only PutChunk(client) can have MaybeOverwrite set", rpc.PutChunkRequestToString(req))
 			} else {
 				//
 				// Client can set the "MaybeOverwrite" flag to true in PutChunkRequest to let the server

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1380,13 +1380,25 @@ refreshFromClustermapAndRetry:
 	// Chunk file must not be present.
 	_, err = os.Stat(chunkPath)
 	if err == nil {
-		if req.SyncID != "" {
-			// In case of sync PutChunk calls, we can get sync write for chunks already present in
-			// the target RV because of the NTPClockSkewMargin added to the sync write time. These
-			// chunks were written by the client write PutChunk calls to the target RV.
-			// So, ignore this and return success.
-			log.Debug("ChunkServiceHandler::PutChunk: syncID = %s, chunk file %s already exists, ignoring sync write",
-				req.SyncID, chunkPath)
+		if req.SyncID != "" || req.MaybeOverwrite {
+			if req.SyncID != "" {
+				//
+				// In case of sync PutChunk calls, we can get sync write for chunks already present in
+				// the target RV because of the NTPClockSkewMargin added to the sync write time. These
+				// chunks were written by the client write PutChunk calls to the target RV.
+				// So, ignore this and return success.
+				//
+				log.Debug("ChunkServiceHandler::PutChunk: syncID = %s, chunk file %s already exists, ignoring sync write",
+					req.SyncID, chunkPath)
+			} else {
+				//
+				// Client can set the "MaybeOverwrite" flag to true in PutChunkRequest to let the server
+				// know that this could potentially be an overwrite of a chunk that we previously wrote,
+				// due to client retrying the WriteMV workflow after refreshing the clustermap.
+				//
+				log.Debug("ChunkServiceHandler::PutChunk: MaybeOverwrite = true, chunk file %s already exists, ignoring write",
+					chunkPath)
+			}
 
 			availableSpace, err := rvInfo.getAvailableSpace()
 			if err != nil {

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -303,11 +303,8 @@ func (rv *rvInfo) incReservedSpace(bytes int64) {
 // Decrement the reserved space for this RV.
 func (rv *rvInfo) decReservedSpace(bytes int64) {
 	common.Assert(bytes > 0)
-	//
-	// TODO: Uncomment this only after clustermanager joinMV() correctly reserves space for MV replica.
-	//
-	// rv.reservedSpace.Add(-bytes)
-	// common.Assert(rv.reservedSpace.Load() >= 0, rv.rvName, rv.reservedSpace.Load())
+	rv.reservedSpace.Add(-bytes)
+	common.Assert(rv.reservedSpace.Load() >= 0, rv.rvName, rv.reservedSpace.Load())
 	log.Debug("rvInfo::decReservedSpace: reserved space for RV %s is %d", rv.rvName, rv.reservedSpace.Load())
 }
 

--- a/internal/dcache/rpc/utils.go
+++ b/internal/dcache/rpc/utils.go
@@ -133,9 +133,9 @@ func GetChunkResponseToString(resp *models.GetChunkResponse) string {
 // convert *models.PutChunkRequest to string
 // exculde data and hash from the string to prevent it from being logged
 func PutChunkRequestToString(req *models.PutChunkRequest) string {
-	return fmt.Sprintf("{SenderNodeID %v, Address %+v, Length %v, SyncID %v, ComponentRV %v}",
+	return fmt.Sprintf("{SenderNodeID %v, Address %+v, Length %v, SyncID %v, ComponentRV %v, MaybeOverwrite %v}",
 		req.SenderNodeID, *req.Chunk.Address, req.Length, req.SyncID,
-		ComponentRVsToString(req.ComponentRV))
+		ComponentRVsToString(req.ComponentRV), req.MaybeOverwrite)
 }
 
 func PutChunkResponseToString(resp *models.PutChunkResponse) string {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
Add `MaybeOverwrite` field in PutChunk request to let the server that this request could potentially be an overwrite of a chunk that we previously wrote, so that it relaxes it's overwrite checks.
This PR also sets the `ReserveSpace` field in JoinMV request in fix-mv workflow.
