### PR TITLE
Convert read options struct to pointer in the pipeline

### DIFF
--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -447,7 +447,7 @@ func (az *AzStorage) ReadFile(options internal.ReadFileOptions) (data []byte, er
 	return az.storage.ReadBuffer(options.Handle.Path, 0, 0)
 }
 
-func (az *AzStorage) ReadInBuffer(options internal.ReadInBufferOptions) (length int, err error) {
+func (az *AzStorage) ReadInBuffer(options *internal.ReadInBufferOptions) (length int, err error) {
 	//log.Trace("AzStorage::ReadInBuffer : Read %s from %d offset", h.Path, offset)
 
 	var size int64

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -1158,7 +1158,7 @@ func (s *blockBlobTestSuite) TestReadInBuffer() {
 	h, _ = s.az.OpenFile(internal.OpenFileOptions{Name: name})
 
 	output := make([]byte, 5)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
 	s.assert.Nil(err)
 	s.assert.EqualValues(5, len)
 	s.assert.EqualValues(testData[:5], output)
@@ -1179,7 +1179,7 @@ func (s *blockBlobTestSuite) TestReadInBufferWithoutHandle() {
 	s.assert.Equal(n, len(data))
 
 	output := make([]byte, 5)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Offset: 0, Data: output, Path: name, Size: (int64)(len(data))})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Offset: 0, Data: output, Path: name, Size: (int64)(len(data))})
 	s.assert.Nil(err)
 	s.assert.EqualValues(5, len)
 	s.assert.EqualValues(testData[:5], output)
@@ -1189,7 +1189,7 @@ func (s *blockBlobTestSuite) TestReadInBufferEmptyPath() {
 	defer s.cleanupTest()
 
 	output := make([]byte, 5)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Offset: 0, Data: output, Size: 5})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Offset: 0, Data: output, Size: 5})
 	s.assert.NotNil(err)
 	s.assert.EqualValues(0, len)
 	s.assert.Equal(err.Error(), "path not given for download")
@@ -1207,7 +1207,7 @@ func (bbTestSuite *blockBlobTestSuite) TestReadInBufferWithETAG() {
 
 	output := make([]byte, 5)
 	var etag string
-	len, err := bbTestSuite.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output, Etag: &etag})
+	len, err := bbTestSuite.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output, Etag: &etag})
 	bbTestSuite.assert.Nil(err)
 	bbTestSuite.assert.NotEqual(etag, "")
 	bbTestSuite.assert.EqualValues(5, len)
@@ -1235,7 +1235,7 @@ func (bbTestSuite *blockBlobTestSuite) TestReadInBufferWithETAGMismatch() {
 	var etag string
 
 	handle, _ = bbTestSuite.az.OpenFile(internal.OpenFileOptions{Name: name})
-	_, err = bbTestSuite.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output, Etag: &etag})
+	_, err = bbTestSuite.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output, Etag: &etag})
 	bbTestSuite.assert.Nil(err)
 	bbTestSuite.assert.NotEqual(etag, "")
 	etag = strings.Trim(etag, `"`)
@@ -1250,7 +1250,7 @@ func (bbTestSuite *blockBlobTestSuite) TestReadInBufferWithETAGMismatch() {
 	_ = bbTestSuite.az.CloseFile(internal.CloseFileOptions{Handle: handle1})
 
 	// Read data back using older handle
-	_, err = bbTestSuite.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle, Offset: 5, Data: output, Etag: &etag})
+	_, err = bbTestSuite.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle, Offset: 5, Data: output, Etag: &etag})
 	bbTestSuite.assert.Nil(err)
 	bbTestSuite.assert.NotEqual(etag, "")
 	etag = strings.Trim(etag, `"`)
@@ -1270,7 +1270,7 @@ func (s *blockBlobTestSuite) TestReadInBufferLargeBuffer() {
 	h, _ = s.az.OpenFile(internal.OpenFileOptions{Name: name})
 
 	output := make([]byte, 1000) // Testing that passing in a super large buffer will still work
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
 	s.assert.Nil(err)
 	s.assert.EqualValues(h.Size, len)
 	s.assert.EqualValues(testData, output[:h.Size])
@@ -1283,7 +1283,7 @@ func (s *blockBlobTestSuite) TestReadInBufferEmpty() {
 	h, _ := s.az.CreateFile(internal.CreateFileOptions{Name: name})
 
 	output := make([]byte, 10)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
 	s.assert.Nil(err)
 	s.assert.EqualValues(0, len)
 }
@@ -1295,7 +1295,7 @@ func (s *blockBlobTestSuite) TestReadInBufferBadRange() {
 	h := handlemap.NewHandle(name)
 	h.Size = 10
 
-	_, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 20, Data: make([]byte, 2)})
+	_, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 20, Data: make([]byte, 2)})
 	s.assert.NotNil(err)
 	s.assert.EqualValues(syscall.ERANGE, err)
 }
