### PR TITLE
Allocate buffer from BufferPool while reading from the Local RV

### DIFF
--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -191,7 +191,7 @@ func (dc *DistributedCache) Start(ctx context.Context) error {
 		return log.LogAndReturnError(errString)
 	}
 
-	err = dcache.CreateBufferPool(dc.cfg.ChunkSize)
+	err = dcache.InitBufferPool(dc.cfg.ChunkSize)
 	if err != nil {
 		return log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [Failed to create BufferPool : %v]", err))
 	}

--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -191,6 +191,11 @@ func (dc *DistributedCache) Start(ctx context.Context) error {
 		return log.LogAndReturnError(errString)
 	}
 
+	err = dcache.CreateBufferPool(dc.cfg.ChunkSize)
+	if err != nil {
+		return log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [Failed to create BufferPool : %v]", err))
+	}
+
 	err = rm.Start()
 	if err != nil {
 		return log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [Failed to start replication manager : %v]", err))

--- a/internal/dcache/buffer.go
+++ b/internal/dcache/buffer.go
@@ -131,6 +131,9 @@ func PutBuffer(buf []byte) {
 	// Caller must free a buffer that's allocated using getBuffer().
 	common.Assert(bufPool.curBuffers.Load() > 0, bufPool.curBuffers.Load())
 
+	// This buffer must have been allocated from the pool and hence must have capacity at least bp.bufSize.
+	common.Assert(cap(buf) >= bufPool.bufSize, cap(buf), bufPool.bufSize)
+
 	// Reslice the length of the buffer to its original capacity if it got compacted.
 	buf = buf[:bufPool.bufSize]
 

--- a/internal/dcache/buffer.go
+++ b/internal/dcache/buffer.go
@@ -31,10 +31,11 @@
    SOFTWARE
 */
 
-package filemanager
+package dcache
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -43,26 +44,68 @@ import (
 
 //go:generate $ASSERT_REMOVER $GOFILE
 
-type bufferPool struct {
+var BufPool *BufferPool
+
+type BufferPool struct {
 	pool       sync.Pool    // sync.Pool to relieve GC
 	bufSize    int          // size of buffers in this pool
 	maxBuffers int64        // max allocated buffers allowed
 	curBuffers atomic.Int64 // buffers currently allocated
 }
 
-func NewBufferPool(bufSize int, maxBuffers int) *bufferPool {
-	return &bufferPool{
+func CreateBufferPool(bufSize uint64) error {
+	common.Assert(BufPool == nil)
+	//
+	// Size of buffers managed by bufferPool.
+	// This should be equal to the chunk size we support, since each buffer can hold upto one chunk
+	// worth of data.
+	//
+
+	//
+	// Maximum numbers of 'bufSize' buffers can be allocated from the bufferPool.
+	// We should allow sufficiently many buffers to support at least few files being read/written
+	// simultaneously.
+	// Note that only writeChunk uses buffers from this pool while readChunk uses buffers allocated by
+	// thrift and those are not accounted in this.
+	//
+	// TODO: Find out how/if thrift controls those buffers, or does it result in OOM killing of the
+	//       process.
+	//
+	maxBuffers := uint64(1024)
+
+	//
+	// How much percent of the system RAM (available memory to be precise) are we allowed to use?
+	//
+	// TODO: This can be config value.
+	//
+	usablePercentSystemRAM := 50
+
+	//
+	// Allow higher number of maxBuffers if system can afford.
+	//
+	ramMB, err := common.GetAvailableMemoryInMB()
+	if err != nil {
+		return fmt.Errorf("NewFileIOManager: %v", err)
+	}
+
+	// usableMemory in bytes capped by usablePercentSystemRAM.
+	usableMemory := (ramMB * 1024 * 1024 * uint64(usablePercentSystemRAM)) / 100
+	maxBuffers = max(maxBuffers, usableMemory/bufSize)
+
+	BufPool = &BufferPool{
 		pool: sync.Pool{
 			New: func() any {
 				return make([]byte, bufSize)
 			},
 		},
-		bufSize:    bufSize,
+		bufSize:    int(bufSize),
 		maxBuffers: int64(maxBuffers),
 	}
+
+	return nil
 }
 
-func (bp *bufferPool) getBuffer() ([]byte, error) {
+func (bp *BufferPool) GetBuffer() ([]byte, error) {
 	if bp.curBuffers.Load() > bp.maxBuffers {
 		return nil, errors.New("Buffers Exhausted")
 	}
@@ -76,11 +119,14 @@ func (bp *bufferPool) getBuffer() ([]byte, error) {
 	return buf, nil
 }
 
-func (bp *bufferPool) putBuffer(buf []byte) {
+func (bp *BufferPool) PutBuffer(buf []byte) {
 	// All buffers allocated from the pool must be of the same size.
-	common.Assert(len(buf) == bp.bufSize, len(buf), bp.bufSize)
+	common.Assert(len(buf) <= bp.bufSize, len(buf), bp.bufSize)
 	// Caller must free a buffer that's allocated using getBuffer().
 	common.Assert(bp.curBuffers.Load() > 0, bp.curBuffers.Load())
+
+	// Reslice the length of the buffer to its original capacity if it got compacted.
+	buf = buf[:bp.bufSize]
 
 	bp.pool.Put(buf)
 	bp.curBuffers.Add(-1)

--- a/internal/dcache/file_manager/utils.go
+++ b/internal/dcache/file_manager/utils.go
@@ -319,7 +319,7 @@ func NewStagedChunk(idx int64, file *DcacheFile, allocateBuf bool) (*StagedChunk
 	var err error
 
 	if allocateBuf {
-		buf, err = fileIOMgr.bp.getBuffer()
+		buf, err = dcache.BufPool.GetBuffer()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/dcache/file_manager/utils.go
+++ b/internal/dcache/file_manager/utils.go
@@ -319,7 +319,7 @@ func NewStagedChunk(idx int64, file *DcacheFile, allocateBuf bool) (*StagedChunk
 	var err error
 
 	if allocateBuf {
-		buf, err = dcache.BufPool.GetBuffer()
+		buf, err = dcache.GetBuffer()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/dcache/replication_manager/models.go
+++ b/internal/dcache/replication_manager/models.go
@@ -128,7 +128,8 @@ func (req *ReadMvRequest) isValid() error {
 }
 
 type ReadMvResponse struct {
-	Data []byte // buffer containing data read from the chunk.
+	Data          []byte // buffer containing data read from the chunk.
+	IsBufExternal bool   // false if the buffer is allocated from the bufferPool.
 }
 
 func (resp *ReadMvResponse) isValid(req *ReadMvRequest) error {

--- a/internal/dcache/rpc/models.thrift
+++ b/internal/dcache/rpc/models.thrift
@@ -38,7 +38,8 @@ struct GetChunkRequest {
     2: Address address,
     3: i64 offsetInChunk,
     4: i64 length,
-    5: list<RVNameAndState> componentRV // used to validate the component RV for the MV
+    5: bool isLocalRV, // true, if both server and client are on the same node
+    6: list<RVNameAndState> componentRV // used to validate the component RV for the MV
 }
 
 struct GetChunkResponse {

--- a/internal/dcache/rpc/server/utils.go
+++ b/internal/dcache/rpc/server/utils.go
@@ -153,6 +153,12 @@ func GetChunkLocal(ctc context.Context, req *models.GetChunkRequest) (*models.Ge
 	// Caller must not set SenderNodeID, catch misbehaving callers.
 	common.Assert(len(req.SenderNodeID) == 0, req.SenderNodeID)
 	req.SenderNodeID = rpc.GetMyNodeUUID()
+
+	//
+	// This chunk is being read locally without any RPC, so we can set IsLocalRV to true. This is used for
+	// taking the decision in the handler to allocate the chunk from the buffer pool instead of initializing
+	// a new buffer.
+	//
 	req.IsLocalRV = true
 
 	common.Assert(handler != nil)

--- a/internal/dcache/rpc/server/utils.go
+++ b/internal/dcache/rpc/server/utils.go
@@ -153,6 +153,7 @@ func GetChunkLocal(ctc context.Context, req *models.GetChunkRequest) (*models.Ge
 	// Caller must not set SenderNodeID, catch misbehaving callers.
 	common.Assert(len(req.SenderNodeID) == 0, req.SenderNodeID)
 	req.SenderNodeID = rpc.GetMyNodeUUID()
+	req.IsLocalRV = true
 
 	common.Assert(handler != nil)
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement
- [ ] Other (describe):

Total Allocations came down while using dcache with 1 replica in 1 node, where entire data of the file is served from local node.

```

|---------------+-------------------|
| Before change | Total Allocs      |
|---------------+-------------------|
| WRITE 10G     | 1297115616(1.2G)  |
| READ 10G      | 11957655696(11.9G) |
|---------------+-------------------|


|--------------+-------------------|
| After change | Total Allocs      |
|--------------+-------------------|
| WRITE 10G    | 1121690104(1.12G) |
| READ 10G     | 1130115944(1.13G) |
|--------------+-------------------|
```