### PR TITLE
Track incomplete words correctly.

### DIFF
--- a/internal/dcache/file_manager/file_manager.go
+++ b/internal/dcache/file_manager/file_manager.go
@@ -130,7 +130,7 @@ func NewFileIOManager() error {
 	// maxUnackedWindow is how much we want to allow writing to the fastest MV before we pause to let the
 	// slowest MV catch up. We want to allow at least one stripe width of chunks to be unacked so that we
 	// allow one write to each MV, but not more than four stripe widths or 4GB worth of chunks.
-	// These limits have been chosen based on some experiments, to minimize wait under normal conditions.
+	// These limits have been chosen based on experiments, to minimize wait under normal conditions.
 	//
 	maxUnackedWindow := int(4096 / cm.GetCacheConfig().ChunkSizeMB)
 	maxUnackedWindow = max(maxUnackedWindow, int(cm.GetCacheConfig().StripeWidth)*1)


### PR DESCRIPTION
Previously we were only considering 00000111 form of completions, i.e., all chunks completed ar the start of the word. While this was fine technically, but for accurate tracking we must track 01000111 also.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
