### PR TITLE
Making the truncate callback handle aware.

### DIFF
--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -776,6 +776,14 @@ func libfuse_flush(path *C.char, fi *C.fuse_file_info_t) C.int {
 }
 
 // libfuse2_truncate changes the size of a file
+// There are two filesystem calls which can lead to this callback:
+//  1. Truncate() -> SetAttr() called on file path.
+//  2. ftruncate()-> SetAttr() called on file handle.
+//
+// man page:    https://man7.org/linux/man-pages/man2/truncate.2.html
+//
+// In fuse2, libfuse don't have the support for file handles in truncate callback, hence we don't get any handle here.
+// So both the truncate() and ftruncate() calls have the same behaviour.
 //
 //export libfuse2_truncate
 func libfuse2_truncate(path *C.char, off C.off_t) C.int {

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -829,14 +829,35 @@ func libfuse_flush(path *C.char, fi *C.fuse_file_info_t) C.int {
 }
 
 // libfuse_truncate changes the size of a file
+// There are two filesystem calls which can lead to this callback:
+//  1. Truncate() -> SetAttr() called on file path.
+//  2. ftruncate()-> SetAttr() called on file handle.
+//
+// man page:    https://man7.org/linux/man-pages/man2/truncate.2.html
+// Libfuse Doc: https://github.com/libfuse/libfuse/blob/fc95fd5076fd845e496bfbcec1ad9da16534b1c9/include/fuse_lowlevel.h#L328
 //
 //export libfuse_truncate
 func libfuse_truncate(path *C.char, off C.off_t, fi *C.fuse_file_info_t) C.int {
 	name := trimFusePath(path)
 	name = common.NormalizeObjectName(name)
-	log.Trace("Libfuse::libfuse_truncate : %s size %d", name, off)
 
-	err := fuseFS.NextComponent().TruncateFile(internal.TruncateFileOptions{Name: name, Size: int64(off)})
+	var handle *handlemap.Handle
+	if fi == nil {
+		handle = nil
+		log.Trace("Libfuse::libfuse_truncate : %, size: %d", name, off)
+	} else {
+		fileHandle := (*C.file_handle_t)(unsafe.Pointer(uintptr(fi.fh)))
+		handle = (*handlemap.Handle)(unsafe.Pointer(uintptr(fileHandle.obj)))
+		log.Trace("Libfuse::libfuse_truncate : %s, handle: %d, size: %d", handle.Path, handle.ID, off)
+	}
+
+	err := fuseFS.NextComponent().TruncateFile(
+		internal.TruncateFileOptions{
+			Handle: handle,
+			Name:   name,
+			Size:   int64(off),
+		})
+
 	if err != nil {
 		log.Err("Libfuse::libfuse_truncate : error truncating file %s [%s]", name, err.Error())
 		if os.IsNotExist(err) {

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -261,6 +261,14 @@ func (suite *libfuseTestSuite) TestTruncateError() {
 	testTruncateError(suite)
 }
 
+func (suite *libfuseTestSuite) TestFTruncate() {
+	testFTruncate(suite)
+}
+
+func (suite *libfuseTestSuite) TestFTruncateError() {
+	testFTruncateError(suite)
+}
+
 // release
 
 func (suite *libfuseTestSuite) TestUnlink() {

--- a/internal/component_options.go
+++ b/internal/component_options.go
@@ -127,8 +127,9 @@ type GetFileBlockOffsetsOptions struct {
 }
 
 type TruncateFileOptions struct {
-	Name string
-	Size int64
+	Handle *handlemap.Handle
+	Name   string
+	Size   int64
 }
 
 type CopyToFileOptions struct {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature**: (Brief description of the feature or issue being addressed)

  * In fuse3, when the call for the truncate is done via file handle(i.e., using the ftruncate call), the file handle can be retrieved from the truncate callback using fuse_file_info struct that was passed, just like the other callbacks like read(), write(), close() which were handle aware.

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->
Units tests were added, also tested manually.

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.