@@ -1307,7 +1307,7 @@ func (s *blockBlobTestSuite) TestReadInBufferError() {
 	h := handlemap.NewHandle(name)
 	h.Size = 10
 
-	_, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: make([]byte, 2)})
+	_, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: make([]byte, 2)})
 	s.assert.NotNil(err)
 	s.assert.EqualValues(syscall.ENOENT, err)
 }

--- a/component/azstorage/datalake_test.go
+++ b/component/azstorage/datalake_test.go
@@ -1421,7 +1421,7 @@ func (s *datalakeTestSuite) TestReadInBuffer() {
 	h, _ = s.az.OpenFile(internal.OpenFileOptions{Name: name})
 
 	output := make([]byte, 5)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
 	s.assert.Nil(err)
 	s.assert.EqualValues(5, len)
 	s.assert.EqualValues(testData[:5], output)
@@ -1442,7 +1442,7 @@ func (s *datalakeTestSuite) TestReadInBufferWithoutHandle() {
 	s.assert.Equal(n, len(data))
 
 	output := make([]byte, 5)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Offset: 0, Data: output, Path: name, Size: (int64)(len(data))})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Offset: 0, Data: output, Path: name, Size: (int64)(len(data))})
 	s.assert.Nil(err)
 	s.assert.EqualValues(5, len)
 	s.assert.EqualValues(testData[:5], output)
@@ -1452,7 +1452,7 @@ func (s *datalakeTestSuite) TestReadInBufferEmptyPath() {
 	defer s.cleanupTest()
 
 	output := make([]byte, 5)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Offset: 0, Data: output, Size: 5})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Offset: 0, Data: output, Size: 5})
 	s.assert.NotNil(err)
 	s.assert.EqualValues(0, len)
 	s.assert.Equal(err.Error(), "path not given for download")
@@ -1470,7 +1470,7 @@ func (suite *datalakeTestSuite) TestReadInBufferWithETAG() {
 
 	output := make([]byte, 5)
 	var etag string
-	len, err := suite.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: fileHandle, Offset: 0, Data: output, Etag: &etag})
+	len, err := suite.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: fileHandle, Offset: 0, Data: output, Etag: &etag})
 	suite.assert.Nil(err)
 	suite.assert.NotEqual(etag, "")
 	suite.assert.EqualValues(5, len)
@@ -1489,7 +1489,7 @@ func (s *datalakeTestSuite) TestReadInBufferLargeBuffer() {
 	h, _ = s.az.OpenFile(internal.OpenFileOptions{Name: name})
 
 	output := make([]byte, 1000) // Testing that passing in a super large buffer will still work
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
 	s.assert.Nil(err)
 	s.assert.EqualValues(h.Size, len)
 	s.assert.EqualValues(testData, output[:h.Size])
@@ -1502,7 +1502,7 @@ func (s *datalakeTestSuite) TestReadInBufferEmpty() {
 	h, _ := s.az.CreateFile(internal.CreateFileOptions{Name: name})
 
 	output := make([]byte, 10)
-	len, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
+	len, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: output})
 	s.assert.Nil(err)
 	s.assert.EqualValues(0, len)
 }
@@ -1514,7 +1514,7 @@ func (s *datalakeTestSuite) TestReadInBufferBadRange() {
 	h := handlemap.NewHandle(name)
 	h.Size = 10
 
-	_, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 20, Data: make([]byte, 2)})
+	_, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 20, Data: make([]byte, 2)})
 	s.assert.NotNil(err)
 	s.assert.EqualValues(syscall.ERANGE, err)
 }
