### PR TITLE
Eliminate du usage

### DIFF
--- a/component/file_cache/cache_policy.go
+++ b/component/file_cache/cache_policy.go
@@ -86,7 +86,7 @@ func getUsagePercentage(path string, maxSize float64) float64 {
 		}
 	} else {
 		// We need to compuate % usage of temp directory against configured limit
-		currSize, err = common.GetUsage(path)
+		currSize, err = common.GetUsageInMegabytes(path)
 		if err != nil {
 			log.Err("cachePolicy::getUsagePercentage : failed to get directory usage for %s [%v]", path, err.Error)
 		}

--- a/component/file_cache/lru_policy.go
+++ b/component/file_cache/lru_policy.go
@@ -39,7 +39,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/log"
 )
 
@@ -123,16 +122,7 @@ func (p *lruPolicy) StartPolicy() error {
 	p.deleteEvent = make(chan string, 1000)
 	p.validateChan = make(chan string, 10000)
 
-	_, err := common.GetUsage(p.tmpPath)
-	if err == nil {
-		p.duPresent = true
-	} else {
-		log.Err("lruPolicy::StartPolicy : 'du' command not found, disabling disk usage checks")
-	}
-
-	if p.duPresent {
-		p.diskUsageMonitor = time.Tick(time.Duration(DiskUsageCheckInterval * time.Minute))
-	}
+	p.diskUsageMonitor = time.Tick(time.Duration(DiskUsageCheckInterval * time.Minute))
 
 	// Only start the timeoutMonitor if evictTime is non-zero.
 	// If evictTime=0, we delete on invalidate so there is no need for a timeout monitor signal to be sent.


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [x] Code quality improvement
- [ ] Other (describe):

## Description
Previously, in order to estimate disk usage for a specific path, the `GetUsage()` function would use the `Command` function to execute the `du` command, parse the output and return the results in megabytes. After troubleshooting an issue that involved file writes to a volume that made use of this driver causing the write to hang, I tracked down the hang to entry into the `GetUsage()` function.

This change removes the usage of `du` in favor of replicating the functionality using the `WalkDir()` function included in the Go standard library. I also added functions with clearer names, preserved the API of the `common` package, updated functions that previously called the `GetUsage()` function to use the newer functions and added additional testing.

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
Removing the use of the `Command` function prevents the creation of a new external process and makes the `GetUsage()` function more portable across Linux distributions.

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [x] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->