### PR TITLE
Preview binaries shall go with a different package name

### DIFF
--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -127,7 +127,13 @@ stages:
           # using fpm tool for packaging of our binary & performing post-install operations
           # for additional information about fpm refer https://fpm.readthedocs.io/en/v1.13.1/
           - script: |
-              fpm -s dir -t deb -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
+              packageName="blobfuse2"
+              # If the version string has preview in it then packageName shall be "blobfuse2-preview"
+              if [[ `./pkgDir/usr/bin/blobfuse2 --version` == *"preview"* ]]; then
+                echo "Preview binary package created"
+                packageName="blobfuse2-preview"
+              fi
+              fpm -s dir -t deb -n $packageName -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.deb ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(tags).x86_64.deb
@@ -136,7 +142,13 @@ stages:
             displayName: 'Make deb Package'
 
           - script: |
-              fpm -s dir -t rpm -n blobfuse2 --rpm-digest sha256 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
+              packageName="blobfuse2"
+              # If the version string has preview in it then packageName shall be "blobfuse2-preview"
+              if [[ `./pkgDir/usr/bin/blobfuse2 --version` == *"preview"* ]]; then
+                echo "Preview binary package created"
+                packageName="blobfuse2-preview"
+              fi
+              fpm -s dir -t rpm -n $packageName --rpm-digest sha256 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(tags).x86_64.rpm
@@ -227,7 +239,13 @@ stages:
           # using fpm tool for packaging of our binary & performing post-install operations
           # for additional information about fpm refer https://fpm.readthedocs.io/en/v1.13.1/
           - script: |
-              fpm -s dir -t deb -n blobfuse2 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
+              packageName="blobfuse2"
+              # If the version string has preview in it then packageName shall be "blobfuse2-preview"
+              if [[ `./pkgDir/usr/bin/blobfuse2 --version` == *"preview"* ]]; then
+                echo "Preview binary package created"
+                packageName="blobfuse2-preview"
+              fi
+              fpm -s dir -t deb -n $packageName -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.deb ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(tags).arm64.deb
@@ -236,7 +254,13 @@ stages:
             displayName: 'Make deb Package'
 
           - script: |
-              fpm -s dir -t rpm -n blobfuse2 --rpm-digest sha256 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
+              packageName="blobfuse2"
+              # If the version string has preview in it then packageName shall be "blobfuse2-preview"
+              if [[ `./pkgDir/usr/bin/blobfuse2 --version` == *"preview"* ]]; then
+                echo "Preview binary package created"
+                packageName="blobfuse2-preview"
+              fi
+              fpm -s dir -t rpm -n $packageName --rpm-digest sha256 -C pkgDir/ -v `./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3` -d $(depends) \
               --maintainer "Blobfuse v-Team <blobfusevteam@microsoft.com>" --url "https://github.com/Azure/azure-storage-fuse" \
               --description "An user-space filesystem for interacting with Azure Storage" 
               mv ./blobfuse2*.rpm ./blobfuse2-`./pkgDir/usr/bin/blobfuse2 --version | cut -d " " -f 3`-$(tags).aarch64.rpm

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -1585,8 +1585,8 @@ stages:
 
   - ${{ if eq(parameters.publish_artifacts, true) }}:
     - stage: PublishArtifacts
-      dependsOn: ReleaseArtifacts
-      condition: succeeded('ReleaseArtifacts')
+      # dependsOn: ReleaseArtifacts
+      # condition: succeeded('ReleaseArtifacts')
       jobs:
         - job: PublishArtifacts
           timeoutInMinutes: 120

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -1637,6 +1637,16 @@ stages:
                 downloadPath: $(Build.ArtifactStagingDirectory)
 
             - script: |
