### PR TITLE
Prevent closing the RPC client again in PutChunkDC timeout

### DIFF
--- a/internal/dcache/rpc/client/client.go
+++ b/internal/dcache/rpc/client/client.go
@@ -94,6 +94,17 @@ type rpcClient struct {
 	// highPrio indicates if this client is used for high priority requests (case 2 above).
 	//
 	highPrio bool
+
+	//
+	// Boolean flag to indicate if this client has been closed. This is used to avoid double closing of
+	// the client. In PutChunkDC we can get timeout because of bad connection between the downstream nodes,
+	// and not necessarily between the client node and target/next-hop node. So, we reset the client for the
+	// target node. Resetting involves closing the client and creating a new one. If the target node is bad,
+	// then creating a new RPC client for the node will fail. So, we then delete all the clients for the
+	// target node. In deleteRPCClient() we will try to close the client again. So, to prevent this, we use
+	// this flag.
+	//
+	isClosed bool
 }
 
 var protocolFactory thrift.TProtocolFactory
@@ -175,6 +186,12 @@ func (c *rpcClient) close() error {
 		log.Err("rpcClient::close: Failed to close transport for node %s at %s [%v]", c.nodeID, c.nodeAddress, err.Error())
 		return err
 	}
+
+	//
+	// Mark the client as closed. This is to prevent closing of the client again.
+	// Refer comment in rpcClient struct for details.
+	//
+	c.isClosed = true
 
 	return nil
 }

--- a/internal/dcache/rpc/client/client.go
+++ b/internal/dcache/rpc/client/client.go
@@ -189,6 +189,7 @@ func (c *rpcClient) close() error {
 
 	//
 	// Mark the client as closed. This is to prevent closing of the client again.
+	// DeleteAllRPCClients() uses this flag to prevent double closing of the client.
 	// Refer comment in rpcClient struct for details.
 	//
 	c.isClosed = true

--- a/internal/dcache/rpc/client/client_pool.go
+++ b/internal/dcache/rpc/client/client_pool.go
@@ -864,8 +864,9 @@ func (cp *clientPool) deleteAllRPCClients(client *rpcClient, confirmedBadNode bo
 	//
 	// Node client pool may not be present for the node in case of PutChunkDC timeout error,
 	// where we first reset the client, which closes the client and then creates a new client.
-	// If the new client creation fails, we come here to delete all clients. Meanwhile some other thread
-	// may have closed all the clients for the target node and deleted the node client pool.
+	// If the new client creation fails, we come here to delete all clients. Meanwhile after
+	// reset has released the node level lock, some other thread may have closed all the clients
+	// for the target node and deleted the node client pool.
 	// So, we assert here that the client passed in the argument is closed.
 	//
 	if ncPool == nil {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
In PutChunkDC timeout error, we reset the client for the target node which first closes the client and then creates a new one. If the new client creation fails, we then try to delete all the clients for the target node. In delete, we again try to close the same client which results in assert failure.
