### PR TITLE
Fix static analysis step - pin golangci-lint to v2.11.0

### DIFF
--- a/blobfuse2-1es_ci.yaml
+++ b/blobfuse2-1es_ci.yaml
@@ -103,7 +103,7 @@ extends:
 
           # Code lint checks (Static-analysis)
           - script: |
-              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.0
               $(go env GOPATH)/bin/golangci-lint --version
               $(go env GOPATH)/bin/golangci-lint run --build-tags $(tags) > lint.log
               result=$(cat lint.log | wc -l)

--- a/blobfuse2-1es_ci.yaml
+++ b/blobfuse2-1es_ci.yaml
@@ -103,7 +103,9 @@ extends:
 
           # Code lint checks (Static-analysis)
           - script: |
-              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.0
+              # Pinned to v2.11.0 due to checksum issue in v2.12.1 (bump when upstream fixes it)
+              # Refer: https://github.com/Azure/azure-storage-fuse/pull/2201
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.0
               $(go env GOPATH)/bin/golangci-lint --version
               $(go env GOPATH)/bin/golangci-lint run --build-tags $(tags) > lint.log
               result=$(cat lint.log | wc -l)


### PR DESCRIPTION
## Problem
The Static Analysis CI step was failing with a checksum verification error when downloading golangci-lint:

```
hash_sha256_verify checksum for 'golangci-lint-2.12.1-linux-amd64.tar.gz' did not verify
4a1fed90469250d59ab1d623521c3584027ed9cf94ea7aba3c2477164746e2cf vs 82c7932d9aa10c34e22ef56961ac5aad71d4a14806a1a31b06931add2688b368
```

The install script in \`blobfuse2-1es_ci.yaml\` was not pinned to a specific version, so it resolved to the latest release (v2.12.1). That release has a checksum mismatch between the downloaded tarball and the \`.sha256\` file on GitHub, causing the installer to abort and golangci-lint to never be installed, silently skipping all lint checks.

## Fix
Pinned the golangci-lint install command to `v2.11.0`, a known-stable release. The `.golangci.yml` config uses `version: "2"` so v2.11.0 is fully compatible.

When the upstream checksum issue for v2.12.1 is resolved, the pinned version can be bumped explicitly.