### PR TITLE
Update MV placer to honor fault domains when choosing component RVs, and many other scale and correctness fixes

### DIFF
--- a/common/assert.go
+++ b/common/assert.go
@@ -65,6 +65,12 @@ func Assert(cond bool, msg ...interface{}) {
 // Note: Use this sparingly only to do stuff that we know for sure doesn't change the behavior of the program.
 //
 //	We need to be very careful in making sure debug build behaves same as prod builds for reliable testing.
+var isDebugBuild bool
+
 func IsDebugBuild() bool {
-	return (os.Getenv("BLOBFUSE_DEBUG") == "1")
+	return isDebugBuild
+}
+
+func init() {
+	isDebugBuild = (os.Getenv("BLOBFUSE_DEBUG") == "1")
 }

--- a/common/util.go
+++ b/common/util.go
@@ -748,6 +748,12 @@ func IsFuseHiddenFile(filePath string) bool {
 
 // Returns true if we are faking scale test.
 // This is used to test scale scenarios by allowing multiple RVs from the same local filesystem.
+var isFakeScaleTest bool
+
 func IsFakingScaleTest() bool {
-	return (os.Getenv("BLOBFUSE_FAKE_SCALE_TEST") == "1")
+	return isFakeScaleTest
+}
+
+func init() {
+	isFakeScaleTest = (os.Getenv("BLOBFUSE_FAKE_SCALE_TEST") == "1")
 }

--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -353,6 +353,9 @@ func (dc *DistributedCache) createRVList() ([]dcache.RawVolume, error) {
 			LocalCachePath: path,
 		}
 	}
+
+	log.Debug("DistributedCache::Start : created RV list with %d RVs: %+v", len(rvList), rvList)
+
 	return rvList, nil
 }
 

--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -281,25 +281,25 @@ func (dc *DistributedCache) createRVList() ([]dcache.RawVolume, error) {
 			// This avoids startup failure in case the query fails for whatever reason, as user doesn't care about
 			// fault and update domains for data placement decisions.
 			//
-			log.Warn("DistributedCache::Start : Failed to query VM's fault and update domain, but IgnoreFD and IgnoreUD are both set to true, proceeding with empty domains: %v", err)
+			log.Warn("DistributedCache::Start : Failed to query VM's fault and update domain, but IgnoreFD and IgnoreUD are both set to true, proceeding with unknown domains: %v", err)
 		}
 	} else {
-		log.Debug("DistributedCache::Start : FaultDomain: %s, UpdateDomain: %s", faultDomain, updateDomain)
+		log.Debug("DistributedCache::Start : FaultDomain: %d, UpdateDomain: %d", faultDomain, updateDomain)
 	}
 
 	// Empty fault/update domain conveys "ignore fault/update domain for data placement" to the data placer.
 	if dc.cfg.IgnoreFD {
-		log.Debug("DistributedCache::Start : IgnoreFD=true, forcing FaultDomain to empty string, placer will ignore FD for data placement decisions")
-		faultDomain = ""
-	} else if faultDomain == "" {
+		log.Debug("DistributedCache::Start : IgnoreFD=true, forcing FaultDomain to -1 (unknown), placer will ignore FD for data placement decisions")
+		faultDomain = -1
+	} else if faultDomain == -1 {
 		// If IgnoreFD is false we can't proceed with empty fault domain.
 		return nil, log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [IgnoreFD=false and VM fault domain not known, cannot proceed]"))
 	}
 
 	if dc.cfg.IgnoreUD {
-		log.Debug("DistributedCache::Start : IgnoreUD=true, forcing UpdateDomain to empty string, placer will ignore UD for data placement decisions")
-		updateDomain = ""
-	} else if updateDomain == "" {
+		log.Debug("DistributedCache::Start : IgnoreUD=true, forcing UpdateDomain to -1 (unknown), placer will ignore UD for data placement decisions")
+		updateDomain = -1
+	} else if updateDomain == -1 {
 		// If IgnoreUD is false we can't proceed with empty update domain.
 		return nil, log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [IgnoreUD=false and VM update domain not known, cannot proceed]"))
 	}

--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -318,7 +318,7 @@ func (dc *DistributedCache) createRVList() ([]dcache.RawVolume, error) {
 		if !common.IsFakingScaleTest() {
 			rvId, err = getBlockDeviceUUId(path)
 			if err != nil {
-				return nil, log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [failed to get raw volume UUID: %v]", err))
+				return nil, log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [failed to get raw volume UUID for %s: %v]", path, err))
 			}
 		}
 

--- a/component/distributed_cache/distributed_cache.go
+++ b/component/distributed_cache/distributed_cache.go
@@ -298,11 +298,18 @@ func (dc *DistributedCache) createRVList() ([]dcache.RawVolume, error) {
 			return nil, log.LogAndReturnError(fmt.Sprintf("DistributedCache::Start error [failed to evaluate local cache Total space: %v]", err))
 		}
 
+		//
+		// TODO: Set fault domain by querying the IMDS endpoint.
+		//       Till then set it to empty string which means fault domain is not known for the RV.
+		//       If fault domain is not known for an RV those RVs are considered to be in a fault domain
+		//       not matching any other fault domain, hence they can host any MV regardless of the
+		//       fault domain of other components RVs of that MV.
+		//
 		rvList[index] = dcache.RawVolume{
 			NodeId:         uuidVal,
 			IPAddress:      ipaddr,
 			RvId:           rvId,
-			FDID:           "0",
+			FDId:           "",
 			State:          dcache.StateOnline,
 			TotalSpace:     totalSpace,
 			AvailableSpace: availableSpace,

--- a/component/distributed_cache/utils.go
+++ b/component/distributed_cache/utils.go
@@ -34,9 +34,12 @@
 package distributed_cache
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"strconv"
@@ -320,4 +323,72 @@ func parseDcacheMetadataForDirEntries(dirList []*internal.ObjAttr) []*internal.O
 // Check if the file name refers to a deleted dcache file (waiting to be GC'ed).
 func isDeletedDcacheFile(rawPath string) bool {
 	return strings.HasSuffix(rawPath, dcache.DcacheDeletingFileNameSuffix)
+}
+
+// Queries the Azure Instance Metadata Service to get the Fault Domain and Update Domain for this VM.
+func queryVMFaultAndUpdateDomain() (string /* faultDomain */, string /* updateDomain */, error) {
+	const imdsURL = "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01"
+
+	//
+	// TODO: There's a "platformSubFaultDomain" also but from the documentation it seems to be not used.
+	//
+	type ComputeMetadata struct {
+		FaultDomain  string `json:"platformFaultDomain"`
+		UpdateDomain string `json:"platformUpdateDomain"`
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", imdsURL, nil)
+	if err != nil {
+		err = fmt.Errorf("error creating request to Azure Instance Metadata Service %s: %v",
+			imdsURL, err)
+		return "", "", err
+	}
+
+	// Required header for Azure Instance Metadata Service.
+	req.Header.Add("Metadata", "true")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		err = fmt.Errorf("error making request to Azure Instance Metadata Service %s: %v",
+			imdsURL, err)
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("error reading response from Azure Instance Metadata Service %s: %v",
+			imdsURL, err)
+		return "", "", err
+	}
+
+	var metadata ComputeMetadata
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		err = fmt.Errorf("error unmarshalling JSON response from Azure Instance Metadata Service %s: %v [%v]",
+			imdsURL, err, body)
+		return "", "", err
+	}
+
+	//
+	// Not sure if FaultDomain and UpdateDomain are always returned by IMDS.
+	// Don't fail if they are empty, just return them as empty strings and let caller handle as per config setting.
+	//
+	if metadata.FaultDomain != "" {
+		_, err = strconv.Atoi(metadata.FaultDomain)
+		if err != nil {
+			err = fmt.Errorf("error converting Fault Domain (%s) to integer: %v", metadata.FaultDomain, err)
+			return "", "", err
+		}
+	}
+
+	if metadata.UpdateDomain != "" {
+		_, err = strconv.Atoi(metadata.UpdateDomain)
+		if err != nil {
+			err = fmt.Errorf("error converting Update Domain (%s) to integer: %v", metadata.UpdateDomain, err)
+			return "", "", err
+		}
+	}
+
+	return metadata.FaultDomain, metadata.UpdateDomain, nil
 }

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -2232,6 +2232,13 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 			offlineRVs++
 		}
 
