### PR TITLE
fix dcache open error

### DIFF
--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -889,8 +889,10 @@ func (dc *DistributedCache) OpenFile(options internal.OpenFileOptions) (*handlem
 		options.Name = rawPath
 		return debug.OpenFile(options)
 	} else {
-		// If the path don't come with no explicit namespace
-		// It should first check the file in dcache, if present, read from dcache,
+		// the path don't come with no explicit namespace
+		//
+		// If file is present in dcache, in ready state, read from dcache,
+		// else If file is present in dcache, but not in ready state, fail with ENOENT,
 		// else check in azure if present, read from azure, else fail the open.
 		common.Assert(rawPath == options.Name, rawPath, options.Name)
 		dcFile, err = fm.OpenDcacheFile(rawPath)
@@ -898,6 +900,13 @@ func (dc *DistributedCache) OpenFile(options internal.OpenFileOptions) (*handlem
 			log.Debug("DistributedCache::OpenFile : Opening the file from Dcache, path : %s", options.Name)
 			handle = handlemap.NewHandle(options.Name)
 			handle.SetFsDcache()
+		} else if err == fm.ErrFileNotReady {
+			//
+			// Maybe some other/ same node is trying to write this file, we cannot serve this file from azure until
+			// dcache file state changes to ready, even if that file is already present in azure.
+			//
+			log.Err("DistributedCache::OpenFile : Failed Opening the file from Dcache, path: %s: %v", options.Name, err)
+			return nil, syscall.ENOENT
 		} else {
 			// todo: make sure we come here when opening dcache file is returning ENOENT
 			log.Err("DistributedCache::OpenFile : Dcache File Open failed with err : %s, path : %s, Trying to Open the file in Azure", err.Error(), options.Name)


### PR DESCRIPTION
if the path comes without any namepace, fail the open with ENOENT if dcache file is present and not in ready state.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:
if the path comes without any namepace, fail the open with ENOENT if
dcache file is present and not in ready state.

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
