### PR TITLE
PutChunk daisy chain implementation

### DIFF
--- a/internal/dcache/file_manager/worker.go
+++ b/internal/dcache/file_manager/worker.go
@@ -157,7 +157,7 @@ func (wp *workerPool) writeChunk(task *task) {
 	// Only dirty StagedChunk must be written.
 	common.Assert(task.chunk.Dirty.Load())
 
-	writeMVReq := &rm.WriteMvRequest{
+	writeMVExReq := &rm.WriteMvExRequest{
 		FileID:         task.file.FileMetadata.FileID,
 		MvName:         getMVForChunk(task.chunk, task.file.FileMetadata),
 		ChunkIndex:     task.chunk.Idx,
@@ -166,10 +166,10 @@ func (wp *workerPool) writeChunk(task *task) {
 		IsLastChunk:    task.chunk.Len != int64(len(task.chunk.Buf)),
 	}
 
-	// Call MvWrite method for writing the chunk.
-	_, err := rm.WriteMV(writeMVReq)
+	// Call WriteMVEx method for writing the chunk.
+	_, err := rm.WriteMVEx(writeMVExReq)
 	if err == nil {
-		// WriteMV completed successfully, staged chunk is now no more dirty.
+		// WriteMVEx completed successfully, staged chunk is now no more dirty.
 		common.Assert(task.chunk.Dirty.Load())
 		task.chunk.Dirty.Store(false)
 		close(task.chunk.Err)

--- a/internal/dcache/rpc/client/functions.go
+++ b/internal/dcache/rpc/client/functions.go
@@ -359,6 +359,96 @@ func PutChunk(ctx context.Context, targetNodeID string, req *models.PutChunkRequ
 		targetNodeID, reqStr)
 }
 
+func PutChunkEx(ctx context.Context, targetNodeID string, req *models.PutChunkExRequest) (*models.PutChunkExResponse, error) {
+	common.Assert(req != nil &&
+		req.Request != nil &&
+		req.Request.Chunk != nil &&
+		req.Request.Chunk.Address != nil)
+
+	// Caller must not set SenderNodeID, catch misbehaving callers.
+	common.Assert(len(req.Request.SenderNodeID) == 0, req.Request.SenderNodeID)
+	req.Request.SenderNodeID = myNodeId
+
+	reqStr := rpc.PutChunkExRequestToString(req)
+	log.Debug("rpc_client::PutChunkEx: Sending PutChunkEx request to node %s: %v", targetNodeID, reqStr)
+
+	//
+	// We retry once after resetting bad connections.
+	//
+	for i := 0; i < 2; i++ {
+		// Get RPC client from the client pool.
+		client, err := cp.getRPCClient(targetNodeID)
+		if err != nil {
+			log.Err("rpc_client::PutChunkEx: Failed to get RPC client for node %s %v: %v",
+				targetNodeID, reqStr, err)
+			return nil, err
+		}
+
+		// Call the rpc method.
+		resp, err := client.svcClient.PutChunkEx(ctx, req)
+		if err != nil {
+			log.Err("rpc_client::PutChunkEx: PutChunkEx failed to node %s %v: %v",
+				targetNodeID, reqStr, err)
+
+			//
+			// If the failure is due to a stale connection to a node that has restarted, reset the connections
+			// and retry once more.
+			//
+			if rpc.IsBrokenPipe(err) {
+				err1 := cp.resetAllRPCClients(client)
+				if err1 != nil {
+					log.Err("rpc_client::PutChunkEx: resetAllRPCClients failed for node %s: %v",
+						targetNodeID, err1)
+					//
+					// Connection refused and timeout are the only viable errors.
+					// Assert to know if anything else happens.
+					//
+					common.Assert(rpc.IsConnectionRefused(err1) || rpc.IsTimedOut(err1), err1)
+					return nil, err
+				}
+
+				// Retry PutChunkEx once more with fresh connection.
+				continue
+			}
+
+			//
+			// Only other possible errors:
+			// - Actual RPC error returned by the server.
+			// - Connection closed by the server (maybe it restarted before it could respond).
+			// - Connection reset by the server (same as above, but peer send a TCP RST instead of FIN).
+			//   Only read()/recv() can fail with this, write()/send() will fail with broken pipe.
+			// - Time out (either node is down or cannot be reached over the n/w).
+			//
+			common.Assert(rpc.IsRPCError(err) ||
+				rpc.IsConnectionClosed(err) ||
+				rpc.IsConnectionReset(err) ||
+				rpc.IsTimedOut(err), err)
+
+			// Fall through to release the RPC client.
+			resp = nil
+		}
+
+		// Release RPC client back to the pool.
+		err1 := cp.releaseRPCClient(client)
+		if err1 != nil {
+			log.Err("rpc_client::PutChunkEx: Failed to release RPC client for node %s %v: %v",
+				targetNodeID, reqStr, err1)
+			// Assert, but not fail the PutChunkEx call.
+			common.Assert(false, err1)
+		}
+
+		return resp, err
+	}
+
+	//
+	// We come here when we could not succeed even after resetting stale connections and retrying.
+	// This is unexpected, but can happen if the target node goes offline or restarts more than once in
+	// quick succession.
+	//
+	return nil, fmt.Errorf("rpc_client::PutChunkEx: Could not find a valid RPC client for node %s %v",
+		targetNodeID, reqStr)
+}
+
 func RemoveChunk(ctx context.Context, targetNodeID string, req *models.RemoveChunkRequest) (*models.RemoveChunkResponse, error) {
 	common.Assert(req != nil && req.Address != nil)
 

--- a/internal/dcache/rpc/gen-go/dcache/models/models.go
+++ b/internal/dcache/rpc/gen-go/dcache/models/models.go
@@ -2568,6 +2568,385 @@ func (p *PutChunkResponse) String() string {
 }
 
 // Attributes:
+//   - Req
+//   - LocalRVName
+//   - NextRVs
+type PutChunkExRequest struct {
+	Req         *PutChunkRequest `thrift:"req,1" db:"req" json:"req"`
+	LocalRVName string           `thrift:"localRVName,2" db:"localRVName" json:"localRVName"`
+	NextRVs     []string         `thrift:"nextRVs,3" db:"nextRVs" json:"nextRVs"`
+}
+
+func NewPutChunkExRequest() *PutChunkExRequest {
+	return &PutChunkExRequest{}
+}
+
+var PutChunkExRequest_Req_DEFAULT *PutChunkRequest
+
+func (p *PutChunkExRequest) GetReq() *PutChunkRequest {
+	if !p.IsSetReq() {
+		return PutChunkExRequest_Req_DEFAULT
+	}
+	return p.Req
+}
+
+func (p *PutChunkExRequest) GetLocalRVName() string {
+	return p.LocalRVName
+}
+
+func (p *PutChunkExRequest) GetNextRVs() []string {
+	return p.NextRVs
+}
+func (p *PutChunkExRequest) IsSetReq() bool {
+	return p.Req != nil
+}
+
+func (p *PutChunkExRequest) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				if err := p.ReadField2(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 3:
+			if fieldTypeId == thrift.LIST {
+				if err := p.ReadField3(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Req = &PutChunkRequest{}
+	if err := p.Req.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Req), err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) ReadField2(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(ctx); err != nil {
+		return thrift.PrependError("error reading field 2: ", err)
+	} else {
+		p.LocalRVName = v
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) ReadField3(ctx context.Context, iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin(ctx)
+	if err != nil {
+		return thrift.PrependError("error reading list begin: ", err)
+	}
+	tSlice := make([]string, 0, size)
+	p.NextRVs = tSlice
+	for i := 0; i < size; i++ {
+		var _elem16 string
+		if v, err := iprot.ReadString(ctx); err != nil {
+			return thrift.PrependError("error reading field 0: ", err)
+		} else {
+			_elem16 = v
+		}
+		p.NextRVs = append(p.NextRVs, _elem16)
+	}
+	if err := iprot.ReadListEnd(ctx); err != nil {
+		return thrift.PrependError("error reading list end: ", err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "PutChunkExRequest"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField2(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField3(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "req", thrift.STRUCT, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:req: ", p), err)
+	}
+	if err := p.Req.Write(ctx, oprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Req), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:req: ", p), err)
+	}
+	return err
+}
+
+func (p *PutChunkExRequest) writeField2(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "localRVName", thrift.STRING, 2); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:localRVName: ", p), err)
+	}
+	if err := oprot.WriteString(ctx, string(p.LocalRVName)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.localRVName (2) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:localRVName: ", p), err)
+	}
+	return err
+}
+
+func (p *PutChunkExRequest) writeField3(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "nextRVs", thrift.LIST, 3); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:nextRVs: ", p), err)
+	}
+	if err := oprot.WriteListBegin(ctx, thrift.STRING, len(p.NextRVs)); err != nil {
+		return thrift.PrependError("error writing list begin: ", err)
+	}
+	for _, v := range p.NextRVs {
+		if err := oprot.WriteString(ctx, string(v)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+		}
+	}
+	if err := oprot.WriteListEnd(ctx); err != nil {
+		return thrift.PrependError("error writing list end: ", err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:nextRVs: ", p), err)
+	}
+	return err
+}
+
+func (p *PutChunkExRequest) Equals(other *PutChunkExRequest) bool {
+	if p == other {
+		return true
+	} else if p == nil || other == nil {
+		return false
+	}
+	if !p.Req.Equals(other.Req) {
+		return false
+	}
+	if p.LocalRVName != other.LocalRVName {
+		return false
+	}
+	if len(p.NextRVs) != len(other.NextRVs) {
+		return false
+	}
+	for i, _tgt := range p.NextRVs {
+		_src17 := other.NextRVs[i]
+		if _tgt != _src17 {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *PutChunkExRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("PutChunkExRequest(%+v)", *p)
+}
+
+// Attributes:
+//   - Responses
+type PutChunkExResponse struct {
+	Responses map[string]*PutChunkResponse `thrift:"responses,1" db:"responses" json:"responses"`
+}
+
+func NewPutChunkExResponse() *PutChunkExResponse {
+	return &PutChunkExResponse{}
+}
+
+func (p *PutChunkExResponse) GetResponses() map[string]*PutChunkResponse {
+	return p.Responses
+}
+func (p *PutChunkExResponse) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.MAP {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *PutChunkExResponse) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	_, _, size, err := iprot.ReadMapBegin(ctx)
+	if err != nil {
+		return thrift.PrependError("error reading map begin: ", err)
+	}
+	tMap := make(map[string]*PutChunkResponse, size)
+	p.Responses = tMap
+	for i := 0; i < size; i++ {
+		var _key18 string
+		if v, err := iprot.ReadString(ctx); err != nil {
+			return thrift.PrependError("error reading field 0: ", err)
+		} else {
+			_key18 = v
+		}
+		_val19 := &PutChunkResponse{}
+		if err := _val19.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _val19), err)
+		}
+		p.Responses[_key18] = _val19
+	}
+	if err := iprot.ReadMapEnd(ctx); err != nil {
+		return thrift.PrependError("error reading map end: ", err)
+	}
+	return nil
+}
+
+func (p *PutChunkExResponse) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "PutChunkExResponse"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *PutChunkExResponse) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "responses", thrift.MAP, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:responses: ", p), err)
+	}
+	if err := oprot.WriteMapBegin(ctx, thrift.STRING, thrift.STRUCT, len(p.Responses)); err != nil {
+		return thrift.PrependError("error writing map begin: ", err)
+	}
+	for k, v := range p.Responses {
+		if err := oprot.WriteString(ctx, string(k)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+		}
+		if err := v.Write(ctx, oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+		}
+	}
+	if err := oprot.WriteMapEnd(ctx); err != nil {
+		return thrift.PrependError("error writing map end: ", err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:responses: ", p), err)
+	}
+	return err
+}
+
+func (p *PutChunkExResponse) Equals(other *PutChunkExResponse) bool {
+	if p == other {
+		return true
+	} else if p == nil || other == nil {
+		return false
+	}
+	if len(p.Responses) != len(other.Responses) {
+		return false
+	}
+	for k, _tgt := range p.Responses {
+		_src20 := other.Responses[k]
+		if !_tgt.Equals(_src20) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *PutChunkExResponse) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("PutChunkExResponse(%+v)", *p)
+}
+
+// Attributes:
 //   - SenderNodeID
 //   - Address
 //   - ComponentRV
@@ -2685,11 +3064,11 @@ func (p *RemoveChunkRequest) ReadField3(ctx context.Context, iprot thrift.TProto
 	tSlice := make([]*RVNameAndState, 0, size)
 	p.ComponentRV = tSlice
 	for i := 0; i < size; i++ {
-		_elem16 := &RVNameAndState{}
-		if err := _elem16.Read(ctx, iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem16), err)
+		_elem21 := &RVNameAndState{}
+		if err := _elem21.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem21), err)
 		}
