### PR TITLE
Perform sync of more than one chunk in parallel, to speed up resync jobs

### DIFF
--- a/internal/dcache/cluster_manager/cluster_manager.go
+++ b/internal/dcache/cluster_manager/cluster_manager.go
@@ -468,6 +468,9 @@ func (cmi *ClusterManager) start(dCacheConfig *dcache.DCacheConfig, rvs []dcache
 // If it's able to successfully fetch the global clustermap, it returns a pointer to the unmarshalled ClusterMap
 // and the Blob etag corresponding to that.
 //
+// If multiple fetchAndUpdateLocalClusterMap() calls race, a call that completes later may get an older clustermap
+// with lower epoch, in that case it doesn't update the local copy and returns the current clustermap and etag.
+//
 // Note: Use this instead of directly calling getClusterMap() as it ensures that once it returns we can safely
 //       call various clustermap functions and they will return information as per the latest downloaded clustermap.
 //       This is important, f.e., updateMVList() may be working on the latest clustermap copy and in the process
@@ -565,6 +568,27 @@ func (cmi *ClusterManager) fetchAndUpdateLocalClusterMap() (*dcache.ClusterMap, 
 		common.Assert(cm.IsValidDcacheConfig(cmi.config))
 		atomic.AddInt64(&stats.Stats.CM.LocalClustermap.Unchanged, 1)
 		return &storageClusterMap, etag, nil
+	}
+
+	//
+	// Sometimes a fetchAndUpdateLocalClusterMap() that started later may be able to update the local
+	// clustermap earlier than one that started earlier, due to various delays in the execution path.
+	// Avoid out-of-order updates by checking the epoch.
+	//
+	if cmi.localMapETag != nil && storageClusterMap.Epoch < cm.GetEpoch() {
+		log.Debug("ClusterManager::fetchAndUpdateLocalClusterMap: Ignoring backward epoch change (%d -> %d) etag: (%s -> %s)",
+			cm.GetEpoch(), storageClusterMap.Epoch, *cmi.localMapETag, *etag)
+
+		localClusterMap := cm.GetClusterMap()
+
+		// Cache config must have been saved when we saved the clustermap.
+		common.Assert(cmi.config != nil)
+		common.Assert(cm.IsValidDcacheConfig(cmi.config))
+		// If epoch is different, etag must be different.
+		common.Assert(*etag != *cmi.localMapETag, *etag, *cmi.localMapETag)
+		atomic.AddInt64(&stats.Stats.CM.LocalClustermap.Unchanged, 1)
+
+		return &localClusterMap, cmi.localMapETag, nil
 	}
 
 	//

--- a/internal/dcache/clustermap/clustermap.go
+++ b/internal/dcache/clustermap/clustermap.go
@@ -407,6 +407,10 @@ func UpdateComponentRVState(mvName string, rvName string, rvNewState dcache.Stat
 	// We would like to know why updates are taking so long, as updates blocked for long can cause other
 	// issues.
 	//
+	// One scenario where this can happen is when some node dies while it was updating the clustermap, so
+	// the clustermap is marked "being updated" and hence it'll remain in that state till the timeout expires
+	// and some other node assumes the leader role. This can easily be more than a minute.
+	//
 	// TODO: We may want to relax this later but for now we want to catch any long updates.
 	//
 	common.Assert(time.Since(updateRVMessage.QueuedAt) < 30*time.Second,

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -1786,9 +1786,9 @@ func copyOutOfSyncChunks(job *syncJob) error {
 			time.Sleep(1 * time.Second)
 
 			if time.Since(startWait) > 60*time.Second {
-				common.Assert(false, time.Since(startWait), len(syncChunkSema), job.toString())
 				log.Err("ReplicationManager::copyOutOfSyncChunks: %d sync threads didn't complete in %s: %s",
 					len(syncChunkSema), time.Since(startWait), job.toString())
+				common.Assert(false, time.Since(startWait), len(syncChunkSema), job.toString())
 				break
 			}
 		}

--- a/internal/dcache/replication_manager/replication_manager.go
+++ b/internal/dcache/replication_manager/replication_manager.go
@@ -1645,10 +1645,17 @@ func copyOutOfSyncChunks(job *syncJob) error {
 		return err
 	}
 
-	chunksCopied := 0
-	bytesCopied := int64(0)
+	var chunksCopied atomic.Int64
+	var bytesCopied atomic.Int64
+	const parallelSyncThreads = 16
+	// Upto parallelSyncThreads concurrent chunk copy operations.
+	var syncChunkSema = make(chan struct{}, parallelSyncThreads)
+	var errCount atomic.Int32
 
-	// TODO: make this parallel
+	//
+	// Go over each chunk and copy the out of sync chunks to the target MV replica,
+	// max parallelSyncThreads outstanding.
+	//
 	for _, entry := range entries {
 		if entry.IsDir() {
 			log.Warn("ReplicationManager::copyOutOfSyncChunks: Skipping directory %s/%s",
@@ -1717,147 +1724,216 @@ func copyOutOfSyncChunks(job *syncJob) error {
 			continue
 		}
 
-		log.Debug("ReplicationManager::copyOutOfSyncChunks: Copying chunk %s/%s, Mtime (%d) <= syncStartTime (%d) [%d usecs before sync start]",
-			sourceMVPath, entry.Name(), info.ModTime().UnixMicro(), job.syncStartTime,
+		log.Debug("ReplicationManager::copyOutOfSyncChunks: Copying chunk %s/%s, size: %d, Mtime (%d) <= syncStartTime (%d) [%d usecs before sync start]",
+			sourceMVPath, entry.Name(), info.Size(), info.ModTime().UnixMicro(), job.syncStartTime,
 			job.syncStartTime-info.ModTime().UnixMicro())
 
-		fileID := chunkParts[0]
-		common.Assert(common.IsValidUUID(fileID))
+		// Get a token (out of max parallelSyncThreads) to start a chunk copy.
+		syncChunkSema <- struct{}{}
 
-		// convert string to int64
-		offsetInMiB, err := strconv.ParseInt(chunkParts[1], 10, 64)
-		if err != nil {
-			// TODO: should we return error in this case?
-			errStr := fmt.Sprintf("Invalid offset for chunk %s [%v]", entry.Name(), err)
-			log.Err("ReplicationManager::copyOutOfSyncChunks: %s", errStr)
-			common.Assert(false, errStr)
-			continue
-		}
+		go func(chunkName string, info os.FileInfo) {
+			//
+			// One token must have been acquired before starting this sync thread, and cannot start
+			// more than parallelSyncThreads sync threads.
+			//
+			common.Assert(len(syncChunkSema) > 0 && len(syncChunkSema) <= parallelSyncThreads,
+				len(syncChunkSema), job.toString())
 
-		srcChunkPath := filepath.Join(sourceMVPath, entry.Name())
-		srcData, err := os.ReadFile(srcChunkPath)
-		if err != nil {
-			// TODO: should we return error in this case?
-			errStr := fmt.Sprintf("os.ReadFile(%s) failed [%v]", srcChunkPath, err.Error())
-			log.Err("ReplicationManager::copyOutOfSyncChunks: %s", errStr)
-			common.Assert(false, errStr)
-			continue
-		}
+			// Release the token once this chunk copy is done (success or failure).
+			defer func() {
+				<-syncChunkSema
+			}()
 
-		putChunkReq := &models.PutChunkRequest{
-			Chunk: &models.Chunk{
-				Address: &models.Address{
-					FileID:      fileID,
-					RvID:        destRvID,
-					MvName:      job.mvName,
-					OffsetInMiB: offsetInMiB,
-				},
-				Data: srcData,
-				Hash: "", // TODO: hash validation will be done later
-			},
-			Length: int64(len(srcData)),
-			// SyncID is used for logging and debugging, to easily match client and server side logs.
-			SyncID:          job.syncID,
-			SourceRVName:    job.srcRVName,
-			ComponentRV:     job.componentRVs,
-			ClustermapEpoch: job.clustermapEpoch,
-		}
-
-		retryCnt := 0
-		for {
-			log.Debug("ReplicationManager::copyOutOfSyncChunks: [%d] Copying chunk %s (%s/%s -> %s/%s): %v",
-				retryCnt, srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
-				rpc.PutChunkRequestToString(putChunkReq))
-
-			ctx, cancel := context.WithTimeout(context.Background(), RPCClientTimeout*time.Second)
-			defer cancel()
-
-			putChunkResp, err := rpc_client.PutChunk(ctx, destNodeID, putChunkReq, false /* fromFwder */)
-			_ = putChunkResp
-
-			// Common case.
-			if err == nil {
-				common.Assert(putChunkResp != nil)
-				log.Debug("ReplicationManager::copyOutOfSyncChunks: Copied chunk %s (%s/%s -> %s/%s): %v",
-					srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
-					rpc.PutChunkResponseToString(putChunkResp))
-				break
+			err, chunkSize := copySingleChunk(job, chunkName)
+			if err != nil {
+				log.Err("ReplicationManager::copyOutOfSyncChunks: copySingleChunk(%s) failed: %v",
+					chunkName, err)
+				errCount.Add(1)
+				return
 			}
+			common.Assert(chunkSize == info.Size(), chunkSize, info.Size(), entry.Name())
+			bytesCopied.Add(chunkSize)
+			chunksCopied.Add(1)
+		}(entry.Name(), info)
 
-			log.Err("ReplicationManager::copyOutOfSyncChunks: Failed to copy chunk %s (%s/%s -> %s/%s) %v: %v",
-				srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
-				rpc.PutChunkRequestToString(putChunkReq), err)
-
-			rpcErr := rpc.GetRPCResponseError(err)
-			if rpcErr == nil || rpcErr.GetCode() == models.ErrorCode_ThriftError {
-				//
-				// This error means that the node is not reachable.
-				// Mark the destination RV as inband-offline, so that the fix-mv workflow can select a new RV
-				// and the resync can be reattempted.
-				//
-				log.Err("ReplicationManager::copyOutOfSyncChunks: Failed to reach node %s [%v]",
-					destNodeID, err)
-
-				// Fall through and return error, caller will mark job.destRVName as inband-offline.
-			} else if rpcErr.GetCode() == models.ErrorCode_NeedToRefreshClusterMap {
-				//
-				// NeedToRefreshClusterMap is the only error on which we retry the PutChunk, but only if
-				// the new clustermap still has the same source and destination RVs, in online and syncing
-				// state respectively. Note that the sync job is responsible for sync'ing one MV replica,
-				// so all we care about is that the source and destination RVs have not changed.
-				//
-				errCM := cm.RefreshClusterMap(-putChunkReq.ClustermapEpoch)
-				if errCM == nil {
-					mvState, rvs, epoch := cm.GetRVsEx(job.mvName)
-					srcRVState, srcRVok := rvs[job.srcRVName]
-					dstRVState, dstRVok := rvs[job.destRVName]
-
-					if srcRVok && dstRVok && srcRVState == dcache.StateOnline &&
-						dstRVState == dcache.StateSyncing {
-						job.componentRVs = cm.RVMapToList(job.mvName, rvs)
-						job.clustermapEpoch = epoch
-
-						putChunkReq.ComponentRV = job.componentRVs
-						putChunkReq.ClustermapEpoch = job.clustermapEpoch
-
-						retryCnt++
-
-						if retryCnt < 5 {
-							log.Debug("ReplicationManager::copyOutOfSyncChunks: Retrying copy of chunk %s (%s/%s -> %s/%s), retryCnt: %d, mvState: %s, epoch: %d",
-								srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
-								retryCnt, mvState, epoch)
-							continue
-						}
-
-						log.Err("ReplicationManager::copyOutOfSyncChunks: Exceeded %d retries while copying chunk %s (%s/%s -> %s/%s), epoch: %d",
-							retryCnt, srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName, epoch)
-					} else {
-						// Clustermap changed in a way that makes it unsafe to continue the sync job.
-						errStr := fmt.Sprintf("Aborting sync, Clustermap changed, srcRVok: %s, srcRVState: %s, dstRVok: %s, dstRVState: %s, mvState: %s, epoch: %d",
-							srcRVok, srcRVState, dstRVok, dstRVState, mvState, epoch)
-						log.Err("ReplicationManager::copyOutOfSyncChunks: %s", errStr)
-					}
-				} else {
-					log.Err("ReplicationManager::copyOutOfSyncChunks: RefreshClusterMap() failed for %s (retryCnt: %d): %v",
-						rpc.PutChunkRequestToString(putChunkReq), retryCnt, errCM)
-				}
-			} else {
-				//
-				// Non-retriable error in syncing.
-				// Fall through and return error, caller will mark job.destRVName as inband-offline.
-				//
-			}
-
-			return err
+		//
+		// Bail out on first error.
+		//
+		if errCount.Load() > 0 {
+			log.Err("ReplicationManager::copyOutOfSyncChunks: Failed to copy one or more chunks (%d), aborting: %s",
+				errCount.Load(), job.toString())
+			break
 		}
-
-		chunksCopied++
-		bytesCopied += int64(len(srcData))
 	}
 
 	log.Debug("ReplicationManager::copyOutOfSyncChunks: Copied %d chunks totalling %d bytes, Sync job: %s",
 		chunksCopied, bytesCopied, job.toString())
 	return nil
+}
+
+func copySingleChunk(job *syncJob, chunkName string) (error, int64) {
+	log.Debug("ReplicationManager::copySingleChunk: chunk: %s, sync job: %s", chunkName, job.toString())
+
+	sourceMVPath := filepath.Join(getCachePathForRVName(job.srcRVName), job.mvName)
+	common.Assert(common.DirectoryExists(sourceMVPath), sourceMVPath)
+
+	destRvID := getRvIDFromRvName(job.destRVName)
+	common.Assert(common.IsValidUUID(destRvID))
+
+	destNodeID := getNodeIDFromRVName(job.destRVName)
+	common.Assert(common.IsValidUUID(destNodeID))
+
+	chunkParts := strings.Split(chunkName, ".")
+	// We should be called only for valid data chunks.
+	common.Assert(len(chunkParts) == 3, chunkName)
+
+	fileID := chunkParts[0]
+	common.Assert(common.IsValidUUID(fileID))
+
+	// Convert string to int64.
+	offsetInMiB, err := strconv.ParseInt(chunkParts[1], 10, 64)
+	if err != nil {
+		// We don't expect invalid chunk names lying around.
+		err = fmt.Errorf("Invalid offset for chunk %s: %v", chunkName, err)
+		log.Err("ReplicationManager::copySingleChunk: %v", err)
+		common.Assert(false, err)
+		return err, -1
+	}
+
+	srcChunkPath := filepath.Join(sourceMVPath, chunkName)
+	srcData, err := os.ReadFile(srcChunkPath)
+	if err != nil {
+		err = fmt.Errorf("os.ReadFile(%s) failed: %v", srcChunkPath, err)
+		log.Err("ReplicationManager::copySingleChunk: %v", err)
+		common.Assert(false, err)
+		return err, -1
+	}
+
+	job.mu.Lock()
+	putChunkReq := &models.PutChunkRequest{
+		Chunk: &models.Chunk{
+			Address: &models.Address{
+				FileID:      fileID,
+				RvID:        destRvID,
+				MvName:      job.mvName,
+				OffsetInMiB: offsetInMiB,
+			},
+			Data: srcData,
+			Hash: "", // TODO: hash validation will be done later
+		},
+		Length: int64(len(srcData)),
+		// SyncID is used for logging and debugging, to easily match client and server side logs.
+		SyncID:          job.syncID,
+		SourceRVName:    job.srcRVName,
+		ComponentRV:     job.componentRVs,
+		ClustermapEpoch: job.clustermapEpoch,
+	}
+	job.mu.Unlock()
+
+	retryCnt := 0
+	for {
+		log.Debug("ReplicationManager::copySingleChunk: [%d] Copying chunk %s (%s/%s -> %s/%s): %v",
+			retryCnt, srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
+			rpc.PutChunkRequestToString(putChunkReq))
+
+		ctx, cancel := context.WithTimeout(context.Background(), RPCClientTimeout*time.Second)
+		defer cancel()
+
+		// In case of retry, clear SenderNodeID, else PutChunk() will complain.
+		putChunkReq.SenderNodeID = ""
+		putChunkResp, err := rpc_client.PutChunk(ctx, destNodeID, putChunkReq, false /* fromFwder */)
+		_ = putChunkResp
+
+		// Common case.
+		if err == nil {
+			common.Assert(putChunkResp != nil)
+			log.Debug("ReplicationManager::copySingleChunk: Copied chunk %s (%s/%s -> %s/%s): %v",
+				srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
+				rpc.PutChunkResponseToString(putChunkResp))
+			break
+		}
+
+		log.Err("ReplicationManager::copySingleChunk: Failed to copy chunk %s (%s/%s -> %s/%s) %v: %v",
+			srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
+			rpc.PutChunkRequestToString(putChunkReq), err)
+
+		rpcErr := rpc.GetRPCResponseError(err)
+		if rpcErr == nil || rpcErr.GetCode() == models.ErrorCode_ThriftError {
+			//
+			// This error means that the node is not reachable.
+			// Mark the destination RV as inband-offline, so that the fix-mv workflow can select a new RV
+			// and the resync can be reattempted.
+			//
+			log.Err("ReplicationManager::copySingleChunk: Failed to reach node %s [%v]",
+				destNodeID, err)
+
+			// Fall through and return error, caller will mark job.destRVName as inband-offline.
+		} else if rpcErr.GetCode() == models.ErrorCode_NeedToRefreshClusterMap {
+			//
+			// NeedToRefreshClusterMap is the only error on which we retry the PutChunk, but only if
+			// the new clustermap still has the same source and destination RVs, in online and syncing
+			// state respectively. Note that the sync job is responsible for sync'ing one MV replica,
+			// so all we care about is that the source and destination RVs have not changed.
+			//
+			errCM := cm.RefreshClusterMap(-putChunkReq.ClustermapEpoch)
+			if errCM == nil {
+				mvState, rvs, epoch := cm.GetRVsEx(job.mvName)
+				srcRVState, srcRVok := rvs[job.srcRVName]
+				dstRVState, dstRVok := rvs[job.destRVName]
+
+				if srcRVok && dstRVok && srcRVState == dcache.StateOnline &&
+					dstRVState == dcache.StateSyncing {
+
+					job.mu.Lock()
+					// Clustermap epoch can only increase.
+					common.Assert(epoch >= job.clustermapEpoch,
+						epoch, job.clustermapEpoch, putChunkReq.ClustermapEpoch, job.toString())
+
+					job.componentRVs = cm.RVMapToList(job.mvName, rvs)
+					job.clustermapEpoch = epoch
+
+					putChunkReq.ComponentRV = job.componentRVs
+					putChunkReq.ClustermapEpoch = job.clustermapEpoch
+					job.mu.Unlock()
+
+					retryCnt++
+
+					if retryCnt < 5 {
+						log.Debug("ReplicationManager::copySingleChunk: Retrying copy of chunk %s (%s/%s -> %s/%s), retryCnt: %d, mvState: %s, epoch: %d",
+							srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName,
+							retryCnt, mvState, epoch)
+						continue
+					}
+
+					log.Err("ReplicationManager::copySingleChunk: Exceeded %d retries while copying chunk %s (%s/%s -> %s/%s), epoch: %d",
+						retryCnt, srcChunkPath, job.srcRVName, job.mvName, job.destRVName, job.mvName, epoch)
+				} else {
+					// Clustermap changed in a way that makes it unsafe to continue the sync job.
+					errStr := fmt.Sprintf("Aborting sync, Clustermap changed, srcRVok: %s, srcRVState: %s, dstRVok: %s, dstRVState: %s, mvState: %s, epoch: %d",
+						srcRVok, srcRVState, dstRVok, dstRVState, mvState, epoch)
+					log.Err("ReplicationManager::copySingleChunk: %s", errStr)
+				}
+			} else {
+				log.Err("ReplicationManager::copySingleChunk: RefreshClusterMap() failed for %s (retryCnt: %d): %v",
+					rpc.PutChunkRequestToString(putChunkReq), retryCnt, errCM)
+			}
+		} else {
+			//
+			// Non-retriable error in syncing.
+			// Fall through and return error, caller will mark job.destRVName as inband-offline.
+			//
+		}
+
+		return err, -1
+	}
+
+	bytesCopied := int64(len(srcData))
+	common.Assert(bytesCopied > 0, bytesCopied, chunkName, job.toString())
+
+	log.Debug("ReplicationManager::copySingleChunk: Copied chunk %s, bytes: %d, Sync job: %s",
+		chunkName, bytesCopied, job.toString())
+
+	return nil, bytesCopied
 }
 
 // GetMVSize() is called from fixMV workflow, by the cluster manager or from syncMV() by replication manager.

--- a/internal/dcache/rpc/client/client_pool.go
+++ b/internal/dcache/rpc/client/client_pool.go
@@ -619,7 +619,14 @@ func (cp *clientPool) getRPCClient(nodeID string, highPrio bool) (*rpcClient, er
 			// node negative. Others who get a client after that must benefit from the negative node
 			// information and avoid unnecessary timeouts.
 			//
-			if err := cp.checkNegativeNode(nodeID); err != nil {
+			// Also need to check if the nodeClientPool is marked deleting, after we acquire the node lock
+			// above, as deleteAllRPCClients() may have set deleting to true while we were waiting for the
+			// node lock. We will also miss that wakeup if we start waiting on the cond variable below.
+			//
+			if err := cp.checkNegativeNode(nodeID); err != nil || ncPool.deleting.Load() {
+				if err == nil {
+						err = fmt.Errorf("node %s marked deleting: %w", nodeID, NegativeNodeError)
+				}
 				//
 				// Release the client back to the channel.
 				// Even though this node is negative, we need to signal *all* waiters on the channel as
@@ -658,6 +665,13 @@ func (cp *clientPool) getRPCClient(nodeID string, highPrio bool) (*rpcClient, er
 
 					ncPool.clientChan <- client
 
+					//
+					// Perform this check once more with mu lock held.
+					// It may so happen that mulitple threads requesting non-high-priority clients call getRPCClient()
+					// simultaneously and all of them reach the above check after dequeuing a client from the channel.
+					// In this case the above check may pass even though there are not enough (or no) high-priority
+					// clients active.
+					//
 					if ncPool.numActiveHighPrio.Load()+int64(len(ncPool.clientChan)) <= ncPool.numReservedHighPrio {
 						ncPool.cond.Wait()
 					} else {

--- a/internal/dcache/rpc/client/client_pool.go
+++ b/internal/dcache/rpc/client/client_pool.go
@@ -625,7 +625,7 @@ func (cp *clientPool) getRPCClient(nodeID string, highPrio bool) (*rpcClient, er
 			//
 			if err := cp.checkNegativeNode(nodeID); err != nil || ncPool.deleting.Load() {
 				if err == nil {
-						err = fmt.Errorf("node %s marked deleting: %w", nodeID, NegativeNodeError)
+					err = fmt.Errorf("node %s marked deleting: %w", nodeID, NegativeNodeError)
 				}
 				//
 				// Release the client back to the channel.

--- a/internal/dcache/rpc/server/handler.go
+++ b/internal/dcache/rpc/server/handler.go
@@ -726,7 +726,13 @@ func (mv *mvInfo) updateComponentRVs(componentRVs []*models.RVNameAndState, clus
 	common.Assert(len(componentRVs) == int(cm.GetCacheConfig().NumReplicas),
 		len(componentRVs), cm.GetCacheConfig().NumReplicas)
 	common.Assert(clustermapEpoch > 0, mv.mvName, clustermapEpoch)
-	common.Assert(clustermapEpoch >= mv.clustermapEpoch, clustermapEpoch, mv.clustermapEpoch, mv.mvName)
+
+	//
+	// A refreshFromClustermap() call can start before another one (and gets an older epoch) but the first one
+	// may reach here after the second call (which may have updated mvInfo) so we may come here with a
+	// clustermapEpoch which is less than mv.clustermapEpoch. In that case we simply skip the update.
+	//
+	//common.Assert(clustermapEpoch >= mv.clustermapEpoch, clustermapEpoch, mv.clustermapEpoch, mv.rv.rvName, mv.mvName)
 
 	mv.rwMutex.Lock()
 	defer mv.rwMutex.Unlock()


### PR DESCRIPTION
currently copyOutOfSyncChunks() copies one chunk at a time, resulting in low resync throughput. This change copies 16 chunks parallely.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
