### PR TITLE
Add max-rvs config for user to specify the cluster size.

### DIFF
--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -420,6 +420,9 @@ func (distributedCache *DistributedCache) Configure(_ bool) error {
 		// Set MVsPerRV needed to achieve these many MVs.
 		distributedCache.cfg.MVsPerRV = uint64(numMVs / minMVs)
 
+		log.Info("DistributedCache::Configure : cfg.MVsPerRV set to %d, minMVs: %d, maxMVs: %d",
+			distributedCache.cfg.MVsPerRV, minMVs, maxMVs)
+
 		// Our calculated MVsPerRV must be within the allowed range.
 		common.Assert(distributedCache.cfg.MVsPerRV >= uint64(cm.MinMVsPerRV) &&
 			distributedCache.cfg.MVsPerRV <= uint64(cm.MaxMVsPerRV),

--- a/component/distributed_cache/distributed_cache_test.go
+++ b/component/distributed_cache/distributed_cache_test.go
@@ -102,7 +102,7 @@ func (suite *distributedCacheTestSuite) TestManadatoryConfigMissing() {
 	suite.assert.EqualValues(300, suite.distributedCache.cfg.ClustermapEpoch)
 	suite.assert.EqualValues(3, suite.distributedCache.cfg.MaxMissedHeartbeats)
 	suite.assert.EqualValues(1, suite.distributedCache.cfg.MinNodes)
-	suite.assert.EqualValues(uint64(10), suite.distributedCache.cfg.MVsPerRv)
+	suite.assert.EqualValues(uint64(10), suite.distributedCache.cfg.MVsPerRV)
 	suite.assert.EqualValues(uint64(80), suite.distributedCache.cfg.RebalancePercentage)
 	suite.assert.EqualValues(95, suite.distributedCache.cfg.RVFullThreshold)
 	suite.assert.EqualValues(80, suite.distributedCache.cfg.RVNearfullThreshold)

--- a/internal/dcache/clustermap/clustermap_dummy_success.json
+++ b/internal/dcache/clustermap/clustermap_dummy_success.json
@@ -7,6 +7,7 @@
 	"config": {
         "cache-id":"mycache1",
 		"min-nodes": 1,
+		"max-rvs": 100,
 		"chunk-size": 4194304,
         "stripe-size": 16777216,
         "num-replicas": 2,

--- a/internal/dcache/clustermap/utils.go
+++ b/internal/dcache/clustermap/utils.go
@@ -67,8 +67,17 @@ var (
 	MinNumReplicas int64 = 1
 	MaxNumReplicas int64 = 256
 
-	MinMvsPerRv int64 = 10
-	MaxMvsPerRv int64 = 100
+	//
+	// Unless explictly set, the system sets cfg.MVsPerRV in a way so as to get close to PreferredMVs
+	// number of MVs. Obviously it'll honour MaxMVsPerRV.
+	//
+	// TODO: See if we need to make this a config option.
+	// TODO: Test if 1000 is a good number.
+	//
+	PreferredMVs int64 = 1000
+
+	MinMVsPerRV int64 = 1
+	MaxMVsPerRV int64 = 100
 
 	MinRvFullThreshold int64 = 80
 	MaxRvFullThreshold int64 = 100
@@ -174,6 +183,13 @@ func IsValidDcacheConfig(cfg *dcache.DCacheConfig) (bool, error) {
 		return false, fmt.Errorf("DCacheConfig: Invalid MinNodes: %d +%v", cfg.MinNodes, *cfg)
 	}
 
+	// Every node must contribute at least one RV.
+	// We must have RVs no less than NumReplicas.
+	// 100K is an arbitrary upper limit for the number of RVs in the cluster.
+	if cfg.MaxRVs < cfg.MinNodes || cfg.MaxRVs < cfg.NumReplicas || cfg.MaxRVs > 100000 {
+		return false, fmt.Errorf("DCacheConfig: Invalid MaxRVs: %d +%v", cfg.MaxRVs, *cfg)
+	}
+
 	if int64(cfg.HeartbeatSeconds) < MinHeartbeatFrequency ||
 		int64(cfg.HeartbeatSeconds) > MaxHeartbeatFrequency {
 		return false, fmt.Errorf("DCacheConfig: Invalid HeartbeatSeconds: %d %+v", cfg.HeartbeatSeconds, *cfg)
@@ -207,14 +223,14 @@ func IsValidDcacheConfig(cfg *dcache.DCacheConfig) (bool, error) {
 		return false, fmt.Errorf("DCacheConfig: Invalid NumReplicas: %d %+v", cfg.NumReplicas, *cfg)
 	}
 
-	if int64(cfg.MvsPerRv) < MinMvsPerRv || int64(cfg.MvsPerRv) > MaxMvsPerRv {
-		return false, fmt.Errorf("DCacheConfig: Invalid MvsPerRv: %d %+v", cfg.MvsPerRv, *cfg)
+	if int64(cfg.MVsPerRV) < MinMVsPerRV || int64(cfg.MVsPerRV) > MaxMVsPerRV {
+		return false, fmt.Errorf("DCacheConfig: Invalid MVsPerRV: %d %+v", cfg.MVsPerRV, *cfg)
 	}
 
-	// MvsPerRv less than NumReplicas is usually pointless.
-	if int64(cfg.MvsPerRv) < int64(cfg.NumReplicas) {
-		return false, fmt.Errorf("DCacheConfig: MvsPerRv(%d) < NumReplicas(%d) %+v",
-			cfg.MvsPerRv, cfg.NumReplicas, *cfg)
+	// MVsPerRV less than NumReplicas is usually pointless.
+	if int64(cfg.MVsPerRV) < int64(cfg.NumReplicas) {
+		return false, fmt.Errorf("DCacheConfig: MVsPerRV(%d) < NumReplicas(%d) %+v",
+			cfg.MVsPerRV, cfg.NumReplicas, *cfg)
 	}
 
 	if int64(cfg.RvFullThreshold) < MinRvFullThreshold || int64(cfg.RvFullThreshold) > MaxRvFullThreshold {

--- a/internal/dcache/models.go
+++ b/internal/dcache/models.go
@@ -107,7 +107,8 @@ type DCacheConfig struct {
 	ChunkSize              uint64 `json:"chunk-size"`
 	StripeSize             uint64 `json:"stripe-size"`
 	NumReplicas            uint32 `json:"num-replicas"`
-	MvsPerRv               uint64 `json:"mvs-per-rv"`
+	MaxRVs                 uint32 `json:"max-rvs"`
+	MVsPerRV               uint64 `json:"mvs-per-rv"`
 	RvFullThreshold        uint64 `json:"rv-full-threshold"`
 	RvNearfullThreshold    uint64 `json:"rv-nearfull-threshold"`
 	HeartbeatSeconds       uint16 `json:"heartbeat-seconds"`

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -2683,7 +2683,7 @@ func (h *ChunkServiceHandler) JoinMV(ctx context.Context, req *models.JoinMVRequ
 			// This might happen due to incomplete JoinMV requests taking up space, so it will help
 			// to refresh rvInfo details from the clustermap and remove any unused MVs, and try again.
 			//
-			errStr := fmt.Sprintf("%s cannot host any more MVs (MVsPerRv: %d)", req.RVName, mvLimit)
+			errStr := fmt.Sprintf("%s cannot host any more MVs (MVsPerRV: %d)", req.RVName, mvLimit)
 			log.Err("ChunkServiceHandler::JoinMV: %s", errStr)
 
 			if !pruned {

--- a/internal/dcache/rpc/server/utils.go
+++ b/internal/dcache/rpc/server/utils.go
@@ -141,7 +141,7 @@ func getRvIDMap(rvs map[string]dcache.RawVolume) map[string]*rvInfo {
 
 // return mvs-per-rv from dcache config
 func getMVsPerRV() int64 {
-	return int64(cm.GetCacheConfig().MvsPerRv)
+	return int64(cm.GetCacheConfig().MVsPerRV)
 }
 
 // This method is wrapper for the GetChunk() RPC call. It is used when the both the client and server


### PR DESCRIPTION
Currently we have mvs-per-rv which is more complex for the user to understand. User can easily express his cluster size in terms of max nodes and hence max RVs (as he will know how many RVs per node). Then we can calculate MVsPerRV accordingly.
We don't want to make too many MVs, but enough to get a decent distribution of file chunks across RVs.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->