-		p.ComponentRV = append(p.ComponentRV, _elem16)
+		p.ComponentRV = append(p.ComponentRV, _elem21)
 	}
 	if err := iprot.ReadListEnd(ctx); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -2784,8 +3163,8 @@ func (p *RemoveChunkRequest) Equals(other *RemoveChunkRequest) bool {
 		return false
 	}
 	for i, _tgt := range p.ComponentRV {
-		_src17 := other.ComponentRV[i]
-		if !_tgt.Equals(_src17) {
+		_src22 := other.ComponentRV[i]
+		if !_tgt.Equals(_src22) {
 			return false
 		}
 	}
@@ -2909,11 +3288,11 @@ func (p *RemoveChunkResponse) ReadField3(ctx context.Context, iprot thrift.TProt
 	tSlice := make([]*RVNameAndState, 0, size)
 	p.ComponentRV = tSlice
 	for i := 0; i < size; i++ {
-		_elem18 := &RVNameAndState{}
-		if err := _elem18.Read(ctx, iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem18), err)
+		_elem23 := &RVNameAndState{}
+		if err := _elem23.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem23), err)
 		}
-		p.ComponentRV = append(p.ComponentRV, _elem18)
+		p.ComponentRV = append(p.ComponentRV, _elem23)
 	}
 	if err := iprot.ReadListEnd(ctx); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -3008,8 +3387,8 @@ func (p *RemoveChunkResponse) Equals(other *RemoveChunkResponse) bool {
 		return false
 	}
 	for i, _tgt := range p.ComponentRV {
-		_src19 := other.ComponentRV[i]
-		if !_tgt.Equals(_src19) {
+		_src24 := other.ComponentRV[i]
+		if !_tgt.Equals(_src24) {
 			return false
 		}
 	}
@@ -3183,11 +3562,11 @@ func (p *JoinMVRequest) ReadField5(ctx context.Context, iprot thrift.TProtocol) 
 	tSlice := make([]*RVNameAndState, 0, size)
 	p.ComponentRV = tSlice
 	for i := 0; i < size; i++ {
-		_elem20 := &RVNameAndState{}
-		if err := _elem20.Read(ctx, iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem20), err)
+		_elem25 := &RVNameAndState{}
+		if err := _elem25.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem25), err)
 		}
-		p.ComponentRV = append(p.ComponentRV, _elem20)
+		p.ComponentRV = append(p.ComponentRV, _elem25)
 	}
 	if err := iprot.ReadListEnd(ctx); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -3320,8 +3699,8 @@ func (p *JoinMVRequest) Equals(other *JoinMVRequest) bool {
 		return false
 	}
 	for i, _tgt := range p.ComponentRV {
-		_src21 := other.ComponentRV[i]
-		if !_tgt.Equals(_src21) {
+		_src26 := other.ComponentRV[i]
+		if !_tgt.Equals(_src26) {
 			return false
 		}
 	}
@@ -3534,11 +3913,11 @@ func (p *UpdateMVRequest) ReadField4(ctx context.Context, iprot thrift.TProtocol
 	tSlice := make([]*RVNameAndState, 0, size)
 	p.ComponentRV = tSlice
 	for i := 0; i < size; i++ {
-		_elem22 := &RVNameAndState{}
-		if err := _elem22.Read(ctx, iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem22), err)
+		_elem27 := &RVNameAndState{}
+		if err := _elem27.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem27), err)
 		}
-		p.ComponentRV = append(p.ComponentRV, _elem22)
+		p.ComponentRV = append(p.ComponentRV, _elem27)
 	}
 	if err := iprot.ReadListEnd(ctx); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -3652,8 +4031,8 @@ func (p *UpdateMVRequest) Equals(other *UpdateMVRequest) bool {
 		return false
 	}
 	for i, _tgt := range p.ComponentRV {
-		_src23 := other.ComponentRV[i]
-		if !_tgt.Equals(_src23) {
+		_src28 := other.ComponentRV[i]
+		if !_tgt.Equals(_src28) {
 			return false
 		}
 	}
@@ -3866,11 +4245,11 @@ func (p *LeaveMVRequest) ReadField4(ctx context.Context, iprot thrift.TProtocol)
 	tSlice := make([]*RVNameAndState, 0, size)
 	p.ComponentRV = tSlice
 	for i := 0; i < size; i++ {
-		_elem24 := &RVNameAndState{}
-		if err := _elem24.Read(ctx, iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem24), err)
+		_elem29 := &RVNameAndState{}
+		if err := _elem29.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem29), err)
 		}
-		p.ComponentRV = append(p.ComponentRV, _elem24)
+		p.ComponentRV = append(p.ComponentRV, _elem29)
 	}
 	if err := iprot.ReadListEnd(ctx); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -3984,8 +4363,8 @@ func (p *LeaveMVRequest) Equals(other *LeaveMVRequest) bool {
 		return false
 	}
 	for i, _tgt := range p.ComponentRV {
-		_src25 := other.ComponentRV[i]
-		if !_tgt.Equals(_src25) {
+		_src30 := other.ComponentRV[i]
+		if !_tgt.Equals(_src30) {
 			return false
 		}
 	}
@@ -4239,11 +4618,11 @@ func (p *StartSyncRequest) ReadField5(ctx context.Context, iprot thrift.TProtoco
 	tSlice := make([]*RVNameAndState, 0, size)
 	p.ComponentRV = tSlice
 	for i := 0; i < size; i++ {
-		_elem26 := &RVNameAndState{}
-		if err := _elem26.Read(ctx, iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem26), err)
+		_elem31 := &RVNameAndState{}
+		if err := _elem31.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem31), err)
 		}
-		p.ComponentRV = append(p.ComponentRV, _elem26)
+		p.ComponentRV = append(p.ComponentRV, _elem31)
 	}
 	if err := iprot.ReadListEnd(ctx); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -4401,8 +4780,8 @@ func (p *StartSyncRequest) Equals(other *StartSyncRequest) bool {
 		return false
 	}
 	for i, _tgt := range p.ComponentRV {
-		_src27 := other.ComponentRV[i]
-		if !_tgt.Equals(_src27) {
+		_src32 := other.ComponentRV[i]
+		if !_tgt.Equals(_src32) {
 			return false
 		}
 	}
@@ -4731,11 +5110,11 @@ func (p *EndSyncRequest) ReadField6(ctx context.Context, iprot thrift.TProtocol)
 	tSlice := make([]*RVNameAndState, 0, size)
 	p.ComponentRV = tSlice
 	for i := 0; i < size; i++ {
-		_elem28 := &RVNameAndState{}
-		if err := _elem28.Read(ctx, iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem28), err)
+		_elem33 := &RVNameAndState{}
+		if err := _elem33.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem33), err)
 		}