+                blobfuseBinaryName=`ls blobfuse2-* | head -n 1`
+                echo "Binary name: $blobfuseBinaryName"
+                if [[ $blobfuseBinaryName == *"preview"* ]]; then
+                  for f in ./blobfuse2-2*; do mv -v "$f" "${f/blobfuse2-/blobfuse2-preview-}" ; done
+                fi
+                ls -l 
+              displayName: 'Rename preview binaries'
+              workingDirectory: $(Build.ArtifactStagingDirectory)/blobfuse2-signed/
+
+            - script: |
                 cd mariner
                 for f in ./blobfuse2*fuse3*.rpm; do mv -v "$f" "${f/-fuse3./-cm2.}"; done
                 ls -lRt

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -1609,8 +1609,8 @@ stages:
 
   - ${{ if eq(parameters.publish_artifacts, true) }}:
     - stage: PublishArtifacts
-      # dependsOn: ReleaseArtifacts
-      # condition: succeeded('ReleaseArtifacts')
+      dependsOn: ReleaseArtifacts
+      condition: succeeded('ReleaseArtifacts')
       jobs:
         - job: PublishArtifacts
           timeoutInMinutes: 120

--- a/setup/packages.csv
+++ b/setup/packages.csv
@@ -1,3 +1,29 @@
 # Do not remove these comments
 # Format of the file : <Distro Name>,<Fuse Version, Architecture, File Type>,<Repo Name>,<Release Name(for deb repos only)>
 Ubuntu-18.04,fuse2AmdDeb,microsoft-ubuntu-bionic-prod-apt,bionic
+Ubuntu-20.04,fuse3AmdDeb,microsoft-ubuntu-focal-prod-apt,focal
+Ubuntu-22.04,fuse3AmdDeb,microsoft-ubuntu-jammy-prod-apt,jammy
+Ubuntu-22.04,fuse3ArmDeb,microsoft-ubuntu-jammy-prod-apt,jammy
+Ubuntu-24.04,fuse3AmdDeb,microsoft-ubuntu-noble-prod-apt,noble
+Ubuntu-24.04,fuse3ArmDeb,microsoft-ubuntu-noble-prod-apt,noble
+Debian-9.0,fuse2AmdDeb,microsoft-debian-stretch-prod-apt,stretch
+Debian-10.0,fuse2AmdDeb,microsoft-debian-buster-prod-apt,buster
+Debian-11.0,fuse3AmdDeb,microsoft-debian-bullseye-prod-apt,bullseye
+Debian-12.0,fuse3AmdDeb,microsoft-debian-bookworm-prod-apt,bookworm
+RHEL-7.5,fuse3AmdRpm,microsoft-rhel7.5-prod-yum,
+RHEL-7.8,fuse3AmdRpm,microsoft-rhel7.8-prod-yum,
+RHEL-8.1,fuse3AmdRpm,microsoft-rhel8.1-prod-yum,
+RHEL-8.2,fuse3AmdRpm,microsoft-rhel8.2-prod-yum,
+RHEL-7.0,fuse3AmdRpm,microsoft-rhel7.0-prod-yum,
+RHEL-8.0,fuse3AmdRpm,microsoft-rhel8.0-prod-yum,
+RHEL-9.0,fuse3AmdRpm,microsoft-rhel9.0-prod-yum,
+RHEL-9.0,fuse3ArmRpm,microsoft-rhel9.0-prod-yum,
+CentOS-7.0,fuse3AmdRpm,microsoft-centos7-prod-yum,
+CentOS-8.0,fuse3AmdRpm,microsoft-centos8-prod-yum,
+SUSE-15Gen2,fuse3AmdRpm,microsoft-sles15-prod-yum,
+Mariner-2.0-x86_64,marinerFuse3AmdRpm,cbl-mariner-2.0-prod-Microsoft-x86_64-yum,
+Mariner-2.0-aarch64,marinerFuse3AarchRpm,cbl-mariner-2.0-prod-Microsoft-aarch64-yum,
+Rocky-8.0,fuse3AmdRpm,microsoft-el8-prod-yum,
+Rocky-9.0,fuse3AmdRpm,microsoft-el9-prod-yum,
+Mariner-3.0-x86_64,marinerFuse3AmdRpm,azurelinux-3.0-prod-ms-oss-x86_64-yum,
+Mariner-3.0-aarch64,marinerFuse3AarchRpm,azurelinux-3.0-prod-ms-oss-aarch64-yum,

