### PR TITLE
Disable msi auth testing in Code coverage

### DIFF
--- a/blobfuse2-code-coverage.yaml
+++ b/blobfuse2-code-coverage.yaml
@@ -65,8 +65,9 @@ stages:
           # -------------------------------------------------------
           # Pull and build the code and create the containers.
           - template: 'azure-pipeline-templates/build.yml'
-            parameters:
-              skip_msi: "false"
+            # Disabling this for now, as user assigned MSI's are disabled for the 1es hosted pools.
+            # parameters:
+            #   skip_msi: "false"
 
           # -------------------------------------------------------
           # UT based code coverage test.
@@ -556,7 +557,7 @@ stages:
           - script: |
               echo 'mode: count' > ./blobfuse2_coverage_raw.rpt
               tail -q -n +2 ./*.cov >> ./blobfuse2_coverage_raw.rpt
-              cat ./blobfuse2_coverage_raw.rpt | grep -v mock_component | grep -v base_component | grep -v loopback | grep -v tools | grep -v "common/log" | grep -v "common/exectime" | grep -v "common/types.go" | grep -v "internal/stats_manager" | grep -v "main.go" | grep -v "component/azstorage/azauthmsi.go" | grep -v "component/azstorage/azauthspn.go" | grep -v "component/stream" | grep -v "component/custom" | grep -v "component/azstorage/azauthcli.go" | grep -v "exported/exported.go" |  grep -v "component/block_cache/stream.go"  | grep -v "component/azstorage/azauthWorkloadIdentity.go" | grep -v "component/azstorage/policies.go" | grep -v "cmd/health-monitor_stop.go" > ./blobfuse2_coverage.rpt
+              cat ./blobfuse2_coverage_raw.rpt | grep -v mock_component | grep -v base_component | grep -v loopback | grep -v tools | grep -v "common/log" | grep -v "common/exectime" | grep -v "common/types.go" | grep -v "internal/stats_manager" | grep -v "main.go" | grep -v "component/azstorage/azauthmsi.go" | grep -v "component/azstorage/azauthspn.go" | grep -v "component/stream" | grep -v "component/custom" | grep -v "component/azstorage/azauthcli.go" | grep -v "exported/exported.go" |  grep -v "component/block_cache/stream.go"  | grep -v "component/azstorage/azauthWorkloadIdentity.go" | grep -v "component/azstorage/policies.go" | grep -v "cmd/health-monitor_stop.go" | grep -v "component/azstorage/azauth.go"  > ./blobfuse2_coverage.rpt
               go tool cover -func blobfuse2_coverage.rpt  > ./blobfuse2_func_cover.rpt
               go tool cover -html=./blobfuse2_coverage.rpt -o ./blobfuse2_coverage.html
               go tool cover -html=./blobfuse2_ut.cov -o ./blobfuse2_ut.html

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -41,6 +41,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -655,4 +656,11 @@ func (suite *utilTestSuite) TestGetGoroutineIDParallel() {
 	}
 
 	suite.Len(idMap, workers, "expected unique goroutine ids equal to workers")
+}
+
+func (suite *utilTestSuite) TestSetFrsize() {
+	st := &syscall.Statfs_t{}
+	var val uint64 = 4096
+	SetFrsize(st, val)
+	suite.assert.Equal(int64(val), st.Frsize)
 }


### PR DESCRIPTION
* Disable msi auth in unit tests to pass the code coverage, this is because the creating user assigned msi is disabled for 1es hosted pools.
* Add missing unit tests