-		p.ComponentRV = append(p.ComponentRV, _elem28)
+		p.ComponentRV = append(p.ComponentRV, _elem33)
 	}
 	if err := iprot.ReadListEnd(ctx); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -4912,8 +5291,8 @@ func (p *EndSyncRequest) Equals(other *EndSyncRequest) bool {
 		return false
 	}
 	for i, _tgt := range p.ComponentRV {
-		_src29 := other.ComponentRV[i]
-		if !_tgt.Equals(_src29) {
+		_src34 := other.ComponentRV[i]
+		if !_tgt.Equals(_src34) {
 			return false
 		}
 	}

--- a/internal/dcache/rpc/gen-go/dcache/models/models.go
+++ b/internal/dcache/rpc/gen-go/dcache/models/models.go
@@ -2568,40 +2568,222 @@ func (p *PutChunkResponse) String() string {
 }
 
 // Attributes:
-//   - Req
-//   - LocalRVName
+//   - Request
 //   - NextRVs
 type PutChunkExRequest struct {
-	Req         *PutChunkRequest `thrift:"req,1" db:"req" json:"req"`
-	LocalRVName string           `thrift:"localRVName,2" db:"localRVName" json:"localRVName"`
-	NextRVs     []string         `thrift:"nextRVs,3" db:"nextRVs" json:"nextRVs"`
+	Request *PutChunkRequest  `thrift:"request,1" db:"request" json:"request"`
+	NextRVs []*RVNameAndState `thrift:"nextRVs,2" db:"nextRVs" json:"nextRVs"`
 }
 
 func NewPutChunkExRequest() *PutChunkExRequest {
 	return &PutChunkExRequest{}
 }
 
-var PutChunkExRequest_Req_DEFAULT *PutChunkRequest
+var PutChunkExRequest_Request_DEFAULT *PutChunkRequest
 
-func (p *PutChunkExRequest) GetReq() *PutChunkRequest {
-	if !p.IsSetReq() {
-		return PutChunkExRequest_Req_DEFAULT
+func (p *PutChunkExRequest) GetRequest() *PutChunkRequest {
+	if !p.IsSetRequest() {
+		return PutChunkExRequest_Request_DEFAULT
 	}
-	return p.Req
+	return p.Request
 }
 
-func (p *PutChunkExRequest) GetLocalRVName() string {
-	return p.LocalRVName
-}
-
-func (p *PutChunkExRequest) GetNextRVs() []string {
+func (p *PutChunkExRequest) GetNextRVs() []*RVNameAndState {
 	return p.NextRVs
 }
-func (p *PutChunkExRequest) IsSetReq() bool {
-	return p.Req != nil
+func (p *PutChunkExRequest) IsSetRequest() bool {
+	return p.Request != nil
 }
 
 func (p *PutChunkExRequest) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.LIST {
+				if err := p.ReadField2(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Request = &PutChunkRequest{}
+	if err := p.Request.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Request), err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) ReadField2(ctx context.Context, iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin(ctx)
+	if err != nil {
+		return thrift.PrependError("error reading list begin: ", err)
+	}
+	tSlice := make([]*RVNameAndState, 0, size)
+	p.NextRVs = tSlice
+	for i := 0; i < size; i++ {
+		_elem16 := &RVNameAndState{}
+		if err := _elem16.Read(ctx, iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem16), err)
+		}
+		p.NextRVs = append(p.NextRVs, _elem16)
+	}
+	if err := iprot.ReadListEnd(ctx); err != nil {
+		return thrift.PrependError("error reading list end: ", err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "PutChunkExRequest"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField2(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *PutChunkExRequest) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "request", thrift.STRUCT, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:request: ", p), err)
+	}
+	if err := p.Request.Write(ctx, oprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Request), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:request: ", p), err)
+	}
+	return err
+}
+
+func (p *PutChunkExRequest) writeField2(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "nextRVs", thrift.LIST, 2); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:nextRVs: ", p), err)
+	}
+	if err := oprot.WriteListBegin(ctx, thrift.STRUCT, len(p.NextRVs)); err != nil {
+		return thrift.PrependError("error writing list begin: ", err)
+	}
+	for _, v := range p.NextRVs {
+		if err := v.Write(ctx, oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+		}
+	}
+	if err := oprot.WriteListEnd(ctx); err != nil {
+		return thrift.PrependError("error writing list end: ", err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:nextRVs: ", p), err)
+	}
+	return err
+}
+
+func (p *PutChunkExRequest) Equals(other *PutChunkExRequest) bool {
+	if p == other {
+		return true
+	} else if p == nil || other == nil {
+		return false
+	}
+	if !p.Request.Equals(other.Request) {
+		return false
+	}
+	if len(p.NextRVs) != len(other.NextRVs) {
+		return false
+	}
+	for i, _tgt := range p.NextRVs {
+		_src17 := other.NextRVs[i]
+		if !_tgt.Equals(_src17) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *PutChunkExRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("PutChunkExRequest(%+v)", *p)
+}
+
+// Attributes:
+//   - Response
+//   - Error
+type PutChunkResponseOrError struct {
+	Response *PutChunkResponse `thrift:"response,1" db:"response" json:"response"`
+	Error    string            `thrift:"error,2" db:"error" json:"error"`
+}
+
+func NewPutChunkResponseOrError() *PutChunkResponseOrError {
+	return &PutChunkResponseOrError{}
+}
+
+var PutChunkResponseOrError_Response_DEFAULT *PutChunkResponse
+
+func (p *PutChunkResponseOrError) GetResponse() *PutChunkResponse {
+	if !p.IsSetResponse() {
+		return PutChunkResponseOrError_Response_DEFAULT
+	}
+	return p.Response
+}
+
+func (p *PutChunkResponseOrError) GetError() string {
+	return p.Error
+}
+func (p *PutChunkResponseOrError) IsSetResponse() bool {
+	return p.Response != nil
+}
+
+func (p *PutChunkResponseOrError) Read(ctx context.Context, iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(ctx); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
 	}
@@ -2635,16 +2817,6 @@ func (p *PutChunkExRequest) Read(ctx context.Context, iprot thrift.TProtocol) er
 					return err
 				}
 			}
-		case 3:
-			if fieldTypeId == thrift.LIST {
-				if err := p.ReadField3(ctx, iprot); err != nil {
-					return err
-				}
-			} else {
-				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
 				return err
@@ -2660,47 +2832,25 @@ func (p *PutChunkExRequest) Read(ctx context.Context, iprot thrift.TProtocol) er
 	return nil
 }
 
-func (p *PutChunkExRequest) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
-	p.Req = &PutChunkRequest{}
-	if err := p.Req.Read(ctx, iprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Req), err)
+func (p *PutChunkResponseOrError) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Response = &PutChunkResponse{}
+	if err := p.Response.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Response), err)
 	}
 	return nil
 }
 
-func (p *PutChunkExRequest) ReadField2(ctx context.Context, iprot thrift.TProtocol) error {
+func (p *PutChunkResponseOrError) ReadField2(ctx context.Context, iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadString(ctx); err != nil {
 		return thrift.PrependError("error reading field 2: ", err)
 	} else {
-		p.LocalRVName = v
+		p.Error = v
 	}
 	return nil
 }
 
-func (p *PutChunkExRequest) ReadField3(ctx context.Context, iprot thrift.TProtocol) error {
-	_, size, err := iprot.ReadListBegin(ctx)
-	if err != nil {
-		return thrift.PrependError("error reading list begin: ", err)
-	}
-	tSlice := make([]string, 0, size)
-	p.NextRVs = tSlice
-	for i := 0; i < size; i++ {
-		var _elem16 string
-		if v, err := iprot.ReadString(ctx); err != nil {
-			return thrift.PrependError("error reading field 0: ", err)
-		} else {
-			_elem16 = v
-		}
-		p.NextRVs = append(p.NextRVs, _elem16)
-	}
-	if err := iprot.ReadListEnd(ctx); err != nil {
-		return thrift.PrependError("error reading list end: ", err)
-	}
-	return nil
-}
-
-func (p *PutChunkExRequest) Write(ctx context.Context, oprot thrift.TProtocol) error {
-	if err := oprot.WriteStructBegin(ctx, "PutChunkExRequest"); err != nil {
+func (p *PutChunkResponseOrError) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "PutChunkResponseOrError"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
 	}
 	if p != nil {
@@ -2708,9 +2858,6 @@ func (p *PutChunkExRequest) Write(ctx context.Context, oprot thrift.TProtocol) e
 			return err
 		}
 		if err := p.writeField2(ctx, oprot); err != nil {
-			return err
-		}
-		if err := p.writeField3(ctx, oprot); err != nil {
 			return err
 		}
 	}
@@ -2723,95 +2870,65 @@ func (p *PutChunkExRequest) Write(ctx context.Context, oprot thrift.TProtocol) e
 	return nil
 }
 
-func (p *PutChunkExRequest) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin(ctx, "req", thrift.STRUCT, 1); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:req: ", p), err)
+func (p *PutChunkResponseOrError) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "response", thrift.STRUCT, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:response: ", p), err)
 	}
-	if err := p.Req.Write(ctx, oprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Req), err)
+	if err := p.Response.Write(ctx, oprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Response), err)
 	}
 	if err := oprot.WriteFieldEnd(ctx); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:req: ", p), err)
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:response: ", p), err)
 	}
 	return err
 }
 
