### PR TITLE
Provide a mode to just disable kernel cache not the blobfuse cache

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -89,6 +89,7 @@ type mountOptions struct {
 	MonitorOpt        monitorOptions `config:"health_monitor"`
 	WaitForMount      time.Duration  `config:"wait-for-mount"`
 	LazyWrite         bool           `config:"lazy-write"`
+	NoKernelCache     bool           `config:"no-kernel-cache"`
 
 	// v1 support
 	Streaming         bool     `config:"streaming"`
@@ -869,6 +870,9 @@ func init() {
 	mountCmd.PersistentFlags().ShorthandLookup("o").Hidden = true
 
 	mountCmd.PersistentFlags().DurationVar(&options.WaitForMount, "wait-for-mount", 5*time.Second, "Let parent process wait for given timeout before exit")
+
+	mountCmd.PersistentFlags().Bool("no-kernel-cache", false, "Disable kerneel cache, but keep blobfuse cache. Default value false.")
+	config.BindPFlag("no-kernel-cache", mountCmd.PersistentFlags().Lookup("no-kernel-cache"))
 
 	config.AttachToFlagSet(mountCmd.PersistentFlags())
 	config.AttachFlagCompletions(mountCmd)

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -75,6 +75,7 @@ type Libfuse struct {
 	maxFuseThreads        uint32
 	directIO              bool
 	umask                 uint32
+	noKernelCache         bool
 }
 
 // To support pagination in readdir calls this structure holds a block of items for a given directory
@@ -194,6 +195,11 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 	lf.ownerGID = opt.Gid
 	lf.ownerUID = opt.Uid
 	lf.umask = opt.Umask
+
+	if lf.noKernelCache {
+		opt.DirectIO = true
+		lf.directIO = true
+	}
 
 	if opt.allowOther {
 		lf.dirPermission = uint(common.DefaultAllowOtherPermissionBits)
@@ -326,6 +332,8 @@ func (lf *Libfuse) Configure(_ bool) error {
 		return err
 	}
 
+	_ = config.UnmarshalKey("no-kernel-cache", &lf.noKernelCache)
+
 	err = lf.Validate(&conf)
 	if err != nil {
 		log.Err("Libfuse::Configure : config error [invalid config settings]")
@@ -340,8 +348,8 @@ func (lf *Libfuse) Configure(_ bool) error {
 		}
 	}
 
-	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max-fuse-threads %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v",
-		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxFuseThreads, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask)
+	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max-fuse-threads %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v, kernel_cache %v",
+		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxFuseThreads, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask, lf.noKernelCache)
 
 	return nil
 }


### PR DESCRIPTION
As of now we either we have direct-io mode where both kernel cache and blobfuse cache are disabled or you have all cache enabled. In AKS mode, few customers want to have blobfuse file level cache but no kernel cache (as kernel page cache can not be controlled as in when to wipe it out). With this change adding a new flag which will internally be treated as direct-io for libfuse component but both file-cache and attr-cache can still be controlled with independent timeouts.