### PR TITLE
Return correct posix error ENAMETOOLONG for dir creation in ADLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))
+- Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2220](https://github.com/Azure/azure-storage-fuse/pull/2220))
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))
-- Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2220](https://github.com/Azure/azure-storage-fuse/pull/2220))
+- Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -278,6 +278,9 @@ func (dl *Datalake) CreateDirectory(name string) error {
 		case ErrFileAlreadyExists:
 			log.Err("Datalake::CreateDirectory : Path already exists for %s [%s]", name, err.Error())
 			return syscall.EEXIST
+		case ErrPathTooDeep:
+			log.Err("Datalake::CreateDirectory : Path is too deep for %s [%s]", name, err.Error())
+			return syscall.ENAMETOOLONG
 		default:
 			log.Err("Datalake::CreateDirectory : Failed to create directory %s [%s]", name, err.Error())
 			return err

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -240,6 +240,7 @@ const (
 	InvalidRange
 	BlobIsUnderLease
 	InvalidPermission
+	ErrPathTooDeep
 )
 
 // For detailed error list refer below link,
@@ -285,6 +286,8 @@ func storeDatalakeErrToErr(err error) uint16 {
 			return BlobIsUnderLease
 		case datalakeerror.AuthorizationPermissionMismatch:
 			return InvalidPermission
+		case datalakeerror.PathIsTooDeep:
+			return ErrPathTooDeep
 		default:
 			return ErrUnknown
 		}

--- a/component/azstorage/utils_test.go
+++ b/component/azstorage/utils_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
 	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/log"
 	"github.com/stretchr/testify/assert"
@@ -475,6 +476,38 @@ func (s *utilsTestSuite) TestRemoveLeadingSlashes() {
 	for _, i := range inputs {
 		assert.Equal(i.result, removeLeadingSlashes(i.subdirectory))
 	}
+}
+
+func (s *utilsTestSuite) TestStoreDatalakeErrToErr() {
+	assert := assert.New(s.T())
+
+	type testCase struct {
+		name     string
+		code     datalakeerror.StorageErrorCode
+		expected uint16
+	}
+
+	inputs := []testCase{
+		{name: "PathAlreadyExists", code: datalakeerror.PathAlreadyExists, expected: ErrFileAlreadyExists},
+		{name: "PathNotFound", code: datalakeerror.PathNotFound, expected: ErrFileNotFound},
+		{name: "SourcePathNotFound", code: datalakeerror.SourcePathNotFound, expected: ErrFileNotFound},
+		{name: "LeaseIDMissing", code: datalakeerror.LeaseIDMissing, expected: BlobIsUnderLease},
+		{name: "AuthorizationPermissionMismatch", code: datalakeerror.AuthorizationPermissionMismatch, expected: InvalidPermission},
+		{name: "PathIsTooDeep", code: datalakeerror.PathIsTooDeep, expected: ErrPathTooDeep},
+		{name: "Unknown", code: datalakeerror.StorageErrorCode("UnknownCode"), expected: ErrUnknown},
+	}
+
+	for _, i := range inputs {
+		s.Run(i.name, func() {
+			respErr := &azcore.ResponseError{ErrorCode: string(i.code)}
+			result := storeDatalakeErrToErr(respErr)
+			assert.Equal(i.expected, result)
+		})
+	}
+
+	// nil error returns ErrNoErr
+	result := storeDatalakeErrToErr(nil)
+	assert.Equal(uint16(ErrNoErr), result)
 }
 
 func (s *utilsTestSuite) TestRemovePrefixPath() {

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -441,6 +441,8 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 			return -C.EACCES
 		} else if os.IsExist(err) {
 			return -C.EEXIST
+		} else if err == syscall.ENAMETOOLONG {
+			return -C.ENAMETOOLONG
 		} else {
 			return -C.EIO
 		}

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -441,7 +441,7 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 			return -C.EACCES
 		} else if os.IsExist(err) {
 			return -C.EEXIST
-		} else if err == syscall.ENAMETOOLONG {
+		} else if errors.Is(err, syscall.ENAMETOOLONG) {
 			return -C.ENAMETOOLONG
 		} else {
 			return -C.EIO

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -445,7 +445,7 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 			return -C.EACCES
 		} else if os.IsExist(err) {
 			return -C.EEXIST
-		} else if err == syscall.ENAMETOOLONG {
+		} else if errors.Is(err, syscall.ENAMETOOLONG) {
 			return -C.ENAMETOOLONG
 		} else {
 			return -C.EIO

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -445,6 +445,8 @@ func libfuse_mkdir(path *C.char, mode C.mode_t) C.int {
 			return -C.EACCES
 		} else if os.IsExist(err) {
 			return -C.EEXIST
+		} else if err == syscall.ENAMETOOLONG {
+			return -C.ENAMETOOLONG
 		} else {
 			return -C.EIO
 		}

--- a/test/e2e_tests/dir_test.go
+++ b/test/e2e_tests/dir_test.go
@@ -45,6 +45,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -254,6 +255,30 @@ func (suite *dirTestSuite) TestDirDeleteNonEmpty() {
 
 // 	suite.dirTestCleanup([]string{dirName})
 // }
+
+// # Create directory path exceeding ADLS depth limit
+func (suite *dirTestSuite) TestDirCreateDeepPath() {
+	if !suite.adlsTest {
+		fmt.Println("Skipping TestDirCreateDeepPath: not an ADLS account")
+		return
+	}
+
+	// ADLS enforces a maximum path depth of 63 segments from the container root.
+	// Build 65 nested levels from testPath to guarantee the limit is exceeded.
+	const depth = 65
+	topDir := suite.testPath + "/deep"
+	deepPath := topDir
+	for i := range depth {
+		deepPath = filepath.Join(deepPath, fmt.Sprintf("l%d", i))
+	}
+
+	err := os.MkdirAll(deepPath, 0777)
+	suite.Error(err)
+	suite.ErrorIs(err, syscall.ENAMETOOLONG)
+
+	// cleanup any intermediate directories created before the limit was hit
+	suite.dirTestCleanup([]string{topDir})
+}
 
 // # Get stats of a directory
 func (suite *dirTestSuite) TestDirGetStats() {


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [x] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:
correct the error from EIO to ENAMETOOLONG when the directory creation fails with pathTooDeep error in ADLS