--- a/setup/packages.csv
+++ b/setup/packages.csv
@@ -1,3 +1,3 @@
 # Do not remove these comments
 # Format of the file : <Distro Name>,<Fuse Version, Architecture, File Type>,<Repo Name>,<Release Name(for deb repos only)>
-Ubuntu-22.04,fuse3AmdDeb,microsoft-ubuntu-jammy-prod-apt,jammy
+Ubuntu-18.04,fuse2AmdDeb,microsoft-ubuntu-bionic-prod-apt,bionic

--- a/setup/packages.csv
+++ b/setup/packages.csv
@@ -1,29 +1,3 @@
 # Do not remove these comments
 # Format of the file : <Distro Name>,<Fuse Version, Architecture, File Type>,<Repo Name>,<Release Name(for deb repos only)>
-Ubuntu-18.04,fuse2AmdDeb,microsoft-ubuntu-bionic-prod-apt,bionic
-Ubuntu-20.04,fuse3AmdDeb,microsoft-ubuntu-focal-prod-apt,focal
 Ubuntu-22.04,fuse3AmdDeb,microsoft-ubuntu-jammy-prod-apt,jammy
-Ubuntu-22.04,fuse3ArmDeb,microsoft-ubuntu-jammy-prod-apt,jammy
-Ubuntu-24.04,fuse3AmdDeb,microsoft-ubuntu-noble-prod-apt,noble
-Ubuntu-24.04,fuse3ArmDeb,microsoft-ubuntu-noble-prod-apt,noble
-Debian-9.0,fuse2AmdDeb,microsoft-debian-stretch-prod-apt,stretch
-Debian-10.0,fuse2AmdDeb,microsoft-debian-buster-prod-apt,buster
-Debian-11.0,fuse3AmdDeb,microsoft-debian-bullseye-prod-apt,bullseye
-Debian-12.0,fuse3AmdDeb,microsoft-debian-bookworm-prod-apt,bookworm
-RHEL-7.5,fuse3AmdRpm,microsoft-rhel7.5-prod-yum,
-RHEL-7.8,fuse3AmdRpm,microsoft-rhel7.8-prod-yum,
-RHEL-8.1,fuse3AmdRpm,microsoft-rhel8.1-prod-yum,
-RHEL-8.2,fuse3AmdRpm,microsoft-rhel8.2-prod-yum,
-RHEL-7.0,fuse3AmdRpm,microsoft-rhel7.0-prod-yum,
-RHEL-8.0,fuse3AmdRpm,microsoft-rhel8.0-prod-yum,
-RHEL-9.0,fuse3AmdRpm,microsoft-rhel9.0-prod-yum,
-RHEL-9.0,fuse3ArmRpm,microsoft-rhel9.0-prod-yum,
-CentOS-7.0,fuse3AmdRpm,microsoft-centos7-prod-yum,
-CentOS-8.0,fuse3AmdRpm,microsoft-centos8-prod-yum,
-SUSE-15Gen2,fuse3AmdRpm,microsoft-sles15-prod-yum,
-Mariner-2.0-x86_64,marinerFuse3AmdRpm,cbl-mariner-2.0-prod-Microsoft-x86_64-yum,
-Mariner-2.0-aarch64,marinerFuse3AarchRpm,cbl-mariner-2.0-prod-Microsoft-aarch64-yum,
-Rocky-8.0,fuse3AmdRpm,microsoft-el8-prod-yum,
-Rocky-9.0,fuse3AmdRpm,microsoft-el9-prod-yum,
-Mariner-3.0-x86_64,marinerFuse3AmdRpm,azurelinux-3.0-prod-ms-oss-x86_64-yum,
-Mariner-3.0-aarch64,marinerFuse3AarchRpm,azurelinux-3.0-prod-ms-oss-aarch64-yum,


### PR DESCRIPTION
By default both preview and GA binaries go with the same package name "blobfuse2". This means if a customer tries to install the latest version, they may end up installing a preview version. We want all out customers to by default have a GA version and make a concious choice to install preview binary explicitly. To do so we are renaming our package for preview binaries to "blobfuse2-preview".