-func (p *PutChunkExRequest) writeField2(ctx context.Context, oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin(ctx, "localRVName", thrift.STRING, 2); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:localRVName: ", p), err)
+func (p *PutChunkResponseOrError) writeField2(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "error", thrift.STRING, 2); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:error: ", p), err)
 	}
-	if err := oprot.WriteString(ctx, string(p.LocalRVName)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.localRVName (2) field write error: ", p), err)
+	if err := oprot.WriteString(ctx, string(p.Error)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.error (2) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(ctx); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:localRVName: ", p), err)
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:error: ", p), err)
 	}
 	return err
 }
 
-func (p *PutChunkExRequest) writeField3(ctx context.Context, oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin(ctx, "nextRVs", thrift.LIST, 3); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:nextRVs: ", p), err)
-	}
-	if err := oprot.WriteListBegin(ctx, thrift.STRING, len(p.NextRVs)); err != nil {
-		return thrift.PrependError("error writing list begin: ", err)
-	}
-	for _, v := range p.NextRVs {
-		if err := oprot.WriteString(ctx, string(v)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
-		}
-	}
-	if err := oprot.WriteListEnd(ctx); err != nil {
-		return thrift.PrependError("error writing list end: ", err)
-	}
-	if err := oprot.WriteFieldEnd(ctx); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:nextRVs: ", p), err)
-	}
-	return err
-}
-
-func (p *PutChunkExRequest) Equals(other *PutChunkExRequest) bool {
+func (p *PutChunkResponseOrError) Equals(other *PutChunkResponseOrError) bool {
 	if p == other {
 		return true
 	} else if p == nil || other == nil {
 		return false
 	}
-	if !p.Req.Equals(other.Req) {
+	if !p.Response.Equals(other.Response) {
 		return false
 	}
-	if p.LocalRVName != other.LocalRVName {
+	if p.Error != other.Error {
 		return false
-	}
-	if len(p.NextRVs) != len(other.NextRVs) {
-		return false
-	}
-	for i, _tgt := range p.NextRVs {
-		_src17 := other.NextRVs[i]
-		if _tgt != _src17 {
-			return false
-		}
 	}
 	return true
 }
 
-func (p *PutChunkExRequest) String() string {
+func (p *PutChunkResponseOrError) String() string {
 	if p == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("PutChunkExRequest(%+v)", *p)
+	return fmt.Sprintf("PutChunkResponseOrError(%+v)", *p)
 }
 
 // Attributes:
 //   - Responses
 type PutChunkExResponse struct {
-	Responses map[string]*PutChunkResponse `thrift:"responses,1" db:"responses" json:"responses"`
+	Responses map[string]*PutChunkResponseOrError `thrift:"responses,1" db:"responses" json:"responses"`
 }
 
 func NewPutChunkExResponse() *PutChunkExResponse {
 	return &PutChunkExResponse{}
 }
 
-func (p *PutChunkExResponse) GetResponses() map[string]*PutChunkResponse {
+func (p *PutChunkExResponse) GetResponses() map[string]*PutChunkResponseOrError {
 	return p.Responses
 }
 func (p *PutChunkExResponse) Read(ctx context.Context, iprot thrift.TProtocol) error {
@@ -2858,7 +2975,7 @@ func (p *PutChunkExResponse) ReadField1(ctx context.Context, iprot thrift.TProto
 	if err != nil {
 		return thrift.PrependError("error reading map begin: ", err)
 	}
-	tMap := make(map[string]*PutChunkResponse, size)
+	tMap := make(map[string]*PutChunkResponseOrError, size)
 	p.Responses = tMap
 	for i := 0; i < size; i++ {
 		var _key18 string
@@ -2867,7 +2984,7 @@ func (p *PutChunkExResponse) ReadField1(ctx context.Context, iprot thrift.TProto
 		} else {
 			_key18 = v
 		}
-		_val19 := &PutChunkResponse{}
+		_val19 := &PutChunkResponseOrError{}
 		if err := _val19.Read(ctx, iprot); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _val19), err)
 		}

--- a/internal/dcache/rpc/gen-go/dcache/service/chunk_service-remote/chunk_service-remote.go
+++ b/internal/dcache/rpc/gen-go/dcache/service/chunk_service-remote/chunk_service-remote.go
@@ -60,6 +60,7 @@ func Usage() {
 	fmt.Fprintln(os.Stderr, "  HelloResponse Hello(HelloRequest request)")
 	fmt.Fprintln(os.Stderr, "  GetChunkResponse GetChunk(GetChunkRequest request)")
 	fmt.Fprintln(os.Stderr, "  PutChunkResponse PutChunk(PutChunkRequest request)")
+	fmt.Fprintln(os.Stderr, "  PutChunkExResponse PutChunkEx(PutChunkExRequest request)")
 	fmt.Fprintln(os.Stderr, "  RemoveChunkResponse RemoveChunk(RemoveChunkRequest request)")
 	fmt.Fprintln(os.Stderr, "  JoinMVResponse JoinMV(JoinMVRequest request)")
 	fmt.Fprintln(os.Stderr, "  UpdateMVResponse UpdateMV(UpdateMVRequest request)")
@@ -194,19 +195,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "Hello requires 1 args")
 			flag.Usage()
 		}
-		arg42 := flag.Arg(1)
-		mbTrans43 := thrift.NewTMemoryBufferLen(len(arg42))
-		defer mbTrans43.Close()
-		_, err44 := mbTrans43.WriteString(arg42)
-		if err44 != nil {
+		arg46 := flag.Arg(1)
+		mbTrans47 := thrift.NewTMemoryBufferLen(len(arg46))
+		defer mbTrans47.Close()
+		_, err48 := mbTrans47.WriteString(arg46)
+		if err48 != nil {
 			Usage()
 			return
 		}
-		factory45 := thrift.NewTJSONProtocolFactory()
-		jsProt46 := factory45.GetProtocol(mbTrans43)
+		factory49 := thrift.NewTJSONProtocolFactory()
+		jsProt50 := factory49.GetProtocol(mbTrans47)
 		argvalue0 := models.NewHelloRequest()
-		err47 := argvalue0.Read(context.Background(), jsProt46)
-		if err47 != nil {
+		err51 := argvalue0.Read(context.Background(), jsProt50)
+		if err51 != nil {
 			Usage()
 			return
 		}
@@ -219,19 +220,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetChunk requires 1 args")
 			flag.Usage()
 		}
-		arg48 := flag.Arg(1)
-		mbTrans49 := thrift.NewTMemoryBufferLen(len(arg48))
-		defer mbTrans49.Close()
-		_, err50 := mbTrans49.WriteString(arg48)
-		if err50 != nil {
+		arg52 := flag.Arg(1)
+		mbTrans53 := thrift.NewTMemoryBufferLen(len(arg52))
+		defer mbTrans53.Close()
+		_, err54 := mbTrans53.WriteString(arg52)
+		if err54 != nil {
 			Usage()
 			return
 		}
-		factory51 := thrift.NewTJSONProtocolFactory()
-		jsProt52 := factory51.GetProtocol(mbTrans49)
+		factory55 := thrift.NewTJSONProtocolFactory()
+		jsProt56 := factory55.GetProtocol(mbTrans53)
 		argvalue0 := models.NewGetChunkRequest()
-		err53 := argvalue0.Read(context.Background(), jsProt52)
-		if err53 != nil {
+		err57 := argvalue0.Read(context.Background(), jsProt56)
+		if err57 != nil {
 			Usage()
 			return
 		}
@@ -244,19 +245,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "PutChunk requires 1 args")
 			flag.Usage()
 		}
-		arg54 := flag.Arg(1)
-		mbTrans55 := thrift.NewTMemoryBufferLen(len(arg54))
-		defer mbTrans55.Close()
-		_, err56 := mbTrans55.WriteString(arg54)
-		if err56 != nil {
+		arg58 := flag.Arg(1)
+		mbTrans59 := thrift.NewTMemoryBufferLen(len(arg58))
+		defer mbTrans59.Close()
+		_, err60 := mbTrans59.WriteString(arg58)
+		if err60 != nil {
 			Usage()
 			return
 		}
-		factory57 := thrift.NewTJSONProtocolFactory()
-		jsProt58 := factory57.GetProtocol(mbTrans55)
+		factory61 := thrift.NewTJSONProtocolFactory()
+		jsProt62 := factory61.GetProtocol(mbTrans59)
 		argvalue0 := models.NewPutChunkRequest()
-		err59 := argvalue0.Read(context.Background(), jsProt58)
-		if err59 != nil {
+		err63 := argvalue0.Read(context.Background(), jsProt62)
+		if err63 != nil {
 			Usage()
 			return
 		}
@@ -264,24 +265,49 @@ func main() {
 		fmt.Print(client.PutChunk(context.Background(), value0))
 		fmt.Print("\n")
 		break
+	case "PutChunkEx":
+		if flag.NArg()-1 != 1 {
+			fmt.Fprintln(os.Stderr, "PutChunkEx requires 1 args")
+			flag.Usage()
+		}
+		arg64 := flag.Arg(1)
+		mbTrans65 := thrift.NewTMemoryBufferLen(len(arg64))
+		defer mbTrans65.Close()
+		_, err66 := mbTrans65.WriteString(arg64)
+		if err66 != nil {
+			Usage()
+			return
+		}
+		factory67 := thrift.NewTJSONProtocolFactory()
+		jsProt68 := factory67.GetProtocol(mbTrans65)
+		argvalue0 := models.NewPutChunkExRequest()
+		err69 := argvalue0.Read(context.Background(), jsProt68)
+		if err69 != nil {
+			Usage()
+			return
+		}
+		value0 := argvalue0
+		fmt.Print(client.PutChunkEx(context.Background(), value0))
+		fmt.Print("\n")
+		break
 	case "RemoveChunk":
 		if flag.NArg()-1 != 1 {
 			fmt.Fprintln(os.Stderr, "RemoveChunk requires 1 args")
 			flag.Usage()
 		}
-		arg60 := flag.Arg(1)
-		mbTrans61 := thrift.NewTMemoryBufferLen(len(arg60))
-		defer mbTrans61.Close()
-		_, err62 := mbTrans61.WriteString(arg60)
-		if err62 != nil {
+		arg70 := flag.Arg(1)
+		mbTrans71 := thrift.NewTMemoryBufferLen(len(arg70))
+		defer mbTrans71.Close()
+		_, err72 := mbTrans71.WriteString(arg70)
+		if err72 != nil {
 			Usage()
 			return
 		}
-		factory63 := thrift.NewTJSONProtocolFactory()
-		jsProt64 := factory63.GetProtocol(mbTrans61)
+		factory73 := thrift.NewTJSONProtocolFactory()
+		jsProt74 := factory73.GetProtocol(mbTrans71)
 		argvalue0 := models.NewRemoveChunkRequest()
-		err65 := argvalue0.Read(context.Background(), jsProt64)
-		if err65 != nil {
+		err75 := argvalue0.Read(context.Background(), jsProt74)
+		if err75 != nil {
 			Usage()
 			return
 		}
@@ -294,19 +320,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "JoinMV requires 1 args")
 			flag.Usage()
 		}
-		arg66 := flag.Arg(1)
-		mbTrans67 := thrift.NewTMemoryBufferLen(len(arg66))
-		defer mbTrans67.Close()
-		_, err68 := mbTrans67.WriteString(arg66)
-		if err68 != nil {
+		arg76 := flag.Arg(1)
+		mbTrans77 := thrift.NewTMemoryBufferLen(len(arg76))
+		defer mbTrans77.Close()
+		_, err78 := mbTrans77.WriteString(arg76)
+		if err78 != nil {
 			Usage()
 			return
 		}
-		factory69 := thrift.NewTJSONProtocolFactory()
-		jsProt70 := factory69.GetProtocol(mbTrans67)
+		factory79 := thrift.NewTJSONProtocolFactory()
+		jsProt80 := factory79.GetProtocol(mbTrans77)
 		argvalue0 := models.NewJoinMVRequest()
-		err71 := argvalue0.Read(context.Background(), jsProt70)
-		if err71 != nil {
+		err81 := argvalue0.Read(context.Background(), jsProt80)
+		if err81 != nil {
 			Usage()
 			return
 		}
@@ -319,19 +345,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "UpdateMV requires 1 args")
 			flag.Usage()
 		}
-		arg72 := flag.Arg(1)
-		mbTrans73 := thrift.NewTMemoryBufferLen(len(arg72))
-		defer mbTrans73.Close()
-		_, err74 := mbTrans73.WriteString(arg72)
-		if err74 != nil {
+		arg82 := flag.Arg(1)
+		mbTrans83 := thrift.NewTMemoryBufferLen(len(arg82))
+		defer mbTrans83.Close()
+		_, err84 := mbTrans83.WriteString(arg82)
+		if err84 != nil {
 			Usage()
 			return
 		}
-		factory75 := thrift.NewTJSONProtocolFactory()
-		jsProt76 := factory75.GetProtocol(mbTrans73)
+		factory85 := thrift.NewTJSONProtocolFactory()
+		jsProt86 := factory85.GetProtocol(mbTrans83)
 		argvalue0 := models.NewUpdateMVRequest()
-		err77 := argvalue0.Read(context.Background(), jsProt76)
-		if err77 != nil {
+		err87 := argvalue0.Read(context.Background(), jsProt86)
+		if err87 != nil {
 			Usage()
 			return
 		}
@@ -344,19 +370,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "LeaveMV requires 1 args")
 			flag.Usage()
 		}
-		arg78 := flag.Arg(1)
-		mbTrans79 := thrift.NewTMemoryBufferLen(len(arg78))
-		defer mbTrans79.Close()
-		_, err80 := mbTrans79.WriteString(arg78)
-		if err80 != nil {
+		arg88 := flag.Arg(1)
+		mbTrans89 := thrift.NewTMemoryBufferLen(len(arg88))
+		defer mbTrans89.Close()
+		_, err90 := mbTrans89.WriteString(arg88)
+		if err90 != nil {
 			Usage()
 			return
 		}
-		factory81 := thrift.NewTJSONProtocolFactory()
-		jsProt82 := factory81.GetProtocol(mbTrans79)
+		factory91 := thrift.NewTJSONProtocolFactory()
+		jsProt92 := factory91.GetProtocol(mbTrans89)
 		argvalue0 := models.NewLeaveMVRequest()
-		err83 := argvalue0.Read(context.Background(), jsProt82)
-		if err83 != nil {
+		err93 := argvalue0.Read(context.Background(), jsProt92)
+		if err93 != nil {
 			Usage()
 			return
 		}
@@ -369,19 +395,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "StartSync requires 1 args")
 			flag.Usage()
 		}
-		arg84 := flag.Arg(1)
-		mbTrans85 := thrift.NewTMemoryBufferLen(len(arg84))
-		defer mbTrans85.Close()
-		_, err86 := mbTrans85.WriteString(arg84)
-		if err86 != nil {
+		arg94 := flag.Arg(1)
+		mbTrans95 := thrift.NewTMemoryBufferLen(len(arg94))
+		defer mbTrans95.Close()
+		_, err96 := mbTrans95.WriteString(arg94)
+		if err96 != nil {
 			Usage()
 			return
 		}
-		factory87 := thrift.NewTJSONProtocolFactory()
-		jsProt88 := factory87.GetProtocol(mbTrans85)
+		factory97 := thrift.NewTJSONProtocolFactory()
+		jsProt98 := factory97.GetProtocol(mbTrans95)
 		argvalue0 := models.NewStartSyncRequest()
-		err89 := argvalue0.Read(context.Background(), jsProt88)
-		if err89 != nil {
+		err99 := argvalue0.Read(context.Background(), jsProt98)
+		if err99 != nil {
 			Usage()
 			return
 		}
@@ -394,19 +420,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "EndSync requires 1 args")
 			flag.Usage()
 		}
-		arg90 := flag.Arg(1)
-		mbTrans91 := thrift.NewTMemoryBufferLen(len(arg90))
-		defer mbTrans91.Close()
-		_, err92 := mbTrans91.WriteString(arg90)
-		if err92 != nil {
+		arg100 := flag.Arg(1)
+		mbTrans101 := thrift.NewTMemoryBufferLen(len(arg100))
+		defer mbTrans101.Close()
+		_, err102 := mbTrans101.WriteString(arg100)
+		if err102 != nil {
 			Usage()
 			return
 		}
-		factory93 := thrift.NewTJSONProtocolFactory()
-		jsProt94 := factory93.GetProtocol(mbTrans91)
+		factory103 := thrift.NewTJSONProtocolFactory()
+		jsProt104 := factory103.GetProtocol(mbTrans101)
 		argvalue0 := models.NewEndSyncRequest()
-		err95 := argvalue0.Read(context.Background(), jsProt94)
-		if err95 != nil {
+		err105 := argvalue0.Read(context.Background(), jsProt104)
+		if err105 != nil {
 			Usage()
 			return
 		}
@@ -419,19 +445,19 @@ func main() {
 			fmt.Fprintln(os.Stderr, "GetMVSize requires 1 args")
 			flag.Usage()
 		}
-		arg96 := flag.Arg(1)
-		mbTrans97 := thrift.NewTMemoryBufferLen(len(arg96))
-		defer mbTrans97.Close()
-		_, err98 := mbTrans97.WriteString(arg96)
-		if err98 != nil {
+		arg106 := flag.Arg(1)
+		mbTrans107 := thrift.NewTMemoryBufferLen(len(arg106))
+		defer mbTrans107.Close()
+		_, err108 := mbTrans107.WriteString(arg106)
+		if err108 != nil {
 			Usage()
 			return
 		}
-		factory99 := thrift.NewTJSONProtocolFactory()
-		jsProt100 := factory99.GetProtocol(mbTrans97)
+		factory109 := thrift.NewTJSONProtocolFactory()
+		jsProt110 := factory109.GetProtocol(mbTrans107)
 		argvalue0 := models.NewGetMVSizeRequest()
-		err101 := argvalue0.Read(context.Background(), jsProt100)
-		if err101 != nil {
+		err111 := argvalue0.Read(context.Background(), jsProt110)
+		if err111 != nil {
 			Usage()
 			return
 		}

--- a/internal/dcache/rpc/gen-go/dcache/service/service.go
+++ b/internal/dcache/rpc/gen-go/dcache/service/service.go
@@ -65,6 +65,9 @@ type ChunkService interface {
 	PutChunk(ctx context.Context, request *models.PutChunkRequest) (_r *models.PutChunkResponse, _err error)
 	// Parameters:
 	//  - Request
+	PutChunkEx(ctx context.Context, request *models.PutChunkExRequest) (_r *models.PutChunkExResponse, _err error)
+	// Parameters:
+	//  - Request
 	RemoveChunk(ctx context.Context, request *models.RemoveChunkRequest) (_r *models.RemoveChunkResponse, _err error)
 	// Parameters:
 	//  - Request
@@ -192,12 +195,12 @@ func (p *ChunkServiceClient) PutChunk(ctx context.Context, request *models.PutCh
 
 // Parameters:
 //   - Request
-func (p *ChunkServiceClient) RemoveChunk(ctx context.Context, request *models.RemoveChunkRequest) (_r *models.RemoveChunkResponse, _err error) {
-	var _args12 ChunkServiceRemoveChunkArgs
+func (p *ChunkServiceClient) PutChunkEx(ctx context.Context, request *models.PutChunkExRequest) (_r *models.PutChunkExResponse, _err error) {
+	var _args12 ChunkServicePutChunkExArgs
 	_args12.Request = request
-	var _result14 ChunkServiceRemoveChunkResult
+	var _result14 ChunkServicePutChunkExResult
 	var _meta13 thrift.ResponseMeta
-	_meta13, _err = p.Client_().Call(ctx, "RemoveChunk", &_args12, &_result14)
+	_meta13, _err = p.Client_().Call(ctx, "PutChunkEx", &_args12, &_result14)
 	p.SetLastResponseMeta_(_meta13)
 	if _err != nil {
 		return
@@ -210,17 +213,17 @@ func (p *ChunkServiceClient) RemoveChunk(ctx context.Context, request *models.Re
 	if _ret15 := _result14.GetSuccess(); _ret15 != nil {
 		return _ret15, nil
 	}
-	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "RemoveChunk failed: unknown result")
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "PutChunkEx failed: unknown result")
 }
 
 // Parameters:
 //   - Request
-func (p *ChunkServiceClient) JoinMV(ctx context.Context, request *models.JoinMVRequest) (_r *models.JoinMVResponse, _err error) {
-	var _args16 ChunkServiceJoinMVArgs
+func (p *ChunkServiceClient) RemoveChunk(ctx context.Context, request *models.RemoveChunkRequest) (_r *models.RemoveChunkResponse, _err error) {
+	var _args16 ChunkServiceRemoveChunkArgs
 	_args16.Request = request
-	var _result18 ChunkServiceJoinMVResult
+	var _result18 ChunkServiceRemoveChunkResult
 	var _meta17 thrift.ResponseMeta
-	_meta17, _err = p.Client_().Call(ctx, "JoinMV", &_args16, &_result18)
+	_meta17, _err = p.Client_().Call(ctx, "RemoveChunk", &_args16, &_result18)
 	p.SetLastResponseMeta_(_meta17)
 	if _err != nil {
 		return
@@ -233,17 +236,17 @@ func (p *ChunkServiceClient) JoinMV(ctx context.Context, request *models.JoinMVR
 	if _ret19 := _result18.GetSuccess(); _ret19 != nil {
 		return _ret19, nil
 	}
-	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "JoinMV failed: unknown result")
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "RemoveChunk failed: unknown result")
 }
 
 // Parameters:
 //   - Request
-func (p *ChunkServiceClient) UpdateMV(ctx context.Context, request *models.UpdateMVRequest) (_r *models.UpdateMVResponse, _err error) {
-	var _args20 ChunkServiceUpdateMVArgs
+func (p *ChunkServiceClient) JoinMV(ctx context.Context, request *models.JoinMVRequest) (_r *models.JoinMVResponse, _err error) {
+	var _args20 ChunkServiceJoinMVArgs
 	_args20.Request = request
-	var _result22 ChunkServiceUpdateMVResult
+	var _result22 ChunkServiceJoinMVResult
 	var _meta21 thrift.ResponseMeta
-	_meta21, _err = p.Client_().Call(ctx, "UpdateMV", &_args20, &_result22)
+	_meta21, _err = p.Client_().Call(ctx, "JoinMV", &_args20, &_result22)
 	p.SetLastResponseMeta_(_meta21)
 	if _err != nil {
 		return
@@ -256,17 +259,17 @@ func (p *ChunkServiceClient) UpdateMV(ctx context.Context, request *models.Updat
 	if _ret23 := _result22.GetSuccess(); _ret23 != nil {
 		return _ret23, nil
 	}
-	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "UpdateMV failed: unknown result")
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "JoinMV failed: unknown result")
 }
 
 // Parameters:
 //   - Request
-func (p *ChunkServiceClient) LeaveMV(ctx context.Context, request *models.LeaveMVRequest) (_r *models.LeaveMVResponse, _err error) {
-	var _args24 ChunkServiceLeaveMVArgs
+func (p *ChunkServiceClient) UpdateMV(ctx context.Context, request *models.UpdateMVRequest) (_r *models.UpdateMVResponse, _err error) {
+	var _args24 ChunkServiceUpdateMVArgs
 	_args24.Request = request
-	var _result26 ChunkServiceLeaveMVResult
+	var _result26 ChunkServiceUpdateMVResult
 	var _meta25 thrift.ResponseMeta
-	_meta25, _err = p.Client_().Call(ctx, "LeaveMV", &_args24, &_result26)
+	_meta25, _err = p.Client_().Call(ctx, "UpdateMV", &_args24, &_result26)
 	p.SetLastResponseMeta_(_meta25)
 	if _err != nil {
 		return
@@ -279,17 +282,17 @@ func (p *ChunkServiceClient) LeaveMV(ctx context.Context, request *models.LeaveM
 	if _ret27 := _result26.GetSuccess(); _ret27 != nil {
 		return _ret27, nil
 	}
-	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "LeaveMV failed: unknown result")
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "UpdateMV failed: unknown result")
 }
 
 // Parameters:
 //   - Request
-func (p *ChunkServiceClient) StartSync(ctx context.Context, request *models.StartSyncRequest) (_r *models.StartSyncResponse, _err error) {
-	var _args28 ChunkServiceStartSyncArgs
+func (p *ChunkServiceClient) LeaveMV(ctx context.Context, request *models.LeaveMVRequest) (_r *models.LeaveMVResponse, _err error) {
+	var _args28 ChunkServiceLeaveMVArgs
 	_args28.Request = request
-	var _result30 ChunkServiceStartSyncResult
+	var _result30 ChunkServiceLeaveMVResult
 	var _meta29 thrift.ResponseMeta
-	_meta29, _err = p.Client_().Call(ctx, "StartSync", &_args28, &_result30)
+	_meta29, _err = p.Client_().Call(ctx, "LeaveMV", &_args28, &_result30)
 	p.SetLastResponseMeta_(_meta29)
 	if _err != nil {
 		return
@@ -302,17 +305,17 @@ func (p *ChunkServiceClient) StartSync(ctx context.Context, request *models.Star
 	if _ret31 := _result30.GetSuccess(); _ret31 != nil {
 		return _ret31, nil
 	}
-	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "StartSync failed: unknown result")
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "LeaveMV failed: unknown result")
 }
 
 // Parameters:
 //   - Request
-func (p *ChunkServiceClient) EndSync(ctx context.Context, request *models.EndSyncRequest) (_r *models.EndSyncResponse, _err error) {
-	var _args32 ChunkServiceEndSyncArgs
+func (p *ChunkServiceClient) StartSync(ctx context.Context, request *models.StartSyncRequest) (_r *models.StartSyncResponse, _err error) {
+	var _args32 ChunkServiceStartSyncArgs
 	_args32.Request = request
-	var _result34 ChunkServiceEndSyncResult
+	var _result34 ChunkServiceStartSyncResult
 	var _meta33 thrift.ResponseMeta
-	_meta33, _err = p.Client_().Call(ctx, "EndSync", &_args32, &_result34)
+	_meta33, _err = p.Client_().Call(ctx, "StartSync", &_args32, &_result34)
 	p.SetLastResponseMeta_(_meta33)
 	if _err != nil {
 		return
@@ -325,17 +328,17 @@ func (p *ChunkServiceClient) EndSync(ctx context.Context, request *models.EndSyn
 	if _ret35 := _result34.GetSuccess(); _ret35 != nil {
 		return _ret35, nil
 	}
-	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "EndSync failed: unknown result")
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "StartSync failed: unknown result")
 }
 
 // Parameters:
 //   - Request
-func (p *ChunkServiceClient) GetMVSize(ctx context.Context, request *models.GetMVSizeRequest) (_r *models.GetMVSizeResponse, _err error) {
-	var _args36 ChunkServiceGetMVSizeArgs
+func (p *ChunkServiceClient) EndSync(ctx context.Context, request *models.EndSyncRequest) (_r *models.EndSyncResponse, _err error) {
+	var _args36 ChunkServiceEndSyncArgs
 	_args36.Request = request
-	var _result38 ChunkServiceGetMVSizeResult
+	var _result38 ChunkServiceEndSyncResult
 	var _meta37 thrift.ResponseMeta
-	_meta37, _err = p.Client_().Call(ctx, "GetMVSize", &_args36, &_result38)
+	_meta37, _err = p.Client_().Call(ctx, "EndSync", &_args36, &_result38)
 	p.SetLastResponseMeta_(_meta37)
 	if _err != nil {
 		return
@@ -347,6 +350,29 @@ func (p *ChunkServiceClient) GetMVSize(ctx context.Context, request *models.GetM
 
 	if _ret39 := _result38.GetSuccess(); _ret39 != nil {
 		return _ret39, nil
+	}
+	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "EndSync failed: unknown result")
+}
+
+// Parameters:
+//   - Request
+func (p *ChunkServiceClient) GetMVSize(ctx context.Context, request *models.GetMVSizeRequest) (_r *models.GetMVSizeResponse, _err error) {
+	var _args40 ChunkServiceGetMVSizeArgs
+	_args40.Request = request
+	var _result42 ChunkServiceGetMVSizeResult
+	var _meta41 thrift.ResponseMeta
+	_meta41, _err = p.Client_().Call(ctx, "GetMVSize", &_args40, &_result42)
+	p.SetLastResponseMeta_(_meta41)
+	if _err != nil {
+		return
+	}
+	switch {
+	case _result42.Err != nil:
+		return _r, _result42.Err
+	}
+
+	if _ret43 := _result42.GetSuccess(); _ret43 != nil {
+		return _ret43, nil
 	}
 	return nil, thrift.NewTApplicationException(thrift.MISSING_RESULT, "GetMVSize failed: unknown result")
 }
@@ -371,18 +397,19 @@ func (p *ChunkServiceProcessor) ProcessorMap() map[string]thrift.TProcessorFunct
 
 func NewChunkServiceProcessor(handler ChunkService) *ChunkServiceProcessor {
 
-	self40 := &ChunkServiceProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self40.processorMap["Hello"] = &chunkServiceProcessorHello{handler: handler}
-	self40.processorMap["GetChunk"] = &chunkServiceProcessorGetChunk{handler: handler}
-	self40.processorMap["PutChunk"] = &chunkServiceProcessorPutChunk{handler: handler}
-	self40.processorMap["RemoveChunk"] = &chunkServiceProcessorRemoveChunk{handler: handler}
-	self40.processorMap["JoinMV"] = &chunkServiceProcessorJoinMV{handler: handler}
-	self40.processorMap["UpdateMV"] = &chunkServiceProcessorUpdateMV{handler: handler}
-	self40.processorMap["LeaveMV"] = &chunkServiceProcessorLeaveMV{handler: handler}
-	self40.processorMap["StartSync"] = &chunkServiceProcessorStartSync{handler: handler}
-	self40.processorMap["EndSync"] = &chunkServiceProcessorEndSync{handler: handler}
-	self40.processorMap["GetMVSize"] = &chunkServiceProcessorGetMVSize{handler: handler}
-	return self40
+	self44 := &ChunkServiceProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
+	self44.processorMap["Hello"] = &chunkServiceProcessorHello{handler: handler}
+	self44.processorMap["GetChunk"] = &chunkServiceProcessorGetChunk{handler: handler}
+	self44.processorMap["PutChunk"] = &chunkServiceProcessorPutChunk{handler: handler}
+	self44.processorMap["PutChunkEx"] = &chunkServiceProcessorPutChunkEx{handler: handler}
+	self44.processorMap["RemoveChunk"] = &chunkServiceProcessorRemoveChunk{handler: handler}
+	self44.processorMap["JoinMV"] = &chunkServiceProcessorJoinMV{handler: handler}
+	self44.processorMap["UpdateMV"] = &chunkServiceProcessorUpdateMV{handler: handler}
+	self44.processorMap["LeaveMV"] = &chunkServiceProcessorLeaveMV{handler: handler}
+	self44.processorMap["StartSync"] = &chunkServiceProcessorStartSync{handler: handler}
+	self44.processorMap["EndSync"] = &chunkServiceProcessorEndSync{handler: handler}
+	self44.processorMap["GetMVSize"] = &chunkServiceProcessorGetMVSize{handler: handler}
+	return self44
 }
 
 func (p *ChunkServiceProcessor) Process(ctx context.Context, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
@@ -395,12 +422,12 @@ func (p *ChunkServiceProcessor) Process(ctx context.Context, iprot, oprot thrift
 	}
 	iprot.Skip(ctx, thrift.STRUCT)
 	iprot.ReadMessageEnd(ctx)
-	x41 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
+	x45 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
 	oprot.WriteMessageBegin(ctx, name, thrift.EXCEPTION, seqId)
-	x41.Write(ctx, oprot)
+	x45.Write(ctx, oprot)
 	oprot.WriteMessageEnd(ctx)
 	oprot.Flush(ctx)
-	return false, x41
+	return false, x45
 
 }
 
@@ -639,6 +666,90 @@ func (p *chunkServiceProcessorPutChunk) Process(ctx context.Context, seqId int32
 	}
 	tickerCancel()
 	if err2 = oprot.WriteMessageBegin(ctx, "PutChunk", thrift.REPLY, seqId); err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err2 = result.Write(ctx, oprot); err == nil && err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err2 = oprot.WriteMessageEnd(ctx); err == nil && err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err2 = oprot.Flush(ctx); err == nil && err2 != nil {
+		err = thrift.WrapTException(err2)
+	}
+	if err != nil {
+		return
+	}
+	return true, err
+}
+
+type chunkServiceProcessorPutChunkEx struct {
+	handler ChunkService
+}
+
+func (p *chunkServiceProcessorPutChunkEx) Process(ctx context.Context, seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+	args := ChunkServicePutChunkExArgs{}
+	var err2 error
+	if err2 = args.Read(ctx, iprot); err2 != nil {
+		iprot.ReadMessageEnd(ctx)
+		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err2.Error())
+		oprot.WriteMessageBegin(ctx, "PutChunkEx", thrift.EXCEPTION, seqId)
+		x.Write(ctx, oprot)
+		oprot.WriteMessageEnd(ctx)
+		oprot.Flush(ctx)
+		return false, thrift.WrapTException(err2)
+	}
+	iprot.ReadMessageEnd(ctx)
+
+	tickerCancel := func() {}
+	// Start a goroutine to do server side connectivity check.
+	if thrift.ServerConnectivityCheckInterval > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
+		var tickerCtx context.Context
+		tickerCtx, tickerCancel = context.WithCancel(context.Background())
+		defer tickerCancel()
+		go func(ctx context.Context, cancel context.CancelFunc) {
+			ticker := time.NewTicker(thrift.ServerConnectivityCheckInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if !iprot.Transport().IsOpen() {
+						cancel()
+						return
+					}
+				}
+			}
+		}(tickerCtx, cancel)
+	}
+
+	result := ChunkServicePutChunkExResult{}
+	var retval *models.PutChunkExResponse
+	if retval, err2 = p.handler.PutChunkEx(ctx, args.Request); err2 != nil {
+		tickerCancel()
+		switch v := err2.(type) {
+		case *models.ResponseError:
+			result.Err = v
+		default:
+			if err2 == thrift.ErrAbandonRequest {
+				return false, thrift.WrapTException(err2)
+			}
+			x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing PutChunkEx: "+err2.Error())
+			oprot.WriteMessageBegin(ctx, "PutChunkEx", thrift.EXCEPTION, seqId)
+			x.Write(ctx, oprot)
+			oprot.WriteMessageEnd(ctx)
+			oprot.Flush(ctx)
+			return true, thrift.WrapTException(err2)
+		}
+	} else {
+		result.Success = retval
+	}
+	tickerCancel()
+	if err2 = oprot.WriteMessageBegin(ctx, "PutChunkEx", thrift.REPLY, seqId); err2 != nil {
 		err = thrift.WrapTException(err2)
 	}
 	if err2 = result.Write(ctx, oprot); err == nil && err2 != nil {
@@ -2045,6 +2156,273 @@ func (p *ChunkServicePutChunkResult) String() string {
 		return "<nil>"
 	}
 	return fmt.Sprintf("ChunkServicePutChunkResult(%+v)", *p)
+}
+
+// Attributes:
+//   - Request
+type ChunkServicePutChunkExArgs struct {
+	Request *models.PutChunkExRequest `thrift:"request,1" db:"request" json:"request"`
+}
+
+func NewChunkServicePutChunkExArgs() *ChunkServicePutChunkExArgs {
+	return &ChunkServicePutChunkExArgs{}
+}
+
+var ChunkServicePutChunkExArgs_Request_DEFAULT *models.PutChunkExRequest
+
+func (p *ChunkServicePutChunkExArgs) GetRequest() *models.PutChunkExRequest {
+	if !p.IsSetRequest() {
+		return ChunkServicePutChunkExArgs_Request_DEFAULT
+	}
+	return p.Request
+}
+func (p *ChunkServicePutChunkExArgs) IsSetRequest() bool {
+	return p.Request != nil
+}
+
+func (p *ChunkServicePutChunkExArgs) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *ChunkServicePutChunkExArgs) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Request = &models.PutChunkExRequest{}
+	if err := p.Request.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Request), err)
+	}
+	return nil
+}
+
+func (p *ChunkServicePutChunkExArgs) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "PutChunkEx_args"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *ChunkServicePutChunkExArgs) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "request", thrift.STRUCT, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:request: ", p), err)
+	}
+	if err := p.Request.Write(ctx, oprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Request), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:request: ", p), err)
+	}
+	return err
+}
+
+func (p *ChunkServicePutChunkExArgs) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("ChunkServicePutChunkExArgs(%+v)", *p)
+}
+
+// Attributes:
+//   - Success
+//   - Err
+type ChunkServicePutChunkExResult struct {
+	Success *models.PutChunkExResponse `thrift:"success,0" db:"success" json:"success,omitempty"`
+	Err     *models.ResponseError      `thrift:"err,1" db:"err" json:"err,omitempty"`
+}
+
+func NewChunkServicePutChunkExResult() *ChunkServicePutChunkExResult {
+	return &ChunkServicePutChunkExResult{}
+}
+
+var ChunkServicePutChunkExResult_Success_DEFAULT *models.PutChunkExResponse
+
+func (p *ChunkServicePutChunkExResult) GetSuccess() *models.PutChunkExResponse {
+	if !p.IsSetSuccess() {
+		return ChunkServicePutChunkExResult_Success_DEFAULT
+	}
+	return p.Success
+}
+
+var ChunkServicePutChunkExResult_Err_DEFAULT *models.ResponseError
+
+func (p *ChunkServicePutChunkExResult) GetErr() *models.ResponseError {
+	if !p.IsSetErr() {
+		return ChunkServicePutChunkExResult_Err_DEFAULT
+	}
+	return p.Err
+}
+func (p *ChunkServicePutChunkExResult) IsSetSuccess() bool {
+	return p.Success != nil
+}
+
+func (p *ChunkServicePutChunkExResult) IsSetErr() bool {
+	return p.Err != nil
+}
+
+func (p *ChunkServicePutChunkExResult) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField0(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *ChunkServicePutChunkExResult) ReadField0(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Success = &models.PutChunkExResponse{}
+	if err := p.Success.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Success), err)
+	}
+	return nil
+}
+
+func (p *ChunkServicePutChunkExResult) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	p.Err = &models.ResponseError{}
+	if err := p.Err.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Err), err)
+	}
+	return nil
+}
+
+func (p *ChunkServicePutChunkExResult) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "PutChunkEx_result"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField0(ctx, oprot); err != nil {
+			return err
+		}
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *ChunkServicePutChunkExResult) writeField0(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if p.IsSetSuccess() {
+		if err := oprot.WriteFieldBegin(ctx, "success", thrift.STRUCT, 0); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 0:success: ", p), err)
+		}
+		if err := p.Success.Write(ctx, oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Success), err)
+		}
+		if err := oprot.WriteFieldEnd(ctx); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 0:success: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *ChunkServicePutChunkExResult) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if p.IsSetErr() {
+		if err := oprot.WriteFieldBegin(ctx, "err", thrift.STRUCT, 1); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:err: ", p), err)
+		}
+		if err := p.Err.Write(ctx, oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Err), err)
+		}
+		if err := oprot.WriteFieldEnd(ctx); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:err: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *ChunkServicePutChunkExResult) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("ChunkServicePutChunkExResult(%+v)", *p)
 }
 
 // Attributes:

