### PR TITLE
Resolve panic in unit tests in policies_test.go

### DIFF
--- a/component/azstorage/policies_test.go
+++ b/component/azstorage/policies_test.go
@@ -41,18 +41,32 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-storage-fuse/v2/common"
+	"github.com/Azure/azure-storage-fuse/v2/common/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
-
-type policiesTestSuite struct {
-	suite.Suite
-}
 
 type mockTransport struct{}
 
 func (m *mockTransport) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: 200}, nil
+}
+
+type policiesTestSuite struct {
+	suite.Suite
+}
+
+func (s *policiesTestSuite) SetupTest() {
+	// Initialize the logger
+	err := log.SetDefaultLogger("silent", common.LogConfig{Level: common.ELogLevel.LOG_DEBUG()})
+	if err != nil {
+		panic("Unable to set silent logger as default.")
+	}
+}
+
+func (s *policiesTestSuite) TearDownTest() {
+	_ = log.Destroy()
 }
 
 func (s *policiesTestSuite) TestRateLimitingPolicy_OpsLimit() {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:
Tests are failing in policies_test.go because of not initializing the logger.

=== RUN   TestPoliciesSuite/TestRateLimitingPolicy_BandwidthLimit
    chan.go:226: test panicked: send on closed channel
        goroutine 10609 [running]:
        runtime/debug.Stack()
        	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
        github.com/stretchr/testify/suite.failOnPanic(0xc000823340, {0xc6dea0, 0xe958b0})
        	/mnt/vss/_work/_temp/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:89 +0x37
        github.com/stretchr/testify/suite.Run.func1.1()
        	/mnt/vss/_work/_temp/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:184 +0x25f
        panic({0xc6dea0?, 0xe958b0?})
        	/usr/local/go/src/runtime/panic.go:783 +0x132
        github.com/Azure/azure-storage-fuse/v2/common/log.(*BaseLogger).logEvent(0xc0000d0200, {0xbcf574, 0x8}, {0xdaaa7b, 0x54}, {0xc001521e40, 0x2, 0x2})
        	/mnt/vss/_work/1/s/common/log/base_logger.go:241 +0x472
        github.com/Azure/azure-storage-fuse/v2/common/log.(*BaseLogger).Info(0xc0000d0200, {0xdaaa7b, 0x54}, {0xc001521e40, 0x2, 0x2})
        	/mnt/vss/_work/1/s/common/log/base_logger.go:107 +0x70
        github.com/Azure/azure-storage-fuse/v2/common/log.Info(...)
        	/mnt/vss/_work/1/s/common/log/logger.go:212
        github.com/Azure/azure-storage-fuse/v2/component/azstorage.newRateLimitingPolicy(0x64, 0xffffffffffffffff)
        	/mnt/vss/_work/1/s/component/azstorage/policies.go:121 +0x19f
        github.com/Azure/azure-storage-fuse/v2/component/azstorage.(*policiesTestSuite).TestRateLimitingPolicy_BandwidthLimit(0x0?)
        	/mnt/vss/_work/1/s/component/azstorage/policies_test.go:90 +0x4d
        reflect.Value.call({0xc001cf6f80?, 0xc00058e3b0?, 0xa8c345?}, {0xd75e34, 0x4}, {0xc001fbcf28, 0x1, 0xc79860?})
        	/usr/local/go/src/reflect/value.go:581 +0xcc6
        reflect.Value.Call({0xc001cf6f80?, 0xc00058e3b0?, 0x127ccf0?}, {0xc001fbcf28?, 0xcef460?, 0x1?})
        	/usr/local/go/src/reflect/value.go:365 +0xb9
        github.com/stretchr/testify/suite.Run.func1(0xc000823340)
        	/mnt/vss/_work/_temp/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:196 +0x425
        testing.tRunner(0xc000823340, 0xc0025fbc20)
        	/usr/local/go/src/testing/testing.go:1934 +0xea
        created by testing.(*T).Run in goroutine 10608
        	/usr/local/go/src/testing/testing.go:1997 +0x465


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
