### PR TITLE
[Race detector-1] Make bitmap threadsafe

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -156,7 +156,7 @@ type LogConfig struct {
 
 // Flags for block
 const (
-	BlockFlagUnknown uint16 = iota
+	BlockFlagUnknown uint64 = iota
 	DirtyBlock
 	TruncatedBlock
 )
@@ -165,7 +165,7 @@ type Block struct {
 	sync.RWMutex
 	StartIndex int64
 	EndIndex   int64
-	Flags      BitMap16
+	Flags      BitMap64
 	Id         string
 	Data       []byte
 }
@@ -182,7 +182,7 @@ func (block *Block) Truncated() bool {
 
 // Flags for block offset list
 const (
-	BlobFlagUnknown     uint16 = iota
+	BlobFlagUnknown     uint64 = iota
 	BlobFlagHasNoBlocks        // set if the blob does not have any blocks
 	BlobFlagBlockListModified
 )
@@ -190,7 +190,7 @@ const (
 // list that holds blocks containing ids and corresponding offsets
 type BlockOffsetList struct {
 	BlockList     []*Block //blockId to offset mapping
-	Flags         BitMap16
+	Flags         BitMap64
 	BlockIdLength int64
 	Size          int64
 	Mtime         time.Time

--- a/common/util.go
+++ b/common/util.go
@@ -52,6 +52,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"gopkg.in/ini.v1"
@@ -294,19 +295,63 @@ func GetCurrentDistro() string {
 	return distro
 }
 
-type BitMap16 uint16
+// ThreadSafe Bitmap Implementation
+type BitMap64 uint64
 
 // IsSet : Check whether the given bit is set or not
-func (bm BitMap16) IsSet(bit uint16) bool { return (bm & (1 << bit)) != 0 }
+func (bm *BitMap64) IsSet(bit uint64) bool {
+	return (atomic.LoadUint64((*uint64)(bm)) & (1 << bit)) != 0
+}
 
 // Set : Set the given bit in bitmap
-func (bm *BitMap16) Set(bit uint16) { *bm |= (1 << bit) }
+// Return true if the bit was not set and was set by this call, false if the bit was already set.
+func (bm *BitMap64) Set(bit uint64) bool {
+	for {
+		loaded := atomic.LoadUint64((*uint64)(bm))
+		if (loaded & (1 << bit)) != 0 {
+			// Bit already set.
+			return false
+		}
+		newValue := loaded | (1 << bit)
+		if atomic.CompareAndSwapUint64((*uint64)(bm), loaded, newValue) {
+			// Bit was set successfully.
+			return true
+		}
+	}
+}
 
 // Clear : Clear the given bit from bitmap
-func (bm *BitMap16) Clear(bit uint16) { *bm &= ^(1 << bit) }
+// Return true if the bit is set and cleared by this call, false if the bit was already cleared.
+func (bm *BitMap64) Clear(bit uint64) bool {
+	for {
+		loaded := atomic.LoadUint64((*uint64)(bm))
+		if (loaded & (1 << bit)) == 0 {
+			// Bit already cleared.
+			return false
+		}
+		newValue := loaded &^ (1 << bit)
+		if atomic.CompareAndSwapUint64((*uint64)(bm), loaded, newValue) {
+			// Bit was cleared successfully.
+			return true
+		}
+	}
+}
 
 // Reset : Reset the whole bitmap by setting it to 0
-func (bm *BitMap16) Reset() { *bm = 0 }
+// Return true if the bitmap is cleared by this call, false if it was already cleared.
+func (bm *BitMap64) Reset() bool {
+	for {
+		loaded := atomic.LoadUint64((*uint64)(bm))
+		if loaded == 0 {
+			// Bitmap already cleared.
+			return false
+		}
+		if atomic.CompareAndSwapUint64((*uint64)(bm), loaded, 0) {
+			// Bitmap was cleared successfully.
+			return true
+		}
+	}
+}
 
 type KeyedMutex struct {
 	mutexes sync.Map // Zero value is empty and ready for use

--- a/component/attr_cache/cacheMap.go
+++ b/component/attr_cache/cacheMap.go
@@ -43,7 +43,7 @@ import (
 
 // Flags represented in BitMap for various flags in the attr cache item
 const (
-	AttrFlagUnknown uint16 = iota
+	AttrFlagUnknown uint64 = iota
 	AttrFlagExists
 	AttrFlagValid
 )
@@ -52,7 +52,7 @@ const (
 type attrCacheItem struct {
 	attr     *internal.ObjAttr
 	cachedAt time.Time
-	attrFlag common.BitMap16
+	attrFlag common.BitMap64
 }
 
 func newAttrCacheItem(attr *internal.ObjAttr, exists bool, cachedAt time.Time) *attrCacheItem {

--- a/component/block_cache/block.go
+++ b/component/block_cache/block.go
@@ -43,7 +43,7 @@ import (
 
 // Various flags denoting state of a block
 const (
-	BlockFlagFresh       uint16 = iota
+	BlockFlagFresh       uint64 = iota
 	BlockFlagDownloading        // Block is being downloaded
 	BlockFlagUploading          // Block is being uploaded
 	BlockFlagDirty              // Block has been written and data is not persisted yet
@@ -64,7 +64,7 @@ type Block struct {
 	offset uint64          // Start offset of the data this block holds
 	id     int64           // Id of the block i.e. (offset / block size)
 	state  chan int        // Channel depicting data has been read for this block or not
-	flags  common.BitMap16 // Various states of the block
+	flags  common.BitMap64 // Various states of the block
 	data   []byte          // Data read from blob
 	node   *list.Element   // node representation of this block in the list inside handle
 }

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -71,7 +71,7 @@ type Libfuse struct {
 	disableWritebackCache bool
 	ignoreOpenFlags       bool
 	nonEmptyMount         bool
-	lsFlags               common.BitMap16
+	lsFlags               common.BitMap64
 	maxFuseThreads        uint32
 	directIO              bool
 	umask                 uint32

--- a/internal/attribute.go
+++ b/internal/attribute.go
@@ -40,26 +40,26 @@ import (
 	"github.com/Azure/azure-storage-fuse/v2/common"
 )
 
-func NewDirBitMap() common.BitMap16 {
-	bm := common.BitMap16(0)
+func NewDirBitMap() common.BitMap64 {
+	bm := common.BitMap64(0)
 	bm.Set(PropFlagIsDir)
 	return bm
 }
 
-func NewSymlinkBitMap() common.BitMap16 {
-	bm := common.BitMap16(0)
+func NewSymlinkBitMap() common.BitMap64 {
+	bm := common.BitMap64(0)
 	bm.Set(PropFlagSymlink)
 	return bm
 }
 
-func NewFileBitMap() common.BitMap16 {
-	bm := common.BitMap16(0)
+func NewFileBitMap() common.BitMap64 {
+	bm := common.BitMap64(0)
 	return bm
 }
 
 // Flags represented in common.BitMap16 for various properties of the object
 const (
-	PropFlagUnknown uint16 = iota
+	PropFlagUnknown uint64 = iota
 	PropFlagNotExists
 	PropFlagIsDir
 	PropFlagEmptyDir
@@ -75,7 +75,7 @@ type ObjAttr struct {
 	Crtime   time.Time          // creation time
 	Size     int64              // size of the file/directory
 	Mode     os.FileMode        // permissions in 0xxx format
-	Flags    common.BitMap16    // flags
+	Flags    common.BitMap64    // flags
 	Path     string             // full path
 	Name     string             // base name of the path
 	MD5      []byte             // MD5 of the blob as per last GetAttr

--- a/internal/handlemap/handle_map.go
+++ b/internal/handlemap/handle_map.go
@@ -51,7 +51,7 @@ const InvalidHandleID HandleID = 0
 
 // Flags represented in BitMap for various flags in the handle
 const (
-	HandleFlagUnknown uint16 = iota
+	HandleFlagUnknown uint64 = iota
 	HandleFlagDirty          // File has been modified with write operation or is a new file
 	HandleFlagFSynced        // User has called fsync on the file explicitly
 	HandleFlagCached         // File is cached in the local system by blobfuse2
@@ -81,7 +81,7 @@ type Handle struct {
 	Mtime    time.Time
 	UnixFD   uint64          // Unix FD created by create/open syscall
 	OptCnt   uint64          // Number of operations done on this file
-	Flags    common.BitMap16 // Various states of the file
+	Flags    common.BitMap64 // Various states of the file
 	Path     string          // Always holds path relative to mount dir
 	values   map[string]any  // Map to hold other info if application wants to store
 }

--- a/test/benchmark_test/bitmap_bench_test.go
+++ b/test/benchmark_test/bitmap_bench_test.go
@@ -1,0 +1,260 @@
+/*
+    _____           _____   _____   ____          ______  _____  ------
+   |     |  |      |     | |     | |     |     | |       |            |
+   |     |  |      |     | |     | |     |     | |       |            |
+   | --- |  |      |     | |-----| |---- |     | |-----| |-----  ------
+   |     |  |      |     | |     | |     |     |       | |       |
+   | ____|  |_____ | ____| | ____| |     |_____|  _____| |_____  |_____
+
+
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2020-2025 Microsoft Corporation. All rights reserved.
+   Author : <blobfusedev@microsoft.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+// run this benchmark with: go test bitmap_bench_test.go -bench=. -benchmem
+
+package benchmark_test
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// --- Your original implementations (paste or import from your package) ---
+
+type BitMap64 uint64
+
+// IsSet : Check whether the given bit is set or not
+func (bm *BitMap64) IsSet(bit uint64) bool {
+	return (atomic.LoadUint64((*uint64)(bm)) & (1 << bit)) != 0
+}
+
+// Set : Set the given bit in bitmap
+// Return true if the bit was not set and was set by this call, false if the bit was already set.
+func (bm *BitMap64) Set(bit uint64) bool {
+	for {
+		loaded := atomic.LoadUint64((*uint64)(bm))
+		if (loaded & (1 << bit)) != 0 {
+			// Bit already set.
+			return false
+		}
+		newValue := loaded | (1 << bit)
+		if atomic.CompareAndSwapUint64((*uint64)(bm), loaded, newValue) {
+			// Bit was set successfully.
+			return true
+		}
+	}
+}
+
+// Clear : Clear the given bit from bitmap
+// Return true if the bit is set and cleared by this call, false if the bit was already cleared.
+func (bm *BitMap64) Clear(bit uint64) bool {
+	for {
+		loaded := atomic.LoadUint64((*uint64)(bm))
+		if (loaded & (1 << bit)) == 0 {
+			// Bit already cleared.
+			return false
+		}
+		newValue := loaded &^ (1 << bit)
+		if atomic.CompareAndSwapUint64((*uint64)(bm), loaded, newValue) {
+			// Bit was cleared successfully.
+			return true
+		}
+	}
+}
+
+// Reset : Reset the whole bitmap by setting it to 0
+// Return true if the bitmap is cleared by this call, false if it was already cleared.
+func (bm *BitMap64) Reset() bool {
+	for {
+		loaded := atomic.LoadUint64((*uint64)(bm))
+		if loaded == 0 {
+			// Bitmap already cleared.
+			return false
+		}
+		if atomic.CompareAndSwapUint64((*uint64)(bm), loaded, 0) {
+			// Bitmap was cleared successfully.
+			return true
+		}
+	}
+}
+
+type BitMap16 uint16
+
+// IsSet : Check whether the given bit is set or not
+func (bm BitMap16) IsSet(bit uint16) bool { return (bm & (1 << bit)) != 0 }
+
+// Set : Set the given bit in bitmap
+func (bm *BitMap16) Set(bit uint16) { *bm |= (1 << bit) }
+
+// Clear : Clear the given bit from bitmap
+func (bm *BitMap16) Clear(bit uint16) { *bm &= ^(1 << bit) }
+
+// Reset : Reset the whole bitmap by setting it to 0
+func (bm *BitMap16) Reset() { *bm = 0 }
+
+// --- Benchmarks ---
+//
+// Run with: go test -bench=. -benchmem
+
+// Single-threaded benchmarks for Set
+
+func BenchmarkBitMap64_Set(b *testing.B) {
+	var bm BitMap64
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Restrict bit index to 0..63
+		bit := uint64(i & 63)
+		bm.Set(bit)
+	}
+}
+
+func BenchmarkBitMap16_Set(b *testing.B) {
+	var bm BitMap16
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Restrict bit index to 0..15
+		bit := uint16(i & 15)
+		bm.Set(bit)
+	}
+}
+
+// Single-threaded benchmarks for IsSet
+
+func BenchmarkBitMap64_IsSet(b *testing.B) {
+	var bm BitMap64
+	// Pre-set some bits
+	for i := 0; i < 64; i++ {
+		bm.Set(uint64(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bit := uint64(i & 63)
+		_ = bm.IsSet(bit)
+	}
+}
+
+func BenchmarkBitMap16_IsSet(b *testing.B) {
+	var bm BitMap16
+	// Pre-set some bits
+	for i := 0; i < 16; i++ {
+		bm.Set(uint16(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bit := uint16(i & 15)
+		_ = bm.IsSet(bit)
+	}
+}
+
+// Single-threaded benchmarks for Clear
+
+func BenchmarkBitMap64_Clear(b *testing.B) {
+	var bm BitMap64
+	// Pre-set all bits
+	for i := 0; i < 64; i++ {
+		bm.Set(uint64(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bit := uint64(i & 63)
+		bm.Clear(bit)
+	}
+}
+
+func BenchmarkBitMap16_Clear(b *testing.B) {
+	var bm BitMap16
+	// Pre-set all bits
+	for i := 0; i < 16; i++ {
+		bm.Set(uint16(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bit := uint16(i & 15)
+		bm.Clear(bit)
+	}
+}
+
+// Single-threaded benchmarks for Reset
+
+func BenchmarkBitMap64_Reset(b *testing.B) {
+	var bm BitMap64
+	// Pre-set all bits once
+	for i := 0; i < 64; i++ {
+		bm.Set(uint64(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bm.Reset()
+	}
+}
+
+func BenchmarkBitMap16_Reset(b *testing.B) {
+	var bm BitMap16
+	// Pre-set all bits once
+	for i := 0; i < 16; i++ {
+		bm.Set(uint16(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bm.Reset()
+	}
+}
+
+// Parallel benchmarks to highlight atomic contention vs non-atomic
+
+func BenchmarkBitMap64_Set_Parallel(b *testing.B) {
+	var bm BitMap64
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			bit := uint64(i & 63)
+			bm.Set(bit)
+			i++
+		}
+	})
+}
+
+func BenchmarkBitMap16_Set_Parallel(b *testing.B) {
+	var bm BitMap16
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			bit := uint16(i & 15)
+			bm.Set(bit)
+			i++
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [x] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- Made bitmap16 threadsafe and converted it to use uint64 (one of the reason for change is uint16 has no support for CAS operations)
- Previously we have unsafe implementation of this, causing races while running race detector

Benchmark: [program](https://go.dev/play/p/FFMYv_5ZOxb)
<img width="1064" height="346" alt="image" src="https://github.com/user-attachments/assets/1aeb6f96-4a3f-49a6-8429-99c97d137edd" />

After evaluating the results, there is no observable perf difference that this is PR is causing


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
