### PR TITLE
Fix when direct-io is enabled in the config file

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -257,6 +257,7 @@ var mountCmd = &cobra.Command{
 		common.MountPath = options.MountPath
 
 		configFileExists := true
+		directIO := false
 
 		if options.ConfigFile == "" {
 			// Config file is not set in cli parameters
@@ -377,9 +378,18 @@ var mountCmd = &cobra.Command{
 				} else if v == "direct_io" || v == "direct_io=true" {
 					config.Set("lfuse.direct-io", "true")
 					config.Set("direct-io", "true")
+					directIO = true
 				} else {
 					return errors.New(common.FuseAllowedFlags)
 				}
+			}
+		}
+
+		// Check if direct-io is enabled in the config file.
+		if !directIO {
+			_ = config.UnmarshalKey("libfuse.direct-io", &directIO)
+			if directIO {
+				config.Set("direct-io", "true")
 			}
 		}
 
@@ -450,10 +460,8 @@ var mountCmd = &cobra.Command{
 		log.Crit("Logging level set to : %s", logLevel.String())
 		log.Debug("Mount allowed on nonempty path : %v", options.NonEmpty)
 
-		directIO := false
-		_ = config.UnmarshalKey("direct-io", &directIO)
 		if directIO {
-			// Directio is enabled, so remove the attr-cache from the pipeline
+			// Direct IO is enabled, so remove the attr-cache from the pipeline
 			for i, name := range options.Components {
 				if name == "attr_cache" {
 					options.Components = append(options.Components[:i], options.Components[i+1:]...)


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
If direct-io was set in the config file, then it was not removing the attr_cache correctly from the components slice.


## How Has This Been Tested?
Added UT.

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.