### PR TITLE
Az storage changes for dcache

### DIFF
--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -433,7 +433,7 @@ func (az *AzStorage) DeleteFile(options internal.DeleteFileOptions) error {
 func (az *AzStorage) RenameFile(options internal.RenameFileOptions) error {
 	log.Trace("AzStorage::RenameFile : %s to %s", options.Src, options.Dst)
 
-	err := az.storage.RenameFile(options.Src, options.Dst, options.SrcAttr)
+	err := az.storage.RenameFile(options)
 
 	if err == nil {
 		azStatsCollector.PushEvents(renameFile, options.Src, map[string]interface{}{src: options.Src, dest: options.Dst})
@@ -587,7 +587,7 @@ func (az *AzStorage) CommitData(opt internal.CommitDataOptions) error {
 	return az.storage.CommitBlocks(opt.Name, opt.List, opt.NewETag)
 }
 
-func (az *AzStorage) WriteFromBuffer(opt internal.WriteFromBufferOptions) error {
+func (az *AzStorage) WriteFromBuffer(opt internal.WriteFromBufferOptions) (string, error) {
 	return az.storage.WriteFromBuffer(opt)
 }
 

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -361,7 +361,7 @@ func (bb *BlockBlob) DeleteDirectory(name string) (err error) {
 // Copy the LMT to the src attr if the copy is success.
 // https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob?tabs=microsoft-entra-id
 func (bb *BlockBlob) RenameFile(options internal.RenameFileOptions) error {
-	log.Trace("BlockBlob::RenameFile : %s -> %s", options.Src, options.Dst)
+	log.Trace("BlockBlob::RenameFile : %s -> %s, NoReplace: %v", options.Src, options.Dst, options.NoReplace)
 
 	blobClient := bb.Container.NewBlockBlobClient(filepath.Join(bb.Config.prefixPath, options.Src))
 	newBlobClient := bb.Container.NewBlockBlobClient(filepath.Join(bb.Config.prefixPath, options.Dst))
@@ -371,6 +371,7 @@ func (bb *BlockBlob) RenameFile(options internal.RenameFileOptions) error {
 	copyFromURLOptions := &blob.StartCopyFromURLOptions{
 		Tier: bb.Config.defaultTier,
 	}
+
 	if options.NoReplace {
 		copyFromURLOptions.AccessConditions = &blob.AccessConditions{
 			ModifiedAccessConditions: &blob.ModifiedAccessConditions{
@@ -388,7 +389,7 @@ func (bb *BlockBlob) RenameFile(options internal.RenameFileOptions) error {
 			log.Err("BlockBlob::RenameFile : Src Blob doesn't Exist %s [%s]", options.Src, err.Error())
 			return syscall.ENOENT
 		} else if serr == ErrFileAlreadyExists {
-			common.Assert(options.NoReplace)
+			common.Assert(options.NoReplace, options)
 			log.Err("BlockBlob::RenameFile : Dst Blob Exists %s [%s]", options.Dst, err.Error())
 			return syscall.EEXIST
 		}

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -1117,6 +1117,29 @@ func (s *blockBlobTestSuite) TestRenameFileError() {
 	s.assert.NotNil(err)
 }
 
+func (s *blockBlobTestSuite) TestRenameFileNoReplace() {
+	defer s.cleanupTest()
+	// Setup
+	src := generateFileName()
+	s.az.CreateFile(internal.CreateFileOptions{Name: src})
+	dst := generateFileName()
+	s.az.CreateFile(internal.CreateFileOptions{Name: dst})
+
+	// Attempt to rename src to dst, which already exists
+	err := s.az.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst, NoReplace: true})
+	s.assert.NotNil(err)
+	s.assert.EqualValues(syscall.EEXIST, err)
+
+	// Src should be in the account
+	source := s.containerClient.NewBlobClient(src)
+	_, err = source.GetProperties(ctx, nil)
+	s.assert.Nil(err)
+	// Dst should  be in the account
+	destination := s.containerClient.NewBlobClient(dst)
+	_, err = destination.GetProperties(ctx, nil)
+	s.assert.Nil(err)
+}
+
 func (s *blockBlobTestSuite) TestReadFile() {
 	defer s.cleanupTest()
 	// Setup

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -3405,9 +3405,10 @@ func (s *blockBlobTestSuite) TestUploadBlobWithCPKEnabled() {
 	s.assert.NotNil(resp.RequestID)
 
 	name2 := generateFileName()
-	_, err = s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
+	eTag, err := s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
 		Data: data})
 	s.assert.Nil(err)
+	s.assert.NotEqual(eTag, "")
 
 	file = s.containerClient.NewBlobClient(name2)
 	resp, err = file.DownloadStream(ctx, &blob.DownloadStreamOptions{

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -3382,7 +3382,7 @@ func (s *blockBlobTestSuite) TestUploadBlobWithCPKEnabled() {
 	s.assert.NotNil(resp.RequestID)
 
 	name2 := generateFileName()
-	err = s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
+	_, err = s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
 		Data: data})
 	s.assert.Nil(err)
 

--- a/component/azstorage/connection.go
+++ b/component/azstorage/connection.go
@@ -112,7 +112,7 @@ type AzConnection interface {
 	DeleteFile(name string) error
 	DeleteDirectory(name string) error
 
-	RenameFile(string, string, *internal.ObjAttr) error
+	RenameFile(options internal.RenameFileOptions) error
 	RenameDirectory(string, string) error
 
 	GetAttr(name string) (attr *internal.ObjAttr, err error)
@@ -125,7 +125,7 @@ type AzConnection interface {
 	ReadInBuffer(name string, offset int64, len int64, data []byte, etag *string) error
 
 	WriteFromFile(name string, metadata map[string]*string, fi *os.File) error
-	WriteFromBuffer(options internal.WriteFromBufferOptions) error
+	WriteFromBuffer(options internal.WriteFromBufferOptions) (string, error)
 	Write(options internal.WriteFileOptions) error
 	GetFileBlockOffsets(name string) (*common.BlockOffsetList, error)
 

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -332,7 +332,7 @@ func (dl *Datalake) DeleteDirectory(name string) (err error) {
 // While renaming the file, Creation time is preserved but LMT is changed for the destination blob.
 // and also Etag of the destination blob changes
 func (dl *Datalake) RenameFile(options internal.RenameFileOptions) error {
-	log.Trace("Datalake::RenameFile : %s -> %s", options.Src, options.Dst)
+	log.Trace("Datalake::RenameFile : %s -> %s, NoReplace: %v", options.Src, options.Dst, options.NoReplace)
 
 	fileClient := dl.Filesystem.NewFileClient(url.PathEscape(filepath.Join(dl.Config.prefixPath, options.Src)))
 
@@ -355,7 +355,7 @@ func (dl *Datalake) RenameFile(options internal.RenameFileOptions) error {
 			log.Err("Datalake::RenameFile : %s does not exist", options.Src)
 			return syscall.ENOENT
 		} else if serr == ErrFileAlreadyExists {
-			common.Assert(options.NoReplace)
+			common.Assert(options.NoReplace, options)
 			log.Err("BlockBlob::RenameFile : Dst Blob Exists %s [%s]", options.Dst, err.Error())
 			return syscall.EEXIST
 		} else {

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -335,16 +335,18 @@ func (dl *Datalake) RenameFile(options internal.RenameFileOptions) error {
 	log.Trace("Datalake::RenameFile : %s -> %s", options.Src, options.Dst)
 
 	fileClient := dl.Filesystem.NewFileClient(url.PathEscape(filepath.Join(dl.Config.prefixPath, options.Src)))
+
 	renameOptions := &file.RenameOptions{
 		CPKInfo: dl.datalakeCPKOpt,
 	}
-	//	if options.NoReplace {
-	renameOptions.AccessConditions = &file.AccessConditions{
-		ModifiedAccessConditions: &file.ModifiedAccessConditions{
-			IfNoneMatch: to.Ptr(azcore.ETagAny),
-		},
+
+	if options.NoReplace {
+		renameOptions.AccessConditions = &file.AccessConditions{
+			ModifiedAccessConditions: &file.ModifiedAccessConditions{
+				IfNoneMatch: to.Ptr(azcore.ETagAny),
+			},
+		}
 	}
-	//	}
 
 	renameResponse, err := fileClient.Rename(context.Background(), filepath.Join(dl.Config.prefixPath, options.Dst), renameOptions)
 	if err != nil {

--- a/component/azstorage/datalake_test.go
+++ b/component/azstorage/datalake_test.go
@@ -1384,6 +1384,27 @@ func (s *datalakeTestSuite) TestRenameFileError() {
 	s.assert.NotNil(err)
 }
 
+func (s *datalakeTestSuite) TestRenameFileNoReplace() {
+	defer s.cleanupTest()
+	// Setup
+	src := generateFileName()
+	s.az.CreateFile(internal.CreateFileOptions{Name: src})
+	dst := generateFileName()
+	s.az.CreateFile(internal.CreateFileOptions{Name: dst})
+
+	err := s.az.RenameFile(internal.RenameFileOptions{Src: src, Dst: dst, NoReplace: true})
+	s.assert.NotNil(err)
+	s.assert.EqualValues(syscall.EEXIST, err)
+
+	// Src and destination should be in the account
+	source := s.containerClient.NewDirectoryClient(src)
+	_, err = source.GetProperties(ctx, nil)
+	s.assert.Nil(err)
+	destination := s.containerClient.NewDirectoryClient(dst)
+	_, err = destination.GetProperties(ctx, nil)
+	s.assert.Nil(err)
+}
+
 func (s *datalakeTestSuite) TestReadFile() {
 	defer s.cleanupTest()
 	// Setup

--- a/component/azstorage/datalake_test.go
+++ b/component/azstorage/datalake_test.go
@@ -2626,7 +2626,7 @@ func (s *datalakeTestSuite) TestUploadWithCPKEnabled() {
 	s.assert.NotNil(resp.RequestID)
 
 	name2 := generateFileName()
-	err = s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
+	_, err = s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
 		Data: data})
 	s.assert.Nil(err)
 

--- a/component/azstorage/datalake_test.go
+++ b/component/azstorage/datalake_test.go
@@ -2647,9 +2647,10 @@ func (s *datalakeTestSuite) TestUploadWithCPKEnabled() {
 	s.assert.NotNil(resp.RequestID)
 
 	name2 := generateFileName()
-	_, err = s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
+	eTag, err := s.az.storage.WriteFromBuffer(internal.WriteFromBufferOptions{Name: name2,
 		Data: data})
 	s.assert.Nil(err)
+	s.assert.NotEqual(eTag, "")
 
 	fileClient = s.containerClient.NewFileClient(name2)
 	resp, err = fileClient.DownloadStream(ctx, &file.DownloadStreamOptions{

--- a/component/distributed_cache/storage_callback_impl.go
+++ b/component/distributed_cache/storage_callback_impl.go
@@ -93,11 +93,11 @@ func (sci *StorageCallbackImpl) SetMetaPropertiesInStorage(options internal.SetM
 	return sci.storage.SetMetadata(options)
 }
 
-func (sci *StorageCallbackImpl) PutBlobInStorage(options internal.WriteFromBufferOptions) error {
+func (sci *StorageCallbackImpl) PutBlobInStorage(options internal.WriteFromBufferOptions) (string, error) {
 	return sci.storage.WriteFromBuffer(options)
 }
 
-func (sci *StorageCallbackImpl) PutBlob(options internal.WriteFromBufferOptions) error {
+func (sci *StorageCallbackImpl) PutBlob(options internal.WriteFromBufferOptions) (string, error) {
 	return sci.nextComp.WriteFromBuffer(options)
 }
 

--- a/component/distributed_cache/storage_callback_impl.go
+++ b/component/distributed_cache/storage_callback_impl.go
@@ -93,10 +93,12 @@ func (sci *StorageCallbackImpl) SetMetaPropertiesInStorage(options internal.SetM
 	return sci.storage.SetMetadata(options)
 }
 
+// Returns Etag of the blob incase of success
 func (sci *StorageCallbackImpl) PutBlobInStorage(options internal.WriteFromBufferOptions) (string, error) {
 	return sci.storage.WriteFromBuffer(options)
 }
 
+// Returns Etag of the blob incase of success
 func (sci *StorageCallbackImpl) PutBlob(options internal.WriteFromBufferOptions) (string, error) {
 	return sci.nextComp.WriteFromBuffer(options)
 }

--- a/internal/base_component.go
+++ b/internal/base_component.go
@@ -357,9 +357,9 @@ func (base *BaseComponent) CommitData(opt CommitDataOptions) error {
 	return nil
 }
 
-func (base *BaseComponent) WriteFromBuffer(opt WriteFromBufferOptions) error {
+func (base *BaseComponent) WriteFromBuffer(opt WriteFromBufferOptions) (string, error) {
 	if base.next != nil {
 		return base.next.WriteFromBuffer(opt)
 	}
-	return nil
+	return "", nil
 }

--- a/internal/component.go
+++ b/internal/component.go
@@ -143,5 +143,5 @@ type Component interface {
 	GetCommittedBlockList(string) (*CommittedBlockList, error)
 	StageData(StageDataOptions) error
 	CommitData(CommitDataOptions) error
-	WriteFromBuffer(WriteFromBufferOptions) error
+	WriteFromBuffer(WriteFromBufferOptions) (string, error)
 }

--- a/internal/component_options.go
+++ b/internal/component_options.go
@@ -104,10 +104,12 @@ type CloseFileOptions struct {
 }
 
 type RenameFileOptions struct {
-	Src     string
-	Dst     string
-	SrcAttr *ObjAttr
-	DstAttr *ObjAttr
+	Src       string
+	Dst       string
+	SrcAttr   *ObjAttr
+	DstAttr   *ObjAttr
+	NoReplace bool // Don't  overwrite newpath of the rename.  Return an error if new‐path already exists.
+	// This option is similar to the RENAME_NOREPLACE flag supported by renameat2() functin by the system.
 }
 
 type ReadFileOptions struct {

--- a/internal/dcache/metadata_manager/metadata_manager_impl.go
+++ b/internal/dcache/metadata_manager/metadata_manager_impl.go
@@ -313,7 +313,7 @@ func (m *BlobMetadataManager) createFileInit(filePath string, fileMetadata []byt
 		"state":               &state,
 	}
 
-	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
+	_, err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
 		Name:                   path,
 		Data:                   fileMetadata,
 		Metadata:               metadata,
@@ -387,7 +387,7 @@ func (m *BlobMetadataManager) createFileFinalize(filePath string, fileMetadata [
 		"state":               &state,
 	}
 
-	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
+	_, err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
 		Name:                   path,
 		Data:                   fileMetadata,
 		Metadata:               metadata,
@@ -719,7 +719,7 @@ func (m *BlobMetadataManager) updateHeartbeat(nodeId string, data []byte) error 
 
 	// Create the heartbeat file path.
 	heartbeatFilePath := filepath.Join(m.mdRoot, "Nodes", nodeId+".hb")
-	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
+	_, err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
 		Name:                   heartbeatFilePath,
 		Data:                   data,
 		IsNoneMatchEtagEnabled: false,
@@ -825,7 +825,7 @@ func (m *BlobMetadataManager) createInitialClusterMap(clustermap []byte) error {
 
 	// Create the clustermap file path.
 	clustermapPath := filepath.Join(m.mdRoot, "clustermap.json")
-	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
+	_, err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
 		Name:                   clustermapPath,
 		Data:                   clustermap,
 		IsNoneMatchEtagEnabled: true,
@@ -871,7 +871,7 @@ func (m *BlobMetadataManager) updateClusterMapStart(clustermap []byte, etag *str
 		common.Assert(err == nil, err)
 	}
 
-	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
+	_, err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
 		Name:                   clustermapPath,
 		Data:                   clustermap,
 		IsNoneMatchEtagEnabled: false,
@@ -914,7 +914,7 @@ func (m *BlobMetadataManager) updateClusterMapEnd(clustermap []byte) error {
 		common.Assert(err == nil, err)
 	}
 
-	err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
+	_, err := m.storageCallback.PutBlobInStorage(internal.WriteFromBufferOptions{
 		Name:                   clustermapPath,
 		Data:                   clustermap,
 		IsNoneMatchEtagEnabled: false,

--- a/internal/dcache/storage_callbacks.go
+++ b/internal/dcache/storage_callbacks.go
@@ -48,7 +48,7 @@ type StorageCallbacks interface {
 	GetPropertiesFromStorage(opt internal.GetAttrOptions) (*internal.ObjAttr, error)
 
 	//It will Put the blob in storage
-	PutBlobInStorage(opt internal.WriteFromBufferOptions) error
+	PutBlobInStorage(opt internal.WriteFromBufferOptions) (string, error)
 
 	//It will Read the directory from storage
 	ReadDirFromStorage(options internal.ReadDirOptions) ([]*internal.ObjAttr, error)
@@ -66,7 +66,7 @@ type StorageCallbacks interface {
 	GetProperties(opt internal.GetAttrOptions) (*internal.ObjAttr, error)
 
 	//It will Put the blob through next Component whichever is in pipeline
-	PutBlob(opt internal.WriteFromBufferOptions) error
+	PutBlob(opt internal.WriteFromBufferOptions) (string, error)
 
 	//It will Read the directory through next Component whichever is in pipeline
 	ReadDir(options internal.ReadDirOptions) ([]*internal.ObjAttr, error)

--- a/internal/dcache/storage_callbacks.go
+++ b/internal/dcache/storage_callbacks.go
@@ -47,7 +47,7 @@ type StorageCallbacks interface {
 	//It will Get the properties of the blob from storage
 	GetPropertiesFromStorage(opt internal.GetAttrOptions) (*internal.ObjAttr, error)
 
-	//It will Put the blob in storage
+	//It will Put the blob in storage, Returns Etag of the blob incase of success
 	PutBlobInStorage(opt internal.WriteFromBufferOptions) (string, error)
 
 	//It will Read the directory from storage
@@ -65,7 +65,7 @@ type StorageCallbacks interface {
 	//It will Get the properties of the blob through next Component whichever is in pipeline
 	GetProperties(opt internal.GetAttrOptions) (*internal.ObjAttr, error)
 
-	//It will Put the blob through next Component whichever is in pipeline
+	//It will Put the blob through next Component whichever is in pipeline, Returns Etag of the blob incase of success
 	PutBlob(opt internal.WriteFromBufferOptions) (string, error)
 
 	//It will Read the directory through next Component whichever is in pipeline

--- a/internal/mock_component.go
+++ b/internal/mock_component.go
@@ -710,11 +710,12 @@ func (mr *MockComponentMockRecorder) CommitData(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitData", reflect.TypeOf((*MockComponent)(nil).TruncateFile), arg0)
 }
 
-func (m *MockComponent) WriteFromBuffer(arg0 WriteFromBufferOptions) error {
+func (m *MockComponent) WriteFromBuffer(arg0 WriteFromBufferOptions) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFromBuffer", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (mr *MockComponentMockRecorder) WriteFromBuffer(arg0 interface{}) *gomock.Call {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
- support for rename-no-replace in fns and hns acnts
- support for returning etag in writeBuffer API, needed this etag to optimize some REST api calls.