--- a/internal/dcache/rpc/models.thrift
+++ b/internal/dcache/rpc/models.thrift
@@ -64,6 +64,16 @@ struct PutChunkResponse {
     3: list<RVNameAndState> componentRV
 }
 
+struct PutChunkExRequest {
+    1: PutChunkRequest req,
+    2: string localRVName,
+    3: list<string> nextRVs
+}
+
+struct PutChunkExResponse {
+    1: map<string, PutChunkResponse> responses // map of RV name to the PutChunk response to that RV
+}
+
 struct RemoveChunkRequest {
     1: string senderNodeID,
     2: Address address,

--- a/internal/dcache/rpc/models.thrift
+++ b/internal/dcache/rpc/models.thrift
@@ -72,7 +72,7 @@ struct PutChunkExRequest {
 // Type for the individual PutChunkResponse or error.
 struct PutChunkResponseOrError {
     1: PutChunkResponse response,
-    2: string error
+    2: ResponseError error
 }
 
 struct PutChunkExResponse {
@@ -173,7 +173,8 @@ enum ErrorCode {
     ChunkNotFound = 5,
     ChunkAlreadyExists = 6,
     MaxMVsExceeded = 7,
-    NeedToRefreshClusterMap = 8
+    NeedToRefreshClusterMap = 8,
+    ThriftError = 9
 }
 
 // Custom error returned by the RPC APIs

--- a/internal/dcache/rpc/models.thrift
+++ b/internal/dcache/rpc/models.thrift
@@ -65,13 +65,18 @@ struct PutChunkResponse {
 }
 
 struct PutChunkExRequest {
-    1: PutChunkRequest req,
-    2: string localRVName,
-    3: list<string> nextRVs
+    1: PutChunkRequest request,
+    2: list<RVNameAndState> nextRVs
+}
+
+// Type for the individual PutChunkResponse or error.
+struct PutChunkResponseOrError {
+    1: PutChunkResponse response,
+    2: string error
 }
 
 struct PutChunkExResponse {
-    1: map<string, PutChunkResponse> responses // map of RV name to the PutChunk response to that RV
+    1: map<string, PutChunkResponseOrError> responses // map of RV name to the PutChunk response or error to that RV
 }
 
 struct RemoveChunkRequest {

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -2049,15 +2049,15 @@ func (h *ChunkServiceHandler) forwardPutChunk(ctx context.Context, req *models.P
 			MaybeOverwrite: req.MaybeOverwrite,
 		}
 
-		putChunkExRequest := &models.PutChunkExRequest{
+		putChunkExReq := &models.PutChunkExRequest{
 			Request: putChunkReq,
 			NextRVs: nextRVs,
 		}
 
 		log.Debug("ChunkServiceHandler::forwardPutChunk: Forwarding PutChunkEx request for %s/%s to node %s: %v",
-			currRV.Name, req.Chunk.Address.MvName, targetNodeID, rpc.PutChunkExRequestToString(putChunkExRequest))
+			currRV.Name, req.Chunk.Address.MvName, targetNodeID, rpc.PutChunkExRequestToString(putChunkExReq))
 
-		rpcResp, err = rpc_client.PutChunkEx(ctx, targetNodeID, putChunkExRequest)
+		rpcResp, err = rpc_client.PutChunkEx(ctx, targetNodeID, putChunkExReq)
 
 		//
 		// If the PutChunkEx RPC call fails, the error returned can be,
@@ -2075,7 +2075,7 @@ func (h *ChunkServiceHandler) forwardPutChunk(ctx context.Context, req *models.P
 			if rpcErr == nil {
 				//
 				// This error indicates some Thrift error like connection error, timeout, etc. or,
-				// it could be an RPC client side error like failed to get RPC client for node.
+				// it could be an RPC client side error like failed to get RPC client for target node.
 				// We wrap this error in *models.ResponseError with code ThriftError.
 				// This is to ensure that the client can take appropriate action based on this error code.
 				//
@@ -2096,7 +2096,7 @@ func (h *ChunkServiceHandler) forwardPutChunk(ctx context.Context, req *models.P
 			common.Assert(rpcResp1.Responses != nil) // rpcResp1.Responses should not be nil
 
 			rpcResp1.Responses[currRV.Name] = &models.PutChunkResponseOrError{
-				Response: nil,    // PutChunk failed for the current RV
+				Response: nil,    // PutChunkEx failed for the current RV
 				Error:    rpcErr, // Error for the current RV
 			}
 

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1878,6 +1878,10 @@ refreshFromClustermapAndRetry:
 	return resp, nil
 }
 
+func (h *ChunkServiceHandler) PutChunkEx(ctx context.Context, req *models.PutChunkExRequest) (*models.PutChunkExResponse, error) {
+	return nil, nil
+}
+
 func (h *ChunkServiceHandler) RemoveChunk(ctx context.Context, req *models.RemoveChunkRequest) (*models.RemoveChunkResponse, error) {
 	// Thrift should not be calling us with nil req.
 	common.Assert(req != nil)

--- a/internal/dcache/rpc/service.thrift
+++ b/internal/dcache/rpc/service.thrift
@@ -13,6 +13,8 @@ service ChunkService {
     // store the chunk on the node on the given rvID
     models.PutChunkResponse PutChunk(1: models.PutChunkRequest request) throws (1:models.ResponseError err)
 
+    models.PutChunkExResponse PutChunkEx(1: models.PutChunkExRequest request) throws (1:models.ResponseError err)
+
     // delete the chunk from the node from the given rvID
     models.RemoveChunkResponse RemoveChunk(1: models.RemoveChunkRequest request) throws (1:models.ResponseError err)
 

--- a/internal/dcache/rpc/utils.go
+++ b/internal/dcache/rpc/utils.go
@@ -150,6 +150,22 @@ func PutChunkExRequestToString(req *models.PutChunkExRequest) string {
 		PutChunkRequestToString(req.Request), ComponentRVsToString(req.NextRVs))
 }
 
+// convert *models.PutChunkExRequest to string
+// used for logging
+func PutChunkExResponseToString(response *models.PutChunkExResponse) string {
+	str := strings.Builder{}
+	str.WriteString("[\n")
+
+	for rvName, resp := range response.Responses {
+		common.Assert(resp != nil)
+		str.WriteString(fmt.Sprintf("{%s : {PutChunkResponse %s, Error %s}}\n",
+			rvName, PutChunkResponseToString(resp.Response), resp.Error))
+	}
+
+	str.WriteString("]")
+	return str.String()
+}
+
 // convert *models.RemoveChunkRequest to string
 // used for logging
 func RemoveChunkRequestToString(req *models.RemoveChunkRequest) string {

--- a/internal/dcache/rpc/utils.go
+++ b/internal/dcache/rpc/utils.go
@@ -159,7 +159,7 @@ func PutChunkExResponseToString(response *models.PutChunkExResponse) string {
 	for rvName, resp := range response.Responses {
 		common.Assert(resp != nil)
 		str.WriteString(fmt.Sprintf("{%s : {PutChunkResponse %s, Error %s}}\n",
-			rvName, PutChunkResponseToString(resp.Response), resp.Error))
+			rvName, PutChunkResponseToString(resp.Response), resp.Error.String()))
 	}
 
 	str.WriteString("]")

--- a/internal/dcache/rpc/utils.go
+++ b/internal/dcache/rpc/utils.go
@@ -143,6 +143,13 @@ func PutChunkResponseToString(resp *models.PutChunkResponse) string {
 		resp.TimeTaken, resp.AvailableSpace, ComponentRVsToString(resp.ComponentRV))
 }
 
+// convert *models.PutChunkExRequest to string
+// used for logging
+func PutChunkExRequestToString(req *models.PutChunkExRequest) string {
+	return fmt.Sprintf("{PutChunkRequest %s, NextRVs %v}",
+		PutChunkRequestToString(req.Request), ComponentRVsToString(req.NextRVs))
+}
+
 // convert *models.RemoveChunkRequest to string
 // used for logging
 func RemoveChunkRequestToString(req *models.RemoveChunkRequest) string {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description

Added PutChunkEx RPC to write chunks to the component RVs in daisy chain manner. When PutChunkEx call is received, it writes the chunk to its local RV and parallelly forwards the call to the next RVs. The response returned by this RPC is the individual PutChunk response for each RV mapped by the RV name.
