### PR TITLE
Ensure logger is destroyed before returning from mount command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug Fixes**
 - Fix panic while reading an archived blob using file-cache ([PR #2127](https://github.com/Azure/azure-storage-fuse/pull/2127)]
+- Ensure logger is properly deinitialized on mount failures ([PR #2125](https://github.com/Azure/azure-storage-fuse/pull/2125)]
 
 ## 2.5.2 (2026-01-19)
 **Features**

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -440,6 +440,12 @@ var mountCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize logger [%s]", err.Error())
 		}
 
+		// It's best to destroy the logger before we return to the caller, as caller may abruptly exit on error and we
+		// might lose some logs in the channel which are not yet flushed to the file in case of not destroying the logger
+		defer func() {
+			_ = log.Destroy()
+		}()
+
 		if !disableVersionCheck {
 			err := VersionCheck()
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -35,23 +35,11 @@ package main
 
 import (
 	"github.com/Azure/azure-storage-fuse/v2/cmd"
-	"github.com/Azure/azure-storage-fuse/v2/common/log"
 )
 
 //go:generate ./cmd/componentGenerator.sh $NAME
 //  To use go:generate run command   "NAME="component" go generate"
 
 func main() {
-	defer log.Destroy() // nolint:errcheck
-	// This recovers the panics only for the functions that run within this context. all the go-routine
-	// spawned by this function need to handle their panics separately if required. Also the FUSE callbacks
-	// wouldn't run in this context, so the panics originated from the callbacks can't get recovered here.
-	defer func() {
-		if panicErr := recover(); panicErr != nil {
-			log.Crit("PANIC: %v", panicErr)
-			panic(panicErr)
-		}
-	}()
-
 	_ = cmd.Execute()
 }


### PR DESCRIPTION
when the logger is destroyd in main function, when error occured and cobra exit the application with 1. then we are losing some logs to the end.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:
It's observed that some of the logs in the end were lost when there is any mount  failure. This is due to destroying the logger in main.go but cobra is exiting with error code 1 on any error. hence is logger is not getting destroyed and we are losing some logs to the end. 
made the change to destroy the logger before returning the control to cobra again. It is also better as logger init and destroy is happening at one place.

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