@@ -1526,7 +1526,7 @@ func (s *datalakeTestSuite) TestReadInBufferError() {
 	h := handlemap.NewHandle(name)
 	h.Size = 10
 
-	_, err := s.az.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: make([]byte, 2)})
+	_, err := s.az.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: make([]byte, 2)})
 	s.assert.NotNil(err)
 	s.assert.EqualValues(syscall.ENOENT, err)
 }

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -573,7 +573,7 @@ func (bc *BlockCache) getBlockSize(fileSize uint64, block *Block) uint64 {
 }
 
 // ReadInBuffer: Read the file into a buffer
-func (bc *BlockCache) ReadInBuffer(options internal.ReadInBufferOptions) (int, error) {
+func (bc *BlockCache) ReadInBuffer(options *internal.ReadInBufferOptions) (int, error) {
 	if options.Offset >= options.Handle.Size {
 		// EOF reached so early exit
 		return 0, io.EOF
@@ -1051,7 +1051,7 @@ func (bc *BlockCache) download(item *workItem) {
 
 	var etag string
 	// If file does not exists then download the block from the container
-	n, err := bc.NextComponent().ReadInBuffer(internal.ReadInBufferOptions{
+	n, err := bc.NextComponent().ReadInBuffer(&internal.ReadInBufferOptions{
 		Handle: item.handle,
 		Offset: int64(item.block.offset),
 		Data:   item.block.data,

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -538,7 +538,7 @@ func (suite *blockCacheTestSuite) TestFileReadTotalBytes() {
 
 	totaldata := uint64(0)
 	for {
-		n, err := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
+		n, err := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
 		totaldata += uint64(n)
 		if err != nil {
 			suite.assert.Contains(err.Error(), "EOF")
@@ -597,7 +597,7 @@ func (suite *blockCacheTestSuite) TestFileReadBlockCacheTmpPath() {
 
 	totaldata := uint64(0)
 	for {
-		n, err := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
+		n, err := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
 		totaldata += uint64(n)
 		if err != nil {
 			suite.assert.Contains(err.Error(), "EOF")
@@ -611,7 +611,7 @@ func (suite *blockCacheTestSuite) TestFileReadBlockCacheTmpPath() {
 
 	totaldata = uint64(0)
 	for {
-		n, err := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
+		n, err := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
 		totaldata += uint64(n)
 		if err != nil {
 			suite.assert.Contains(err.Error(), "EOF")
@@ -672,7 +672,7 @@ func (suite *blockCacheTestSuite) TestFileReadSerial() {
 
 	totaldata := uint64(0)
 	for {
-		n, err := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
+		n, err := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: int64(totaldata), Data: data})
 		totaldata += uint64(n)
 		if err != nil {
 			break
@@ -714,7 +714,7 @@ func (suite *blockCacheTestSuite) TestFileReadRandom() {
 	max := int64(100 * _1MB)
 	for i := 0; i < 50; i++ {
 		offset := rand.Int63n(max)
-		n, _ := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: offset, Data: data})
+		n, _ := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: offset, Data: data})
 		suite.assert.LessOrEqual(n, 100)
 	}
 
@@ -755,7 +755,7 @@ func (suite *blockCacheTestSuite) TestFileReadRandomNoPrefetch() {
 	max := int64(100 * _1MB)
 	for i := 0; i < 50; i++ {
 		offset := rand.Int63n(max)
-		n, _ := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: offset, Data: data})
+		n, _ := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: offset, Data: data})
 		suite.assert.Equal(h.Buffers.Cooked.Len(), 1)
 		suite.assert.Equal(h.Buffers.Cooking.Len(), 0)
 		suite.assert.LessOrEqual(n, 100)
@@ -2158,7 +2158,7 @@ func (suite *blockCacheTestSuite) TestBlockParallelReadAndWriteValidation() {
 
 	// read 1MB data at offset 0
 	data := make([]byte, _1MB)
-	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: nh, Offset: 0, Data: data})
+	n, err = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: nh, Offset: 0, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 
@@ -2367,7 +2367,7 @@ func (suite *blockCacheTestSuite) TestBlockDownloadOffsetGreaterThanFileSize() {
 	h.Size = int64(4 * _1MB)
 
 	data := make([]byte, _1MB)
-	n, err := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
+	n, err := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 
@@ -2413,7 +2413,7 @@ func (suite *blockCacheTestSuite) TestReadStagedBlock() {
 	suite.assert.Equal(1, h.Buffers.Cooked.Len())
 
 	data := make([]byte, _1MB)
-	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
+	n, err = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 
@@ -2484,7 +2484,7 @@ func (suite *blockCacheTestSuite) TestReadUncommittedBlockValidation() {
 
 	// read blocks 0, 1 and 2 which are uncommitted
 	data := make([]byte, 2*_1MB)
-	n, err := tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
+	n, err := tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(2*_1MB))
 	suite.assert.Equal(data[:], dataBuff[512:2*_1MB+512])
@@ -2492,7 +2492,7 @@ func (suite *blockCacheTestSuite) TestReadUncommittedBlockValidation() {
 
 	// read block 4 which has been committed by the previous read
 	data = make([]byte, _1MB)
-	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(4 * _1MB), Data: data})
+	n, err = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: int64(4 * _1MB), Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 	suite.assert.Equal(data[:], dataBuff[4*_1MB:5*_1MB])
@@ -2568,7 +2568,7 @@ func (suite *blockCacheTestSuite) TestReadUncommittedPrefetchedBlock() {
 
 	// read blocks 0, 1 and 2 where prefetched blocks 1 and 2 are uncommitted
 	data := make([]byte, 2*_1MB)
-	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
+	n, err = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(2*_1MB))
 	suite.assert.Equal(data[:], dataBuff[512:2*_1MB+512])
@@ -2576,7 +2576,7 @@ func (suite *blockCacheTestSuite) TestReadUncommittedPrefetchedBlock() {
 
 	// read block 4 which has been committed by the previous read
 	data = make([]byte, _1MB)
-	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(4 * _1MB), Data: data})
+	n, err = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: int64(4 * _1MB), Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(_1MB))
 	suite.assert.Equal(data[:], dataBuff[4*_1MB:5*_1MB])
@@ -2638,14 +2638,14 @@ func (suite *blockCacheTestSuite) TestReadWriteBlockInParallel() {
 
 	// read blocks 0, 1 and 2
 	data := make([]byte, 2*_1MB)
-	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
+	n, err = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 512, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(2*_1MB))
 	suite.assert.Equal(data[:], dataBuff[512:2*_1MB+512])
 	suite.assert.True(h.Dirty())
 
 	// read blocks 4 and 5
-	n, err = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: int64(4 * _1MB), Data: data})
+	n, err = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: int64(4 * _1MB), Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(n, int(2*_1MB))
 	suite.assert.Equal(data[:_1MB], dataBuff[4*_1MB:])
@@ -2795,7 +2795,7 @@ func (suite *blockCacheTestSuite) TestStrongConsistency() {
 	h, err = tobj.blockCache.OpenFile(internal.OpenFileOptions{Name: path, Flags: os.O_RDWR})
 	suite.assert.Nil(err)
 	suite.assert.NotNil(h)
-	_, _ = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
+	_, _ = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
 	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
 	suite.assert.Nil(err)
 	suite.assert.Nil(h.Buffers.Cooked)
@@ -2816,7 +2816,7 @@ func (suite *blockCacheTestSuite) TestStrongConsistency() {
 	h, err = tobj.blockCache.OpenFile(internal.OpenFileOptions{Name: path, Flags: os.O_RDWR})
 	suite.assert.Nil(err)
 	suite.assert.NotNil(h)
-	_, _ = tobj.blockCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
+	_, _ = tobj.blockCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: h, Offset: 0, Data: data})
 	err = tobj.blockCache.CloseFile(internal.CloseFileOptions{Handle: h})
 	suite.assert.Nil(err)
 	suite.assert.Nil(h.Buffers.Cooked)

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -1149,7 +1149,7 @@ func (fc *FileCache) ReadFile(options internal.ReadFileOptions) ([]byte, error) 
 }
 
 // ReadInBuffer: Read the local file into a buffer
-func (fc *FileCache) ReadInBuffer(options internal.ReadInBufferOptions) (int, error) {
+func (fc *FileCache) ReadInBuffer(options *internal.ReadInBufferOptions) (int, error) {
 	//defer exectime.StatTimeCurrentBlock("FileCache::ReadInBuffer")()
 	// The file should already be in the cache since CreateFile/OpenFile was called before and a shared lock was acquired.
 	// log.Debug("FileCache::ReadInBuffer : Reading %v bytes from %s", len(options.Data), options.Handle.Path)

--- a/component/file_cache/file_cache_test.go
+++ b/component/file_cache/file_cache_test.go
@@ -1018,7 +1018,7 @@ func (suite *fileCacheTestSuite) TestReadInBufferEmpty() {
 	handle, _ := suite.fileCache.CreateFile(internal.CreateFileOptions{Name: file, Mode: 0777})
 
 	data := make([]byte, 0)
-	length, err := suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: data})
+	length, err := suite.fileCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.EqualValues(0, length)
 	suite.assert.Empty(data)
@@ -1036,7 +1036,7 @@ func (suite *fileCacheTestSuite) TestReadInBufferNoFlush() {
 	handle, _ = suite.fileCache.OpenFile(internal.OpenFileOptions{Name: file, Mode: 0777})
 
 	output := make([]byte, 9)
-	length, err := suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output})
+	length, err := suite.fileCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output})
 	suite.assert.Nil(err)
 	suite.assert.EqualValues(data, output)
 	suite.assert.EqualValues(len(data), length)
@@ -1055,7 +1055,7 @@ func (suite *fileCacheTestSuite) TestReadInBuffer() {
 	handle, _ = suite.fileCache.OpenFile(internal.OpenFileOptions{Name: file, Mode: 0777})
 
 	output := make([]byte, 9)
-	length, err := suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output})
+	length, err := suite.fileCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle, Offset: 0, Data: output})
 	suite.assert.Nil(err)
 	suite.assert.EqualValues(data, output)
 	suite.assert.EqualValues(len(data), length)
@@ -1066,7 +1066,7 @@ func (suite *fileCacheTestSuite) TestReadInBufferErrorBadFd() {
 	// Setup
 	file := "file18"
 	handle := handlemap.NewHandle(file)
-	length, err := suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle})
+	length, err := suite.fileCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle})
 	suite.assert.NotNil(err)
 	suite.assert.EqualValues(syscall.EBADF, err)
 	suite.assert.EqualValues(0, length)
