### PR TITLE
Make adding myRVs to clustermap more efficient.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea/
 .vscode/
 *.out
-config.yaml
+config*.yaml
 testcnf.yaml
 blobfuse2.log
 blobfuse2.test

--- a/component/distributed_cache/parallel_writer.go
+++ b/component/distributed_cache/parallel_writer.go
@@ -66,7 +66,8 @@ func newParallelWriter() *parallelWriter {
 		go pw.azureWriter()
 	}
 
-	log.Info("parallelWriter:: %d writers started for dcache, Used when writing to Unqualified path")
+	log.Info("parallelWriter:: %d writers started for dcache, Used when writing to Unqualified path",
+		pw.maxWriters)
 
 	return pw
 }
@@ -74,7 +75,8 @@ func newParallelWriter() *parallelWriter {
 func (pw *parallelWriter) destroyParallelWriter() {
 	close(pw.azureWriterQueue)
 	pw.wg.Wait()
-	log.Info("parallelWriter:: %d writers destroyed for dcache, Used when writing to Unqualified path")
+	log.Info("parallelWriter:: %d writers destroyed for dcache, Used when writing to Unqualified path",
+		pw.maxWriters)
 }
 
 func (pw *parallelWriter) azureWriter() {

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -111,6 +111,11 @@ func GetAllRVs() map[string]dcache.RawVolume {
 	return clusterMap.getAllRVs()
 }
 
+// It will return the RVs Map <rvId, RV> as per local cache copy of cluster map.
+func GetAllRVsById() map[string]dcache.RawVolume {
+	return clusterMap.getAllRVsById()
+}
+
 // Is rvName hosted on this node.
 func IsMyRV(rvName string) bool {
 	return clusterMap.isMyRV(rvName)
@@ -478,6 +483,14 @@ func (c *ClusterMap) getMyRVs() map[string]dcache.RawVolume {
 
 func (c *ClusterMap) getAllRVs() map[string]dcache.RawVolume {
 	return c.getLocalMap().RVMap
+}
+
+func (c *ClusterMap) getAllRVsById() map[string]dcache.RawVolume {
+	rvsById := make(map[string]dcache.RawVolume)
+	for _, rv := range c.getLocalMap().RVMap {
+		rvsById[rv.RvId] = rv
+	}
+	return rvsById
 }
 
 func (c *ClusterMap) isMyRV(rvName string) bool {

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -134,6 +134,12 @@ func GetRVsEx(mvName string) (dcache.StateEnum, map[string]dcache.StateEnum, int
 	return clusterMap.getRVsEx(mvName)
 }
 
+// Get a map of all component RVs in the cluster map.
+// The map is of the form <rvName, count> where count is the number of MVs that have this RV as a component.
+func GetAllComponentRVs() map[string]int {
+	return clusterMap.getAllComponentRVs()
+}
+
 // Return the state of the given RV from the local cache copy of cluster map.
 func GetRVState(rvName string) dcache.StateEnum {
 	return clusterMap.getRVState(rvName)
@@ -524,6 +530,20 @@ func (c *ClusterMap) getRVsEx(mvName string) (dcache.StateEnum, map[string]dcach
 		return dcache.StateInvalid, nil, -1
 	}
 	return mv.State, mv.RVs, localMap.Epoch
+}
+
+func (c *ClusterMap) getAllComponentRVs() map[string]int {
+	allComponentRVs := make(map[string]int)
+	for _, mv := range c.getLocalMap().MVMap {
+		for rvName := range mv.RVs {
+			if _, ok := allComponentRVs[rvName]; !ok {
+				allComponentRVs[rvName] = 1
+			} else {
+				allComponentRVs[rvName]++
+			}
+		}
+	}
+	return allComponentRVs
 }
 
 func (c *ClusterMap) getRVState(rvName string) dcache.StateEnum {

--- a/internal/dcache/models.go
+++ b/internal/dcache/models.go
@@ -99,6 +99,7 @@ type ClusterMapExport struct {
 }
 
 type HeartbeatData struct {
+	InitialHB     bool        `json:"initial_hb"`
 	Hostname      string      `json:"hostname"`
 	IPAddr        string      `json:"ipaddr"`
 	NodeID        string      `json:"nodeid"`

--- a/internal/dcache/rpc/client/client_pool.go
+++ b/internal/dcache/rpc/client/client_pool.go
@@ -612,7 +612,8 @@ func (ncPool *nodeClientPool) closeRPCClients() error {
 	// We never have a partially allocated client pool and we only clean up a client pool when all
 	// previously allocated clients have been released back to the pool
 	//
-	common.Assert(len(ncPool.clientChan) == int(cp.maxPerNode), len(ncPool.clientChan), cp.maxPerNode)
+	common.Assert(len(ncPool.clientChan) == int(cp.maxPerNode),
+		len(ncPool.clientChan), cp.maxPerNode, ncPool.nodeID)
 
 	close(ncPool.clientChan)
 

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -3266,11 +3266,17 @@ func (h *ChunkServiceHandler) GetMVSize(ctx context.Context, req *models.GetMVSi
 	// must have sent it and if we don't have it, refreshing from clustermap cannot add it.
 	// This cannot happen unless sender is doing something wrong, hence assert.
 	//
+	// Update: This can happen if a component RV which is still part of the MV is no longer published
+	//         by the owning node after it restarted. Client who fetches the component RV info from
+	//         clustermap will find the RV as part of the MV and hence it may send the GetMVSize request
+	//         to the node but the node that has now restarted doesn't have the component RV, hence it
+	//         fails with "InvalidRequest" error.
+	//
 	mvInfo := rvInfo.getMVInfo(req.MV)
 	if mvInfo == nil {
 		errStr := fmt.Sprintf("%s/%s not hosted by this node", rvInfo.rvName, req.MV)
 		log.Err("ChunkServiceHandler::GetMVSize: %s", errStr)
-		common.Assert(false, errStr)
+		//common.Assert(false, errStr)
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
 	}
 


### PR DESCRIPTION
Currently a new node that starts up adds its RVs to the clustermap before it can proceed. Every node does it for their RVs and they have to claim ownership on clustermap before they can do it. With large number of nodes, this serial process takes lot of time. Practically observed one node every half a second. So for 10K nodes, this will take 5000 secs. This is not acceptable.
This change improves it by letting one node add new RVs for multiple nodes, this reducing the changes needed to clustermap and thus the time.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->