### PR TITLE
Correct direct_io behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.6.0 (Unreleased)
 **Bug Fixes**
 - Fail file open operation if the file being downloaded by file-cache can not fit in available disk space (either configured by user or computed implicitly by blobfuse). User application will receive ENOSPC (no space left on device) in response to file open call.
+- *direct_io* mode was disabling both kernel and blobfuse level caching post 2.4.0. With this release it will disable kernel data and metadata caching. Blobfuse level data and metadata caching will be valid for 1 second by default but user can tune these using file_cache and attr_cache timeouts.
+
 
 ## 2.5.0 (2025-07-17)
 **Bug Fixes**

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -395,11 +395,6 @@ var mountCmd = &cobra.Command{
 			}
 		}
 
-		if config.IsSet("disable-kernel-cache") && directIO {
-			// Both flag shall not be enable together
-			return fmt.Errorf("direct-io and disable-kernel-cache cannot be enabled together")
-		}
-
 		if !config.IsSet("logging.file-path") {
 			options.Logging.LogFilePath = common.DefaultLogFilePath
 		}
@@ -463,17 +458,6 @@ var mountCmd = &cobra.Command{
 		log.Info("Mount Command: %s", os.Args)
 		log.Crit("Logging level set to : %s", logLevel.String())
 		log.Debug("Mount allowed on nonempty path : %v", options.NonEmpty)
-
-		if directIO {
-			// Direct IO is enabled, so remove the attr-cache from the pipeline
-			for i, name := range options.Components {
-				if name == "attr_cache" {
-					options.Components = append(options.Components[:i], options.Components[i+1:]...)
-					log.Crit("Mount::runPipeline : Direct IO enabled, removing attr_cache from pipeline")
-					break
-				}
-			}
-		}
 
 		// Clean up any cache directory if cleanup-on-start is set from the cli parameter or specified in parameter in
 		// config file for a specific component for file-cache, block-cache, xload.

--- a/component/file_cache/file_cache.go
+++ b/component/file_cache/file_cache.go
@@ -235,9 +235,9 @@ func (c *FileCache) Configure(_ bool) error {
 	directIO := false
 	_ = config.UnmarshalKey("direct-io", &directIO)
 
-	if directIO {
-		c.cacheTimeout = 0
-		log.Crit("FileCache::Configure : Direct IO mode enabled, cache timeout is set to 0")
+	if directIO && !config.IsSet(compName+".file-cache-timeout-in-seconds") && !config.IsSet(compName+".timeout-sec") {
+		c.cacheTimeout = 1
+		log.Crit("FileCache::Configure : Direct IO mode enabled, cache timeout is set to 1")
 	}
 
 	if config.IsSet(compName + ".empty-dir-check") {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
Correcting direct_io behaviour
1. Disable kernel data and metadata caching
2. Set file-cache timeout to 1 second if not configured explicitly by user
3. Set attr-cache timeout to 1 second if not configured explicitly by user

## How Has This Been Tested?
Mabual

## Checklist
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [x] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
NA