### PR TITLE
Turn off kernel attribute caching regardless of direct_io mount option

### DIFF
--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -250,12 +250,26 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		}
 	*/
 
-	if lf.directIO {
-		lf.negativeTimeout = 0
-		lf.attributeExpiration = 0
-		lf.entryExpiration = 0
-		log.Crit("Libfuse::Validate : DirectIO enabled, setting fuse timeouts to 0")
-	}
+	//
+	// For now I'm turning off kernel attribute caching altogether, as it causes issues with
+	// new files getting created. Kernel caches the file size as -1 (when the file is created)
+	// and later when the file is completely written and its size updated, the kernel cache is
+	// not invalidated, so the file size is still -1.
+	//
+	// TODO: Later if we want to support kernel attribute caching, we have to duly invalidte the
+	//       kernel cache when the file is written and its size is updated.
+	//
+	/*
+		if lf.directIO {
+			lf.negativeTimeout = 0
+			lf.attributeExpiration = 0
+			lf.entryExpiration = 0
+			log.Crit("Libfuse::Validate : DirectIO enabled, setting fuse timeouts to 0")
+		}
+	*/
+	lf.negativeTimeout = 0
+	lf.attributeExpiration = 0
+	lf.entryExpiration = 0
 
 	if !(config.IsSet(compName+".uid") || config.IsSet(compName+".gid") ||
 		config.IsSet("lfuse.uid") || config.IsSet("lfuse.gid")) {

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -229,8 +229,11 @@ func populateFuseArgs(opts *C.fuse_options_t, args *C.fuse_args_t) (*C.fuse_opti
 	// We want to keep as few fuse threads as possible, just large enough to handle parallel requests
 	// fairly well. Fuse has a default of 10 which should be ok but we set it to 8 to be explicit about
 	// our intent to use a small number of threads.
+	// Commenting out max_threads for now as some systems still has older libfuse which does not support
+	// this option.
+	// TODO: Make it conditional based on libfuse version.
 	//
-	options += ",max_threads=8"
+	//options += ",max_threads=8"
 	options += ",max_idle_threads=100000"
 
 	// clone_fd should generally we good, let's keep a watch on this.


### PR DESCRIPTION
Since a new file starts with size -1 which is later updated to the correct size after the write is done and the file is closed, but we dont't invalidsate the kernel cache so kernel still reports -1 as the file size. For now I'm turning off the kernel attribute cache fully, later if we want to enable the kernel attribute cache we need to invalidte the cache when file size changes.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
