### PR TITLE
Increase file cache size limit in config file.

### DIFF
--- a/testdata/config/azure_key.yaml
+++ b/testdata/config/azure_key.yaml
@@ -18,7 +18,7 @@ libfuse:
 file_cache:
   path: { 1 }
   timeout-sec: 30
-  max-size-mb: 2048
+  max-size-mb: 20480
   allow-non-empty-temp: true
   cleanup-on-start: true
 


### PR DESCRIPTION
…pipeline

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
Increase file cache size in the config file due to the recent [change ](https://github.com/Azure/azure-storage-fuse/pull/1870)where cache size is treated as the hard limit and fail the read/write operations with IO error in config file. To prevent this file cache size is increased from 2G->20G. The maximum file size used in the tests is 10G.