### PR TITLE
Add GitHub Action to label dependabot and copilot PRs

### DIFF
--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -1,15 +1,15 @@
 name: Label PRs
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [opened]
 
 jobs:
   add-label:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check and add copilot label
         uses: actions/github-script@v7

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -2,7 +2,7 @@ name: Label PRs
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   add-label:

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -3,6 +3,12 @@ name: Label PRs
 on:
   pull_request_target:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to label'
+        required: true
+        type: number
 
 jobs:
   add-label:
@@ -17,8 +23,16 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prNumber = context.payload.pull_request.number;
-            const prAuthor = context.payload.pull_request.user?.login;
+
+            let prNumber, prAuthor;
+            if (context.eventName === 'workflow_dispatch') {
+              prNumber = Number(context.payload.inputs.pr_number);
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              prAuthor = pr.user?.login;
+            } else {
+              prNumber = context.payload.pull_request.number;
+              prAuthor = context.payload.pull_request.user?.login;
+            }
 
             // Check if PR is from dependabot
             if (prAuthor === 'dependabot[bot]' || prAuthor === 'dependabot') {

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -1,0 +1,67 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check and add copilot label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const actor = context.actor;
+
+            // Check if PR is from dependabot
+            if (actor === 'dependabot[bot]' || actor === 'dependabot') {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber,
+                labels: ['copilot']
+              });
+              console.log('Added copilot label: PR authored by dependabot');
+              return;
+            }
+
+            // Check if >50% of commits are AI-generated.
+            // Detects:
+            //   - Co-authored-by: Copilot / GitHub Copilot (inline suggestions)
+            //   - Signed-off-by or trailers containing "copilot" (IDE agent via git hook)
+            //   - Commit messages tagged with [copilot] (manual convention)
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              { owner, repo, pull_number: prNumber }
+            );
+
+            let copilotCommits = 0;
+            for (const commit of commits) {
+              const message = (commit.commit.message || '').toLowerCase();
+              const authorName = (commit.commit.author?.name || '').toLowerCase();
+              if (
+                message.includes('co-authored-by: copilot') ||
+                message.includes('co-authored-by: github copilot') ||
+                message.includes('[copilot]') ||
+                message.includes('generated-by: copilot') ||
+                authorName.includes('copilot')
+              ) {
+                copilotCommits++;
+              }
+            }
+
+            const totalCommits = commits.length;
+            const percentage = totalCommits > 0 ? (copilotCommits / totalCommits) * 100 : 0;
+            console.log(`Copilot commits: ${copilotCommits}/${totalCommits} (${percentage.toFixed(1)}%)`);
+
+            if (percentage > 50) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber,
+                labels: ['copilot']
+              });
+              console.log('Added copilot label: >50% commits identified as AI-generated');
+            }

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -17,10 +17,10 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.payload.pull_request.number;
-            const actor = context.actor;
+            const prAuthor = context.payload.pull_request.user?.login;
 
             // Check if PR is from dependabot
-            if (actor === 'dependabot[bot]' || actor === 'dependabot') {
+            if (prAuthor === 'dependabot[bot]' || prAuthor === 'dependabot') {
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: prNumber,
                 labels: ['copilot']

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -8,7 +8,8 @@ jobs:
   add-label:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      issues: write
+      pull-requests: read
     steps:
       - name: Check and add copilot label
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Adds a new GitHub Actions workflow that automatically adds the `copilot` label to PRs when:

1. **PR author is dependabot** (`dependabot[bot]` or `dependabot`)
2. **>50% of commits contain Copilot co-author trailers** (e.g. `Co-authored-by: Copilot`, `[copilot]`, `generated-by: copilot`)

### Files
- `.github/workflows/dependabot-label.yml` — new workflow

### Notes
- Runs on `pull_request: opened` events
- Uses `actions/github-script@v7`
- Permissions scoped to `pull-requests: write`