### PR TITLE
Fix duplicated prefix in CPK block blob attribute lookup for subdirectory mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 **Features**
 
 **Bug Fixes**
+- Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))
 
 ## 2.5.3 (2026-03-25)
 **Features**

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -702,7 +702,7 @@ func (bb *BlockBlob) processBlobItems(blobItems []*container.BlobItem) ([]*inter
 func (bb *BlockBlob) getBlobAttr(blobInfo *container.BlobItem) (*internal.ObjAttr, error) {
 	if blobInfo.Properties.CustomerProvidedKeySHA256 != nil && *blobInfo.Properties.CustomerProvidedKeySHA256 != "" {
 		log.Trace("BlockBlob::List : blob is encrypted with customer provided key so fetching metadata explicitly using REST")
-		return bb.getAttrUsingRest(*blobInfo.Name)
+		return bb.getAttrUsingRest(removePrefixPath(bb.Config.prefixPath, *blobInfo.Name))
 	}
 	mode, err := bb.getFileMode(blobInfo.Properties.Permissions)
 	if err != nil {

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -2094,6 +2094,76 @@ func (s *blockBlobTestSuite) TestGetAttrDirWithCPKEnabled() {
 	s.assert.True(checkMetadata(props.Metadata, folderKey, "true"))
 }
 
+func (s *blockBlobTestSuite) TestGetAttrFileWithCPKEnabledAndPrefixPath() {
+	defer s.cleanupTest()
+	CPKEncryptionKey, CPKEncryptionKeySHA256 := generateCPKInfo()
+	config := fmt.Sprintf("azstorage:\n  account-name: %s\n  endpoint: https://%s.blob.core.windows.net/\n  type: block\n  cpk-enabled: true\n  cpk-encryption-key: %s\n  cpk-encryption-key-sha256: %s\n  account-key: %s\n  mode: key\n  container: %s\n",
+		storageTestConfigurationParameters.BlockAccount, storageTestConfigurationParameters.BlockAccount, CPKEncryptionKey, CPKEncryptionKeySHA256, storageTestConfigurationParameters.BlockKey, s.container)
+
+	s.tearDownTestHelper(false)
+	s.setupTestHelper(config, s.container, false)
+
+	// Create a subdirectory to use as a prefix path and a file inside it
+	prefix := generateDirectoryName()
+	err := s.az.CreateDir(internal.CreateDirOptions{Name: prefix})
+	s.assert.NoError(err)
+
+	fileName := generateFileName()
+	filePath := prefix + "/" + fileName
+	_, err = s.az.CreateFile(internal.CreateFileOptions{Name: filePath})
+	s.assert.NoError(err)
+
+	// Set the prefix path to the subdirectory
+	_ = s.az.storage.SetPrefixPath(prefix)
+
+	// GetAttr should resolve the file correctly without duplicating the prefix path
+	props, err := s.az.GetAttr(internal.GetAttrOptions{Name: fileName})
+	s.assert.NoError(err)
+	s.assert.NotNil(props)
+	s.assert.Equal(fileName, props.Path)
+	s.assert.False(props.IsDir())
+}
+
+func (s *blockBlobTestSuite) TestReadDirWithCPKEnabledAndPrefixPath() {
+	defer s.cleanupTest()
+	CPKEncryptionKey, CPKEncryptionKeySHA256 := generateCPKInfo()
+	config := fmt.Sprintf("azstorage:\n  account-name: %s\n  endpoint: https://%s.blob.core.windows.net/\n  type: block\n  cpk-enabled: true\n  cpk-encryption-key: %s\n  cpk-encryption-key-sha256: %s\n  account-key: %s\n  mode: key\n  container: %s\n",
+		storageTestConfigurationParameters.BlockAccount, storageTestConfigurationParameters.BlockAccount, CPKEncryptionKey, CPKEncryptionKeySHA256, storageTestConfigurationParameters.BlockKey, s.container)
+
+	s.tearDownTestHelper(false)
+	s.setupTestHelper(config, s.container, false)
+
+	// Create a subdirectory to use as a prefix path with files inside it
+	prefix := generateDirectoryName()
+	err := s.az.CreateDir(internal.CreateDirOptions{Name: prefix})
+	s.assert.NoError(err)
+
+	fileName := generateFileName()
+	filePath := prefix + "/" + fileName
+	_, err = s.az.CreateFile(internal.CreateFileOptions{Name: filePath})
+	s.assert.NoError(err)
+
+	// Set the prefix path to the subdirectory
+	_ = s.az.storage.SetPrefixPath(prefix)
+
+	// ReadDir should list the file correctly without duplicating the prefix path
+	entries, err := s.az.ReadDir(internal.ReadDirOptions{Name: "/"})
+	s.assert.NoError(err)
+	s.assert.NotEmpty(entries)
+
+	// Verify the file path does not have a duplicated prefix
+	found := false
+	for _, entry := range entries {
+		if entry.Name == fileName {
+			found = true
+			s.assert.Equal(fileName, entry.Path)
+			s.assert.False(entry.IsDir())
+			break
+		}
+	}
+	s.assert.True(found, "Expected file not found in ReadDir results")
+}
+
 func (s *blockBlobTestSuite) TestGetAttrFile() {
 	defer s.cleanupTest()
 	vdConfig := fmt.Sprintf("azstorage:\n  account-name: %s\n  endpoint: https://%s.blob.core.windows.net/\n  type: block\n  account-key: %s\n  mode: key\n  container: %s\n  fail-unsupported-op: true\n  virtual-directory: true",


### PR DESCRIPTION
## Summary
Fix a block blob path handling bug in the CPK plus subdirectory flow.

When blob names returned from the list API already include prefixPath, the CPK branch passed the full name into getAttrUsingRest, which then joined prefixPath again and built an incorrect blob path.

This change strips prefixPath before calling getAttrUsingRest, aligning the CPK path with the existing non-CPK handling.

## Root Cause
- List results return blobInfo.Name as the full path inside the container, including the configured prefix or subdirectory.
- The CPK branch in getBlobAttr forwarded that full path unchanged.
- getAttrUsingRest joins prefixPath with the incoming name, so the resulting lookup duplicated the prefix.

## Validation
- Full project build: `go build -tags fuse3 ./...`
- Static analysis: `go vet -tags fuse3 ./component/azstorage/...`
- Unit tests: `go test -v -timeout=2m -run TestUtils/TestRemovePrefixPath ./component/azstorage/ --tags=unittest,fuse3`
- Format check: `gofmt -s -l -d .`