+		if offlineRVs == 0 {
+			// If not offline, must have at least one outofsync, else why the MV is degraded.
+			log.Debug("+ClusterManager::fixMV: %s has no offline/inband-offline component RV, nothing to fix %+v",
+				mvName, mv.RVs)
+			return
+		}
+
 		// Degraded MVs must have one or more but not all component RVs as offline, inband-offline or outofsync.
 		common.Assert((offlineRVs+outofsyncRVs) != 0 && (offlineRVs+outofsyncRVs) < NumReplicas,
 			mvName, offlineRVs, outofsyncRVs, NumReplicas)

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -870,11 +870,11 @@ func (cmi *ClusterManager) safeCleanupMyRVs(myRVs []dcache.RawVolume) (bool, err
 	// Also some other node may add a duplicate RV into the clustermap after the following check,
 	// hence we need to later check for duplicates after locking the clustermap.
 	//
-	allRVsFromClustermap := cm.GetAllRVsById()
+	allRVIdsFromClustermap := cm.GetAllRVsById()
 	for _, myRV := range myRVs {
 		common.Assert(myRV.NodeId == cmi.myNodeId, cmi.myNodeId, myRV)
 
-		cmRV, ok := allRVsFromClustermap[myRV.RvId]
+		cmRV, ok := allRVIdsFromClustermap[myRV.RvId]
 		if !ok {
 			// This RVId is not present in the clustermap, so no duplicates.
 			continue

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -1978,9 +1978,15 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 
 			if excludeNodes != nil {
 				if _, ok := excludeNodes[rv.nodeId]; ok {
+					//
 					// Skip RVs from excluded nodes.
-					log.Debug("ClusterManager::getAvailableRVsList: Skipping %s from node %s in excludeNodes %+v",
-						rv.rvName, rv.nodeId, excludeNodes)
+					// When faking scale test we add 1000s of RVs to a node which makes this log very chatty.
+					// Skip it only for that as it may be useful for a real cluster.
+					//
+					if !common.IsFakingScaleTest() {
+						log.Debug("ClusterManager::getAvailableRVsList: Skipping %s from node %s in excludeNodes %+v",
+							rv.rvName, rv.nodeId, excludeNodes)
+					}
 					continue
 				}
 			}

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -2386,7 +2386,7 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 			// Iterate over the availableRVsList and pick the first suitable RV.
 			for _, rv := range availableRVsList {
 				// availableRVsList must only contain online RVs.
-				common.Assert(rvMap[rv.rvName].State == dcache.StateOnline, rv.rvName, rvMap[rv.rvName].State)
+				//common.Assert(rvMap[rv.rvName].State == dcache.StateOnline, rv.rvName, rvMap[rv.rvName].State)
 
 				// Max slots for an RV is MVsPerRVForFixMV.
 				common.Assert(rv.slots <= MVsPerRVForFixMV, rv.slots, MVsPerRVForFixMV)

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -655,7 +655,7 @@ func cleanupRV(rv dcache.RawVolume, doNotDeleteMVs map[string]struct{}) error {
 	var deleteFailures atomic.Int64
 
 	// More than a few parallel deletes may be counter productive.
-	const maxParallelDeletes = 32
+	const maxParallelDeletes = 8
 	var tokens = make(chan struct{}, maxParallelDeletes)
 
 	entries, err := os.ReadDir(rv.LocalCachePath)
@@ -790,6 +790,7 @@ func (cmi *ClusterManager) safeCleanupMyRVs(myRVs []dcache.RawVolume) (bool, err
 	var wg sync.WaitGroup
 	var failedRV atomic.Int64
 
+	start := time.Now()
 	//
 	// Helper function for cleaning up all my RV, once we know they are not being used by the cluster.
 	//
@@ -819,7 +820,8 @@ func (cmi *ClusterManager) safeCleanupMyRVs(myRVs []dcache.RawVolume) (bool, err
 		}
 
 		// Successfully cleaned up all RVs.
-		log.Info("ClusterManager::safeCleanupMyRVs: ==> Successfully cleaned up %d RV(s) %v", len(myRVs), myRVs)
+		log.Info("ClusterManager::safeCleanupMyRVs: ==> Successfully cleaned up %d RV(s) %v in %s",
+			len(myRVs), myRVs, time.Since(start))
 
 		return nil
 	}
@@ -952,7 +954,8 @@ func (cmi *ClusterManager) safeCleanupMyRVs(myRVs []dcache.RawVolume) (bool, err
 			failedRV.Load())
 	}
 
-	log.Info("ClusterManager::safeCleanupMyRVs: ==> Successfully cleaned up %d RV(s) %v", len(myRVs), myRVs)
+	log.Info("ClusterManager::safeCleanupMyRVs: ==> Successfully cleaned up %d RV(s) %v in %s",
+		len(myRVs), myRVs, time.Since(start))
 	return true, nil
 }
 

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -2483,8 +2483,8 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 				// Remove the bad RV from MV. Do this before assigning the replacement RV, in case both
 				// are same.
 				//
-				log.Debug("ClusterManager::fixMV: Replacing (%s/%s [%s] -> %s/%s [%s])",
-					rvName, mvName, mv.RVs[rvName], newRvName, mvName, dcache.StateOutOfSync)
+				log.Debug("ClusterManager::fixMV: Replacing (%s/%s [%s] -> %s/%s [%s] [with slots: %d])",
+					rvName, mvName, mv.RVs[rvName], newRvName, mvName, dcache.StateOutOfSync, rv.slots)
 
 				delete(mv.RVs, rvName)
 				mv.RVs[newRvName] = dcache.StateOutOfSync

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -923,7 +923,7 @@ func (cmi *ClusterManager) safeCleanupMyRVs(myRVs []dcache.RawVolume) (bool, err
 			log.Info("ClusterManager::safeCleanupMyRVs: My RV %s is present as %s in clustermap", rv.RvId, rvName)
 
 			// Active MVs that we should not delete.
-			doNotDeleteMVs := cm.GetActiveMVsForRV(rvName)
+			doNotDeleteMVs = cm.GetActiveMVsForRV(rvName)
 			if len(doNotDeleteMVs) > 0 {
 				log.Debug("ClusterManager::safeCleanupMyRVs: %s has %d active MVs %+v, will not delete them",
 					rvName, len(doNotDeleteMVs), doNotDeleteMVs)

--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -2374,6 +2374,9 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 				// Remove the bad RV from MV. Do this before assigning the replacement RV, in case both
 				// are same.
 				//
+				log.Debug("ClusterManager::fixMV: Replacing (%s/%s [%s] -> %s/%s [%s])",
+					rvName, mvName, mv.RVs[rvName], newRvName, mvName, dcache.StateOutOfSync)
+
 				delete(mv.RVs, rvName)
 				mv.RVs[newRvName] = dcache.StateOutOfSync
 
@@ -2382,9 +2385,6 @@ func (cmi *ClusterManager) updateMVList(rvMap map[string]dcache.RawVolume,
 				// We don't yet update existingMVMap, we will do it once joinMV() returns
 				// successfully.
 				//
-
-				log.Debug("ClusterManager::fixMV: Replacing (%s/%s [%s] -> %s/%s)",
-					rvName, mvName, mv.RVs[rvName], newRvName, mvName)
 				foundReplacement = true
 				fixedRVs++
 				break

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -94,7 +94,7 @@ func GetOfflineMVs() map[string]dcache.MirroredVolume {
 // It will return a set of active MVs hosted by the given RV.
 // An MV is termed active for an RV if, as per the clusterMap:
 // 1. The RV is a component of the MV, and
-// 2. The component RV is in active use, i.e., its state is not offline or inband-offline.
+// 2. The component RV has state online.
 //
 // Any other MV is stale and can be safely deleted from the RV's directory.
 func GetActiveMVsForRV(rvName string) map[string]struct{} {

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -350,6 +350,8 @@ func UpdateComponentRVState(mvName string, rvName string, rvNewState dcache.Stat
 	// We would like to know why updates are taking so long, as updates blocked for long can cause other
 	// issues.
 	//
+	// TODO: We may want to relax this later but for now we want to catch any long updates.
+	//
 	common.Assert(time.Since(updateRVMessage.QueuedAt) < 30*time.Second,
 		updateRVMessage, time.Since(updateRVMessage.QueuedAt))
 

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -584,7 +584,7 @@ func (c *ClusterMap) getClusterMap() dcache.ClusterMap {
 func (c *ClusterMap) getMyRVs() map[string]dcache.RawVolume {
 	nodeId, err := common.GetNodeUUID()
 	_ = err
-	common.Assert(err == nil, fmt.Sprintf("Error getting nodeId: %v", err))
+	common.Assert(err == nil, err)
 
 	myRvs := make(map[string]dcache.RawVolume)
 	for name, rv := range c.getLocalMap().RVMap {
@@ -598,7 +598,7 @@ func (c *ClusterMap) getMyRVs() map[string]dcache.RawVolume {
 func (c *ClusterMap) getMyRVsById() map[string]dcache.RawVolume {
 	nodeId, err := common.GetNodeUUID()
 	_ = err
-	common.Assert(err == nil, fmt.Sprintf("Error getting nodeId: %v", err))
+	common.Assert(err == nil, err)
 
 	myRvsById := make(map[string]dcache.RawVolume)
 	for _, rv := range c.getLocalMap().RVMap {

--- a/internal/dcache/clustermap/clustermap_dummy_success.json
+++ b/internal/dcache/clustermap/clustermap_dummy_success.json
@@ -19,7 +19,9 @@
 		"clustermap-epoch": 300,
 		"rebalance-percentage": 80,
 		"safe-deletes": true,
-		"cache-access": "automatic"
+		"cache-access": "automatic",
+		"ignore-fd": true,
+		"ignore-ud": true
 	},
 	"rv-map": {
 		"rv0": {

--- a/internal/dcache/clustermap/utils.go
+++ b/internal/dcache/clustermap/utils.go
@@ -319,21 +319,7 @@ func IsValidRV(rv *dcache.RawVolume) (bool, error) {
 		return false, fmt.Errorf("RawVolume: Invalid RvId: %s: %+v", rv.RvId, *rv)
 	}
 
-	// If IgnoreFD config is set, FDId will be empty.
-	if rv.FDId != "" {
-		_, err := strconv.Atoi(rv.FDId)
-		if err != nil {
-			return false, fmt.Errorf("RawVolume: Invalid FDId (must be integer): %s: %+v", rv.FDId, *rv)
-		}
-	}
-
-	// If IgnoreUD config is set, UDId will be empty.
-	if rv.UDId != "" {
-		_, err := strconv.Atoi(rv.UDId)
-		if err != nil {
-			return false, fmt.Errorf("RawVolume: Invalid UDId (must be integer): %s: %+v", rv.UDId, *rv)
-		}
-	}
+	// TODO: Is there a validity check for FDId and UDId?
 
 	if rv.State != dcache.StateOnline && rv.State != dcache.StateOffline {
 		return false, fmt.Errorf("RawVolume: Invalid state: %s: %+v", rv.State, *rv)

--- a/internal/dcache/clustermap/utils.go
+++ b/internal/dcache/clustermap/utils.go
@@ -319,7 +319,21 @@ func IsValidRV(rv *dcache.RawVolume) (bool, error) {
 		return false, fmt.Errorf("RawVolume: Invalid RvId: %s: %+v", rv.RvId, *rv)
 	}
 
-	// TODO: Once we add support for querying fault domains, add the validation for FDId.
+	// If IgnoreFD config is set, FDId will be empty.
+	if rv.FDId != "" {
+		_, err := strconv.Atoi(rv.FDId)
+		if err != nil {
+			return false, fmt.Errorf("RawVolume: Invalid FDId (must be integer): %s: %+v", rv.FDId, *rv)
+		}
+	}
+
+	// If IgnoreUD config is set, UDId will be empty.
+	if rv.UDId != "" {
+		_, err := strconv.Atoi(rv.UDId)
+		if err != nil {
+			return false, fmt.Errorf("RawVolume: Invalid UDId (must be integer): %s: %+v", rv.UDId, *rv)
+		}
+	}
 
 	if rv.State != dcache.StateOnline && rv.State != dcache.StateOffline {
 		return false, fmt.Errorf("RawVolume: Invalid state: %s: %+v", rv.State, *rv)

--- a/internal/dcache/clustermap/utils.go
+++ b/internal/dcache/clustermap/utils.go
@@ -319,9 +319,7 @@ func IsValidRV(rv *dcache.RawVolume) (bool, error) {
 		return false, fmt.Errorf("RawVolume: Invalid RvId: %s: %+v", rv.RvId, *rv)
 	}
 
-	if len(rv.FDID) == 0 {
-		return false, fmt.Errorf("RawVolume: Invalid empty FDID: %+v", *rv)
-	}
+	// TODO: Once we add support for querying fault domains, add the validation for FDId.
 
 	if rv.State != dcache.StateOnline && rv.State != dcache.StateOffline {
 		return false, fmt.Errorf("RawVolume: Invalid state: %s: %+v", rv.State, *rv)

--- a/internal/dcache/clustermap/utils.go
+++ b/internal/dcache/clustermap/utils.go
@@ -198,14 +198,14 @@ func IsValidDcacheConfig(cfg *dcache.DCacheConfig) (bool, error) {
 	// MinNodes must be at least 1.
 	// We add an upper limit of 1000 as a sanity check.
 	if cfg.MinNodes < 1 || cfg.MinNodes > 1000 {
-		return false, fmt.Errorf("DCacheConfig: Invalid MinNodes: %d +%v", cfg.MinNodes, *cfg)
+		return false, fmt.Errorf("DCacheConfig: Invalid MinNodes: %d %+v", cfg.MinNodes, *cfg)
 	}
 
 	// Every node must contribute at least one RV.
 	// We must have RVs no less than NumReplicas.
 	// 100K is an arbitrary upper limit for the number of RVs in the cluster.
 	if cfg.MaxRVs < cfg.MinNodes || cfg.MaxRVs < cfg.NumReplicas || cfg.MaxRVs > 100000 {
-		return false, fmt.Errorf("DCacheConfig: Invalid MaxRVs: %d +%v", cfg.MaxRVs, *cfg)
+		return false, fmt.Errorf("DCacheConfig: Invalid MaxRVs: %d %+v", cfg.MaxRVs, *cfg)
 	}
 
 	if int64(cfg.HeartbeatSeconds) < MinHeartbeatFrequency ||
@@ -268,7 +268,7 @@ func IsValidMvMap(mvMap map[string]dcache.MirroredVolume, expectedReplicasCount 
 	for mvName, mv := range mvMap {
 		isValid, err := IsValidMV(&mv, expectedReplicasCount)
 		if !isValid {
-			return false, fmt.Errorf("MVList: Invalid MV: %v +%v", mvName, err)
+			return false, fmt.Errorf("MVList: Invalid MV: %v %+v", mvName, err)
 		}
 
 	}
@@ -352,12 +352,12 @@ func IsValidRVList(rvs []dcache.RawVolume, myRVs bool) (bool, error) {
 	for _, rv := range rvs {
 		if myRVs {
 			if rv.NodeId != myNodeID {
-				return false, fmt.Errorf("RVList: NodeId (%s) doesn't match my NodeId (%s) +%v",
+				return false, fmt.Errorf("RVList: NodeId (%s) doesn't match my NodeId (%s) %+v",
 					rv.NodeId, myNodeID, rv)
 			}
 
 			if rv.IPAddress != myIP {
-				return false, fmt.Errorf("RVList: IPAddress (%s) doesn't match my IPAddress (%s) +%v",
+				return false, fmt.Errorf("RVList: IPAddress (%s) doesn't match my IPAddress (%s) %+v",
 					rv.IPAddress, myIP, rv)
 			}
 		}
@@ -365,7 +365,7 @@ func IsValidRVList(rvs []dcache.RawVolume, myRVs bool) (bool, error) {
 		valid, err := IsValidRV(&rv)
 
 		if !valid {
-			return false, fmt.Errorf("RVList: Invalid RV: %v +%v", err, rv)
+			return false, fmt.Errorf("RVList: Invalid RV: %v %+v", err, rv)
 		}
 	}
 

--- a/internal/dcache/debug/stats/stats.go
+++ b/internal/dcache/debug/stats/stats.go
@@ -459,7 +459,17 @@ type CMStats struct {
 		MaxTime   Duration  `json:"max_time,omitempty"`
 		TotalTime Duration  `json:"-"`
 		AvgTime   Duration  `json:"avg_time,omitempty"`
-		JoinMV    struct {
+
+		GetAvailableRVsList struct {
+			Calls     int64     `json:"calls"`
+			MinTime   *Duration `json:"min_time,omitempty"`
+			MaxTime   Duration  `json:"max_time,omitempty"`
+			TotalTime Duration  `json:"-"`
+			AvgTime   Duration  `json:"avg_time,omitempty"`
+			LastError string    `json:"last_error,omitempty"`
+		} `json:"get_available_rvs_list,omitempty"`
+
+		JoinMV struct {
 			Calls              int64     `json:"calls"`
 			CallsCumulative    int64     `json:"calls_cumulative,omitempty"`
 			Failures           int64     `json:"failures,omitempty"`
@@ -651,6 +661,11 @@ func (s *DCacheStats) Preprocess() {
 	if s.CM.FixMV.CallsCumulative > 0 {
 		s.CM.FixMV.AvgTime =
 			Duration(float64(s.CM.FixMV.TotalTime) / float64(s.CM.FixMV.CallsCumulative))
+	}
+
+	if s.CM.FixMV.GetAvailableRVsList.Calls > 0 {
+		s.CM.FixMV.GetAvailableRVsList.AvgTime =
+			Duration(float64(s.CM.FixMV.GetAvailableRVsList.TotalTime) / float64(s.CM.FixMV.GetAvailableRVsList.Calls))
 	}
 
 	if s.CM.FixMV.JoinMV.CallsCumulative > 0 {

--- a/internal/dcache/debug/stats/stats.go
+++ b/internal/dcache/debug/stats/stats.go
@@ -459,17 +459,7 @@ type CMStats struct {
 		MaxTime   Duration  `json:"max_time,omitempty"`
 		TotalTime Duration  `json:"-"`
 		AvgTime   Duration  `json:"avg_time,omitempty"`
-
-		GetAvailableRVsList struct {
-			Calls     int64     `json:"calls"`
-			MinTime   *Duration `json:"min_time,omitempty"`
-			MaxTime   Duration  `json:"max_time,omitempty"`
-			TotalTime Duration  `json:"-"`
-			AvgTime   Duration  `json:"avg_time,omitempty"`
-			LastError string    `json:"last_error,omitempty"`
-		} `json:"get_available_rvs_list,omitempty"`
-
-		JoinMV struct {
+		JoinMV    struct {
 			Calls              int64     `json:"calls"`
 			CallsCumulative    int64     `json:"calls_cumulative,omitempty"`
 			Failures           int64     `json:"failures,omitempty"`
@@ -661,11 +651,6 @@ func (s *DCacheStats) Preprocess() {
 	if s.CM.FixMV.CallsCumulative > 0 {
 		s.CM.FixMV.AvgTime =
 			Duration(float64(s.CM.FixMV.TotalTime) / float64(s.CM.FixMV.CallsCumulative))
-	}
-
-	if s.CM.FixMV.GetAvailableRVsList.Calls > 0 {
-		s.CM.FixMV.GetAvailableRVsList.AvgTime =
-			Duration(float64(s.CM.FixMV.GetAvailableRVsList.TotalTime) / float64(s.CM.FixMV.GetAvailableRVsList.Calls))
 	}
 
 	if s.CM.FixMV.JoinMV.CallsCumulative > 0 {

--- a/internal/dcache/metadata_manager/metadata_manager_impl.go
+++ b/internal/dcache/metadata_manager/metadata_manager_impl.go
@@ -1345,6 +1345,13 @@ func (m *BlobMetadataManager) updateClusterMapEnd(clustermap []byte) error {
 // to the returned clustermap blob, returns error on failure.
 func (m *BlobMetadataManager) getClusterMap() ([]byte, *string, error) {
 	atomic.AddInt64(&stats.Stats.MM.Clustermap.GetCalls, 1)
+	//
+	// TODO: Currently getBlobSafe() makes minimum 3 REST calls (could be much higher in case of parallel updates)
+	//       to safely get the clustermap blob. We can optimize this to use a single REST call by embedding a checksum
+	//       property in the clustermap json itself. If that matches the checksum of the clustermap json then reader
+	//       can be sure about the integrity of the clustermap json. With this most readers will need just one call
+	//       and it'll reduce/avoid many of the unnecessary retries that happen today.
+	//
 	data, attr, err := m.getBlobSafe(filepath.Join(m.mdRoot, "clustermap.json"))
 	if err != nil {
 		stats.Stats.MM.Clustermap.LastError = err.Error()

--- a/internal/dcache/models.go
+++ b/internal/dcache/models.go
@@ -42,8 +42,8 @@ type RawVolume struct {
 	NodeId         string    `json:"node_id"`
 	IPAddress      string    `json:"ipaddr"`
 	RvId           string    `json:"rvid"`
-	FDId           string    `json:"fdid"`
-	UDId           string    `json:"udid"`
+	FDId           int       `json:"fdid"`
+	UDId           int       `json:"udid"`
 	State          StateEnum `json:"state"`
 	TotalSpace     uint64    `json:"total_space"`
 	AvailableSpace uint64    `json:"available_space"`

--- a/internal/dcache/models.go
+++ b/internal/dcache/models.go
@@ -33,6 +33,10 @@
 
 package dcache
 
+import (
+	"time"
+)
+
 type MirroredVolume struct {
 	State StateEnum            `json:"state"`
 	RVs   map[string]StateEnum `json:"rvs"`
@@ -160,5 +164,6 @@ type ComponentRVUpdateMessage struct {
 	MvName     string
 	RvName     string
 	RvNewState StateEnum
+	QueuedAt   time.Time
 	Err        chan error
 }

--- a/internal/dcache/models.go
+++ b/internal/dcache/models.go
@@ -42,7 +42,7 @@ type RawVolume struct {
 	NodeId         string    `json:"node_id"`
 	IPAddress      string    `json:"ipaddr"`
 	RvId           string    `json:"rvid"`
-	FDID           string    `json:"fdid"`
+	FDId           string    `json:"fdid"`
 	State          StateEnum `json:"state"`
 	TotalSpace     uint64    `json:"total_space"`
 	AvailableSpace uint64    `json:"available_space"`

--- a/internal/dcache/models.go
+++ b/internal/dcache/models.go
@@ -43,6 +43,7 @@ type RawVolume struct {
 	IPAddress      string    `json:"ipaddr"`
 	RvId           string    `json:"rvid"`
 	FDId           string    `json:"fdid"`
+	UDId           string    `json:"udid"`
 	State          StateEnum `json:"state"`
 	TotalSpace     uint64    `json:"total_space"`
 	AvailableSpace uint64    `json:"available_space"`
@@ -123,6 +124,8 @@ type DCacheConfig struct {
 	RebalancePercentage    uint8  `json:"rebalance-percentage"`
 	SafeDeletes            bool   `json:"safe-deletes"`
 	CacheAccess            string `json:"cache-access"`
+	IgnoreFD               bool   `json:"ignore-fd"`
+	IgnoreUD               bool   `json:"ignore-ud"`
 }
 
 type FileState string

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -2554,6 +2554,9 @@ refreshFromClustermapAndRetry:
 		mvInfo.incTotalChunkBytes(req.Length)
 	} else {
 		// JoinMV would have reserved this space before starting sync.
+		// TODO: [Tomar] I've seen this assert fail and also some other places where we assert for reservedSpace
+		//       panic: Assertion failed: [13091 4194304]
+		//       The reservedSpace update possibly has some race.
 		common.Assert(rvInfo.reservedSpace.Load() >= req.Length, rvInfo.reservedSpace.Load(), req.Length)
 		common.Assert(rvInfo.reservedSpace.Load() >= mvInfo.reservedSpace.Load(),
 			rvInfo.reservedSpace.Load(), mvInfo.reservedSpace.Load())

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -519,11 +519,16 @@ func (rv *rvInfo) getMVs() []string {
 				mvInfo.lmt)
 			common.Assert(!mvInfo.lmt.IsZero(), rv.rvName, mvInfo.mvName, mvInfo.lmb,
 				mvInfo.lmt)
+
+			mvs = append(mvs, mvInfo.mvName)
 		} else {
-			common.Assert(false, fmt.Sprintf("mvMap[%s] has value which is not of type *mvInfo", mvName))
+			err := fmt.Errorf("mvMap[%s] has value which is not of type *mvInfo: %T", mvName, val)
+			common.Assert(false, err)
+			log.Err("rvInfo::getMVs: %v", err)
+
+			/* Skip invalid entry */
 		}
 
-		mvs = append(mvs, mvInfo.mvName)
 		return true
 	})
 
@@ -1074,24 +1079,39 @@ func (mv *mvInfo) getComponentRVNameAndState(rvName string) *models.RVNameAndSta
 // This provides resilience as the retry would help client to get the updated clustermap (if there's one)
 // and if not client will retry the RPC so that we can retry again and if it fails for a limited number of
 // times and only then we fail the application IO.
+//
+// doNotFetchClustermap is used by the caller to convey if they want us to fetch fresh storage clustermap,
+// or should we use the existing local clustermap copy to refresh the mvInfo componentRVs. Caller will
+// typically make the first call with doNotFetchClustermap=true, to refresh the mvInfo componentRVs from the
+// cached local clustermap copy, and if that doesn't help, it will call this function again, this time with
+// doNotFetchClustermap=false, to fetch the latest clustermap from the storage and try again.
+// The first call with doNotFetchClustermap=true completes very fast as it just updates the mvInfo componentRVs
+// from the cached clustermap copy. This optimization is very useful for cases where some node has lot of RVs and
+// lot of MVs on those RVs and all/many of those MVs have one replica on our node. If that node goes down and comes
+// back up and those MVs are being fixed, lot of UpdateMV RPCs will be sent to our node, and we will be unnecessarily
+// refreshing the clustermap for each of those RPCs, while we only need to refresh it once and then all the
+// subsequent UpdateMV RPCs can refresh the mvInfo componentRVs from the updated local copy of the clustermap.
 
-func (mv *mvInfo) refreshFromClustermap() *models.ResponseError {
-	log.Debug("mvInfo::refreshFromClustermap: %s/%s", mv.rv.rvName, mv.mvName)
+func (mv *mvInfo) refreshFromClustermap(doNotFetchClustermap bool) *models.ResponseError {
+	log.Debug("mvInfo::refreshFromClustermap: %s/%s doNotFetchClustermap=%v",
+		mv.rv.rvName, mv.mvName, doNotFetchClustermap)
 
 	//
 	// Refresh the clustermap synchronously. Once this returns, clustermap package has the updated
 	// clustermap.
 	//
-	err := cm.RefreshClusterMap(0 /* higherThanEpoch */)
-	if err != nil {
-		errStr := fmt.Sprintf("mvInfo::refreshFromClustermap: %s/%s, failed: %v", mv.rv.rvName, mv.mvName, err)
-		log.Err("%s", errStr)
-		common.Assert(false, errStr)
-		//
-		// ErrorCode_NeedToRefreshClusterMap can also be used to convey to the client that we ran into a
-		// transient error and possibly refreshing the clustermap and retrying will help.
-		//
-		return rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
+	if !doNotFetchClustermap {
+		err := cm.RefreshClusterMap(0 /* higherThanEpoch */)
+		if err != nil {
+			errStr := fmt.Sprintf("mvInfo::refreshFromClustermap: %s/%s, failed: %v", mv.rv.rvName, mv.mvName, err)
+			log.Err("%s", errStr)
+			common.Assert(false, errStr)
+			//
+			// ErrorCode_NeedToRefreshClusterMap can also be used to convey to the client that we ran into a
+			// transient error and possibly refreshing the clustermap and retrying will help.
+			//
+			return rpc.NewResponseError(models.ErrorCode_NeedToRefreshClusterMap, errStr)
+		}
 	}
 
 	// Get component RV details from the just refreshed clustermap.
@@ -1308,7 +1328,8 @@ func (mv *mvInfo) refreshFromClustermap() *models.ResponseError {
 	// We force the update as this is the membership info that we got from clustermap.
 	// Note that with forceUpdate=true, updateComponentRVs() must never fail, hence the assert.
 	//
-	err = mv.updateComponentRVs(newComponentRVs, true /* forceUpdate */, rpc.GetMyNodeUUID())
+	err := mv.updateComponentRVs(newComponentRVs, true /* forceUpdate */, rpc.GetMyNodeUUID())
+	_ = err
 	common.Assert(err == nil, err)
 
 	return nil
@@ -1475,7 +1496,7 @@ func (mv *mvInfo) isComponentRVsValid(componentRVsInReq []*models.RVNameAndState
 	common.Assert(!containsInbandOfflineState(&componentRVsInReq), componentRVsInReq)
 
 	var componentRVsInMV []*models.RVNameAndState
-	clustermapRefreshed := false
+	clustermapRefreshed := 0
 
 	for {
 		componentRVsInMV = mv.getComponentRVs()
@@ -1487,8 +1508,12 @@ func (mv *mvInfo) isComponentRVsValid(componentRVsInReq []*models.RVNameAndState
 		//
 		err := isComponentRVsValid(componentRVsInMV, componentRVsInReq, checkState)
 		if err != nil {
-			if !clustermapRefreshed {
-				rpcErr := mv.refreshFromClustermap()
+			//
+			// Try refreshFromClustermap() twice, first time with local clustermap copy, and if that doesn't help,
+			// then try again with the latest clustermap from storage.
+			//
+			if clustermapRefreshed < 2 {
+				rpcErr := mv.refreshFromClustermap(clustermapRefreshed == 0)
 				if rpcErr != nil {
 					errStr := fmt.Sprintf("Request component RVs are invalid for MV %s [%v]",
 						mv.mvName, rpcErr.String())
@@ -1497,7 +1522,7 @@ func (mv *mvInfo) isComponentRVsValid(componentRVsInReq []*models.RVNameAndState
 					common.Assert(rpcErr.Code == models.ErrorCode_NeedToRefreshClusterMap, errStr)
 					return rpc.NewResponseError(rpcErr.Code, errStr)
 				}
-				clustermapRefreshed = true
+				clustermapRefreshed++
 				continue
 			}
 
@@ -1587,7 +1612,7 @@ func (mv *mvInfo) validateComponentRVsInSync(componentRVsInReq []*models.RVNameA
 		validState = string(dcache.StateSyncing)
 	}
 
-	clustermapRefreshed := false
+	clustermapRefreshed := 0
 
 	for {
 		targetRVNameAndState := mv.getComponentRVNameAndState(targetRVName)
@@ -1619,8 +1644,12 @@ func (mv *mvInfo) validateComponentRVsInSync(componentRVsInReq []*models.RVNameA
 			log.Err("ChunkServiceHandler::validateComponentRVsInSync: %s, clustermapRefreshed: %v",
 				errStr, clustermapRefreshed)
 
-			if !clustermapRefreshed {
-				rpcErr := mv.refreshFromClustermap()
+			//
+			// Try refreshFromClustermap() twice, first time with local clustermap copy, and if that doesn't help,
+			// then try again with the latest clustermap from storage.
+			//
+			if clustermapRefreshed < 2 {
+				rpcErr := mv.refreshFromClustermap(clustermapRefreshed == 0)
 				if rpcErr != nil {
 					err1 := fmt.Errorf("ChunkServiceHandler::validateComponentRVsInSync: Failed to refresh clustermap [%s]",
 						rpcErr.String())
@@ -1629,7 +1658,7 @@ func (mv *mvInfo) validateComponentRVsInSync(componentRVsInReq []*models.RVNameA
 					common.Assert(rpcErr.Code == models.ErrorCode_NeedToRefreshClusterMap, err1)
 					return rpcErr
 				}
-				clustermapRefreshed = true
+				clustermapRefreshed++
 				continue
 			}
 
@@ -1943,7 +1972,7 @@ func (h *ChunkServiceHandler) GetChunk(ctx context.Context, req *models.GetChunk
 	// checkValidChunkAddress() has already done the membership check, so we just need to do the state
 	// check.
 	//
-	clustermapRefreshed := false
+	clustermapRefreshed := 0
 
 	for {
 		rvNameAndState := mvInfo.getComponentRVNameAndState(rvInfo.rvName)
@@ -1980,8 +2009,12 @@ func (h *ChunkServiceHandler) GetChunk(ctx context.Context, req *models.GetChunk
 				rvInfo.rvName, req.Address.MvName, rvNameAndState.State)
 			log.Err("ChunkServiceHandler::GetChunk: %s", errStr)
 
-			if !clustermapRefreshed {
-				rpcErr := mvInfo.refreshFromClustermap()
+			//
+			// Try refreshFromClustermap() twice, first time with local clustermap copy, and if that doesn't help,
+			// then try again with the latest clustermap from storage.
+			//
+			if clustermapRefreshed < 2 {
+				rpcErr := mvInfo.refreshFromClustermap(clustermapRefreshed == 0)
 				if rpcErr != nil {
 					err1 := fmt.Errorf("ChunkServiceHandler::validateComponentRVsInSync: Failed to refresh clustermap [%s]",
 						rpcErr.String())
@@ -1990,7 +2023,7 @@ func (h *ChunkServiceHandler) GetChunk(ctx context.Context, req *models.GetChunk
 					common.Assert(rpcErr.Code == models.ErrorCode_NeedToRefreshClusterMap, err1)
 					return nil, rpcErr
 				}
-				clustermapRefreshed = true
+				clustermapRefreshed++
 				continue
 			}
 
@@ -2270,7 +2303,7 @@ func (h *ChunkServiceHandler) PutChunk(ctx context.Context, req *models.PutChunk
 	mvInfo.acquireSyncOpReadLock()
 	defer mvInfo.releaseSyncOpReadLock()
 
-	clustermapRefreshed := false
+	clustermapRefreshed := 0
 
 refreshFromClustermapAndRetry:
 	componentRVsInMV := mvInfo.getComponentRVs()
@@ -2318,8 +2351,12 @@ refreshFromClustermapAndRetry:
 				log.Err("ChunkServiceHandler::PutChunk: %s", errStr)
 				//common.Assert(false, errStr)
 
-				if !clustermapRefreshed {
-					rpcErr := mvInfo.refreshFromClustermap()
+				//
+				// Try refreshFromClustermap() twice, first time with local clustermap copy, and if that doesn't help,
+				// then try again with the latest clustermap from storage.
+				//
+				if clustermapRefreshed < 2 {
+					rpcErr := mvInfo.refreshFromClustermap(clustermapRefreshed == 0)
 					if rpcErr != nil {
 						err1 := fmt.Errorf("ChunkServiceHandler::PutChunk: Failed to refresh clustermap [%s]",
 							rpcErr.String())
@@ -2328,7 +2365,7 @@ refreshFromClustermapAndRetry:
 						common.Assert(rpcErr.Code == models.ErrorCode_NeedToRefreshClusterMap, err1)
 						return nil, rpcErr
 					}
-					clustermapRefreshed = true
+					clustermapRefreshed++
 					goto refreshFromClustermapAndRetry
 				}
 
@@ -2354,8 +2391,12 @@ refreshFromClustermapAndRetry:
 					rv.Name, req.Chunk.Address.MvName, rvNameAndState.State)
 				log.Err("ChunkServiceHandler::PutChunk: %s", errStr)
 
-				if !clustermapRefreshed {
-					rpcErr := mvInfo.refreshFromClustermap()
+				//
+				// Try refreshFromClustermap() twice, first time with local clustermap copy, and if that doesn't help,
+				// then try again with the latest clustermap from storage.
+				//
+				if clustermapRefreshed < 2 {
+					rpcErr := mvInfo.refreshFromClustermap(clustermapRefreshed == 0)
 					if rpcErr != nil {
 						err1 := fmt.Errorf("ChunkServiceHandler::PutChunk: Failed to refresh clustermap [%s]",
 							rpcErr.String())
@@ -2364,7 +2405,7 @@ refreshFromClustermapAndRetry:
 						common.Assert(rpcErr.Code == models.ErrorCode_NeedToRefreshClusterMap, err1)
 						return nil, rpcErr
 					}
-					clustermapRefreshed = true
+					clustermapRefreshed++
 					goto refreshFromClustermapAndRetry
 				}
 
@@ -2984,7 +3025,7 @@ func (h *ChunkServiceHandler) JoinMV(ctx context.Context, req *models.JoinMVRequ
 		// For newMV, we won't have the MV in clustermap yet, so no need to refresh.
 		//
 		if !newMV {
-			rpcErr := mvInfo.refreshFromClustermap()
+			rpcErr := mvInfo.refreshFromClustermap(false /* doNotUpdateClustermap */)
 			if rpcErr != nil {
 				errStr = fmt.Sprintf("%s, refreshFromClustermap() failed, aborting JoinMV: %s",
 					errStr, rpcErr.String())
@@ -3091,7 +3132,8 @@ func (h *ChunkServiceHandler) UpdateMV(ctx context.Context, req *models.UpdateMV
 		return nil, rpc.NewResponseError(models.ErrorCode_InvalidRequest, errStr)
 	}
 
-	clustermapRefreshed := false
+	clustermapRefreshed := 0
+
 	for {
 		rvInfo := h.getRVInfoFromRVName(req.RVName)
 		if rvInfo == nil {
@@ -3141,14 +3183,18 @@ func (h *ChunkServiceHandler) UpdateMV(ctx context.Context, req *models.UpdateMV
 		//
 		err := mvInfo.updateComponentRVs(req.ComponentRV, false /* forceUpdate */, req.SenderNodeID)
 		if err != nil {
-			if !clustermapRefreshed {
-				rpcErr := mvInfo.refreshFromClustermap()
+			//
+			// Try refreshFromClustermap() twice, first time with local clustermap copy, and if that doesn't help,
+			// then try again with the latest clustermap from storage.
+			//
+			if clustermapRefreshed < 2 {
+				rpcErr := mvInfo.refreshFromClustermap(clustermapRefreshed == 0)
 				if rpcErr != nil {
 					log.Err("ChunkServiceHandler::UpdateMV: Failed to refresh clustermap [%s]",
 						rpcErr.String())
 					return nil, rpcErr
 				}
-				clustermapRefreshed = true
+				clustermapRefreshed++
 				continue
 			}
 

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -366,19 +366,20 @@ func NewChunkServiceHandler(rvMap map[string]dcache.RawVolume) error {
 			//
 			updateInbandOfflineToOffline(&componentRVs)
 
-			//
-			// Acquire lock on rvInfo.rwMutex.
-			// This is running from the single startup thread, so we don't really need the lock, but
-			// addToMVMap() asserts for that.
-			//
 			mvDirSize, err := getMVDirSize(filepath.Join(rv.LocalCachePath, mvName))
 			if err != nil {
 				log.Err("NewChunkServiceHandler: %v", err)
+				common.Assert(false, rv.LocalCachePath, mvName, err)
 			}
 
 			mvInfo := newMVInfo(rvInfo, mvName, componentRVs, rpc.GetMyNodeUUID())
 			mvInfo.incTotalChunkBytes(mvDirSize)
 
+			//
+			// Acquire lock on rvInfo.rwMutex.
+			// This is running from the single startup thread, so we don't really need the lock, but
+			// addToMVMap() asserts for that.
+			//
 			rvInfo.acquireRvInfoLock()
 			rvInfo.addToMVMap(mvName, mvInfo, 0 /* reservedSpace */)
 			rvInfo.releaseRvInfoLock()

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -1397,7 +1397,7 @@ func (mv *mvInfo) incTotalChunkBytes(bytes int64) {
 func (mv *mvInfo) decTotalChunkBytes(bytes int64) {
 	mv.totalChunkBytes.Add(-bytes)
 	log.Debug("mvInfo::decTotalChunkBytes: totalChunkBytes for MV %s is %d", mv.mvName, mv.totalChunkBytes.Load())
-	common.Assert(mv.totalChunkBytes.Load() >= 0, fmt.Sprintf("totalChunkBytes for MV %s is %d", mv.mvName, mv.totalChunkBytes.Load()))
+	common.Assert(mv.totalChunkBytes.Load() >= 0, fmt.Sprintf("totalChunkBytes for MV %s is %d, bytes: %d", mv.mvName, mv.totalChunkBytes.Load(), bytes))
 }
 
 // acquire read lock on the opMutex.


### PR DESCRIPTION
Fault domain may or may not be available for an RV. If available we honor it and do not pick multiple component RVs of an MV from the same fault domain. If fault domain is not available for an RV it can be used for pplacing any MV. This way we work well w/ and w/o fault domain info for RVs.
This change itself doesn't add support to query fault domain from IMDS endpoint.

This also updates the placer so that it tries to distribute MVs uniformly across various RVs picking RVs which are free over RVs which are fuller.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [] Bug fix
- [x] New feature
- [x] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