@@ -1815,7 +1815,7 @@ func (suite *fileCacheTestSuite) TestReadFileWithRefresh() {
 	f, err := suite.fileCache.OpenFile(options)
 	suite.assert.Nil(err)
 	suite.assert.False(f.Dirty())
-	n, err := suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: f, Offset: 0, Data: data})
+	n, err := suite.fileCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: f, Offset: 0, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(9, n)
 	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
@@ -1827,7 +1827,7 @@ func (suite *fileCacheTestSuite) TestReadFileWithRefresh() {
 	f, err = suite.fileCache.OpenFile(options)
 	suite.assert.Nil(err)
 	suite.assert.False(f.Dirty())
-	n, err = suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: f, Offset: 0, Data: data})
+	n, err = suite.fileCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: f, Offset: 0, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(9, n)
 	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})
@@ -1840,7 +1840,7 @@ func (suite *fileCacheTestSuite) TestReadFileWithRefresh() {
 	f, err = suite.fileCache.OpenFile(options)
 	suite.assert.Nil(err)
 	suite.assert.False(f.Dirty())
-	n, err = suite.fileCache.ReadInBuffer(internal.ReadInBufferOptions{Handle: f, Offset: 0, Data: data})
+	n, err = suite.fileCache.ReadInBuffer(&internal.ReadInBufferOptions{Handle: f, Offset: 0, Data: data})
 	suite.assert.Nil(err)
 	suite.assert.Equal(15, n)
 	err = suite.fileCache.CloseFile(internal.CloseFileOptions{Handle: f})

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -699,7 +699,7 @@ func libfuse_read(path *C.char, buf *C.char, size C.size_t, off C.off_t, fi *C.f
 		//bytesRead, err = handle.FObj.ReadAt(data[:size], int64(offset))
 	} else {
 		bytesRead, err = fuseFS.NextComponent().ReadInBuffer(
-			internal.ReadInBufferOptions{
+			&internal.ReadInBufferOptions{
 				Handle: handle,
 				Offset: int64(offset),
 				Data:   data[:size],

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -752,7 +752,7 @@ func libfuse_read(path *C.char, buf *C.char, size C.size_t, off C.off_t, fi *C.f
 		//bytesRead, err = handle.FObj.ReadAt(data[:size], int64(offset))
 	} else {
 		bytesRead, err = fuseFS.NextComponent().ReadInBuffer(
-			internal.ReadInBufferOptions{
+			&internal.ReadInBufferOptions{
 				Handle: handle,
 				Offset: int64(offset),
 				Data:   data[:size],

--- a/component/loopback/loopback_fs.go
+++ b/component/loopback/loopback_fs.go
@@ -334,7 +334,7 @@ func (lfs *LoopbackFS) ReadLink(options internal.ReadLinkOptions) (string, error
 	return strings.TrimPrefix(targetPath, lfs.path), nil
 }
 
-func (lfs *LoopbackFS) ReadInBuffer(options internal.ReadInBufferOptions) (int, error) {
+func (lfs *LoopbackFS) ReadInBuffer(options *internal.ReadInBufferOptions) (int, error) {
 	// if handle is nil, create a new handle
 	// added because after changes in xload, path and size can be passed in ReadInBufferOptions, where handle can be nil
 	if options.Handle == nil {

--- a/component/loopback/loopback_fs_test.go
+++ b/component/loopback/loopback_fs_test.go
@@ -224,7 +224,7 @@ func (suite *LoopbackFSTestSuite) TestReadInBuffer() {
 	}
 
 	for _, testCase := range testCases {
-		n, err := suite.lfs.ReadInBuffer(internal.ReadInBufferOptions{Handle: handle, Offset: testCase.offset, Data: testCase.data})
+		n, err := suite.lfs.ReadInBuffer(&internal.ReadInBufferOptions{Handle: handle, Offset: testCase.offset, Data: testCase.data})
 		assert.Nil(err)
 		assert.Equal(n, len(testCase.truth), "ReadInBuffer: number of bytes returned not equal to input size")
 		assert.Equal(testCase.data, testCase.truth)

--- a/component/xload/data_manager.go
+++ b/component/xload/data_manager.go
@@ -120,7 +120,7 @@ func (rdm *remoteDataManager) Process(item *WorkItem) (int, error) {
 func (rdm *remoteDataManager) ReadData(item *WorkItem) (int, error) {
 	// log.Debug("remoteDataManager::ReadData : Scheduling download for %s offset %v", item.Path, item.Block.Offset)
 
-	bytesTransferred, err := rdm.GetRemote().ReadInBuffer(internal.ReadInBufferOptions{
+	bytesTransferred, err := rdm.GetRemote().ReadInBuffer(&internal.ReadInBufferOptions{
 		Offset: item.Block.Offset,
 		Data:   item.Block.Data,
 		Path:   item.Path,

--- a/internal/base_component.go
+++ b/internal/base_component.go
@@ -193,7 +193,7 @@ func (base *BaseComponent) ReadFile(options ReadFileOptions) (b []byte, err erro
 	return b, err
 }
 
-func (base *BaseComponent) ReadInBuffer(options ReadInBufferOptions) (int, error) {
+func (base *BaseComponent) ReadInBuffer(options *ReadInBufferOptions) (int, error) {
 	if base.next != nil {
 		return base.next.ReadInBuffer(options)
 	}

--- a/internal/component.go
+++ b/internal/component.go
@@ -107,7 +107,7 @@ type Component interface {
 	RenameFile(RenameFileOptions) error
 
 	ReadFile(ReadFileOptions) ([]byte, error)
-	ReadInBuffer(ReadInBufferOptions) (int, error)
+	ReadInBuffer(*ReadInBufferOptions) (int, error)
 
 	WriteFile(WriteFileOptions) (int, error)
 	TruncateFile(TruncateFileOptions) error

--- a/internal/mock_component.go
+++ b/internal/mock_component.go
@@ -459,7 +459,7 @@ func (mr *MockComponentMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 }
 
 // ReadInBuffer mocks base method.
-func (m *MockComponent) ReadInBuffer(arg0 ReadInBufferOptions) (int, error) {
+func (m *MockComponent) ReadInBuffer(arg0 *ReadInBufferOptions) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadInBuffer", arg0)
 	ret0, _ := ret[0].(int)


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**: (Brief description of the feature or issue being addressed)
convert read options struct to pointer in the pipeline.
```
type ReadInBufferOptions struct {
    Handle *handlemap.Handle
    Offset int64
    Etag   *string
    Data   []byte
    Path   string
    Size   int64
}
```
The above struct takes 74 bytes, we don't want to do copy of this struct across the pipeline for every readcall. As the read operations were very frequent. This cause some performance penality.
Currently we do 3 copies of this struct for every read call, if we have the pipeline as libfuse->block_cache->attr_cache->azstorage


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->