### PR TITLE
Add gzip compression of rolled-over log files for the base logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.5 (Unreleased)
 **Features**
 - Added support for Ubuntu 26.04 on both AMD64 and ARM64 architectures.
+- Add gzip compression of rolled-over log files for the base logger. Enable with `compress: true` under the `logging` section in config, or via the `--log-compress` CLI flag.
 
 **Bug Fixes**
 - Correct kernel list cache compatibility detection. Libfuse 3.5 through 3.15 expose `cache_readdir`, but versions before 3.16.1 do not forward it through the high-level `opendir` path used by blobfuse2. Blobfuse2 now enables the feature only when it was built with compatible headers, the loaded libfuse runtime is 3.16.1 or newer, and the kernel supports FUSE protocol 7.28 or newer. Stock Ubuntu 20.04, 22.04, and 24.04 ship older libfuse runtimes, so kernel list caching remains disabled there. Unsupported environments receive a warning identifying the failing compatibility layer.

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -196,7 +196,6 @@ func OnConfigChange() {
 		MaxFileSize: newLogOptions.MaxLogFileSize,
 		FileCount:   newLogOptions.LogFileCount,
 		TimeTracker: newLogOptions.TimeTracker,
-		LogCompress: newLogOptions.LogCompress,
 	})
 
 	if err != nil {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -69,6 +69,7 @@ type LogOptions struct {
 	LogFileCount   uint64 `config:"file-count" yaml:"file-count,omitempty"`
 	LogGoroutineID bool   `config:"goroutine-id" yaml:"goroutine-id,omitempty"`
 	TimeTracker    bool   `config:"track-time" yaml:"track-time,omitempty"`
+	LogCompress    bool   `config:"compress" yaml:"compress,omitempty"`
 }
 
 type mountOptions struct {
@@ -195,6 +196,7 @@ func OnConfigChange() {
 		MaxFileSize: newLogOptions.MaxLogFileSize,
 		FileCount:   newLogOptions.LogFileCount,
 		TimeTracker: newLogOptions.TimeTracker,
+		LogCompress: newLogOptions.LogCompress,
 	})
 
 	if err != nil {
@@ -435,6 +437,7 @@ var mountCmd = &cobra.Command{
 			Level:          logLevel,
 			TimeTracker:    options.Logging.TimeTracker,
 			LogGoroutineID: options.Logging.LogGoroutineID,
+			LogCompress:    options.Logging.LogCompress,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to initialize logger [%s]", err.Error())
@@ -884,6 +887,10 @@ func init() {
 	mountCmd.PersistentFlags().Bool("log-goroutine-id",
 		false, "Enable logging of goroutine IDs. Default is true for LOG_DEBUG level, false otherwise.")
 	config.BindPFlag("logging.goroutine-id", mountCmd.PersistentFlags().Lookup("log-goroutine-id"))
+
+	mountCmd.PersistentFlags().Bool("log-compress",
+		false, "Enable gzip compression of rolled-over log files. Only applies to base logger.")
+	config.BindPFlag("logging.compress", mountCmd.PersistentFlags().Lookup("log-compress"))
 
 	mountCmd.PersistentFlags().Bool("foreground", false, "Mount the system in foreground mode. Default value false.")
 	config.BindPFlag("foreground", mountCmd.PersistentFlags().Lookup("foreground"))

--- a/cmd/mount_all.go
+++ b/cmd/mount_all.go
@@ -131,6 +131,7 @@ func processCommand() error {
 		FileCount:   options.Logging.LogFileCount,
 		Level:       logLevel,
 		TimeTracker: options.Logging.TimeTracker,
+		LogCompress: options.Logging.LogCompress,
 	})
 
 	if err != nil {

--- a/common/log/base_logger.go
+++ b/common/log/base_logger.go
@@ -143,6 +143,7 @@ func (l *BaseLogger) SetLogFile(name string) error {
 				l.fileConfig.currentLogSize = uint64(fi.Size())
 			}
 		}
+		l.logger.SetOutput(l.logFileHandle)
 	}
 	return nil
 }
@@ -171,7 +172,7 @@ func (l *BaseLogger) init() error {
 		}
 	}
 	if l.fileConfig.LogLevel == common.ELogLevel.INVALID() {
-		l.SetLogLevel(common.ELogLevel.LOG_DEBUG())
+		l.fileConfig.LogLevel = common.ELogLevel.LOG_DEBUG()
 	}
 	if l.fileConfig.LogSize == 0 {
 		l.SetMaxLogSize(common.DefaultMaxLogFileSize)
@@ -257,13 +258,13 @@ func (l *BaseLogger) logDumper(id int, channel <-chan string) {
 }
 
 func (l *BaseLogger) LogRotate() error {
-	//fmt.Println("Log Rotation started")
-	if err := l.logFileHandle.Close(); err != nil {
-		return err
-	}
 	// skip if the file is standard output
 	if l.fileConfig.LogFile == "stdout" {
 		return nil
+	}
+
+	if err := l.logFileHandle.Close(); err != nil {
+		return err
 	}
 
 	var fname string

--- a/common/log/base_logger.go
+++ b/common/log/base_logger.go
@@ -70,6 +70,8 @@ type BaseLogger struct {
 
 	fileConfig LogFileConfig
 	compressWg sync.WaitGroup
+	rotateMu   sync.Mutex
+	rotationID uint64
 }
 
 func newBaseLogger(config LogFileConfig) (*BaseLogger, error) {
@@ -146,7 +148,6 @@ func (l *BaseLogger) SetLogFile(name string) error {
 				l.fileConfig.currentLogSize = uint64(fi.Size())
 			}
 		}
-		l.logger.SetOutput(l.logFileHandle)
 	}
 	return nil
 }
@@ -175,7 +176,7 @@ func (l *BaseLogger) init() error {
 		}
 	}
 	if l.fileConfig.LogLevel == common.ELogLevel.INVALID() {
-		l.fileConfig.LogLevel = common.ELogLevel.LOG_DEBUG()
+		l.SetLogLevel(common.ELogLevel.LOG_DEBUG())
 	}
 	if l.fileConfig.LogSize == 0 {
 		l.SetMaxLogSize(common.DefaultMaxLogFileSize)
@@ -268,47 +269,35 @@ func (l *BaseLogger) LogRotate() error {
 		return nil
 	}
 
-	// ensure any previous async compression has finished before shifting files
-	l.compressWg.Wait()
+	l.rotateMu.Lock()
+	defer l.rotateMu.Unlock()
 
 	if err := l.logFileHandle.Close(); err != nil {
 		return err
 	}
 
-	var fname, fnameNew string
+	l.rotationID++
+	rotationID := l.rotationID
+	logFile := l.fileConfig.LogFile
+	fileCount := l.fileConfig.LogFileCount
 
-	// delete the oldest file (plain or compressed)
-	fname = fmt.Sprintf("%s.%d.gz", l.fileConfig.LogFile, l.fileConfig.LogFileCount-1)
-	os.Remove(fname)
-	fname = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, l.fileConfig.LogFileCount-1)
-	os.Remove(fname)
+	// Delete the oldest file, then shift each completed archive independently.
+	os.Remove(fmt.Sprintf("%s.%d.gz", logFile, fileCount-1))
+	os.Remove(fmt.Sprintf("%s.%d", logFile, fileCount-1))
 
-	// shift .N-1 → .N, preferring .gz variant
-	for i := l.fileConfig.LogFileCount - 2; i > 0; i-- {
-		fname = fmt.Sprintf("%s.%d.gz", l.fileConfig.LogFile, i)
-		fnameNew = fmt.Sprintf("%s.%d.gz", l.fileConfig.LogFile, i+1)
-		if _, err := os.Stat(fname); err == nil {
-			_ = os.Rename(fname, fnameNew)
-		} else {
-			fname = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, i)
-			fnameNew = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, i+1)
-			_ = os.Rename(fname, fnameNew)
-		}
+	for i := fileCount - 2; i > 0; i-- {
+		_ = os.Rename(fmt.Sprintf("%s.%d.gz", logFile, i), fmt.Sprintf("%s.%d.gz", logFile, i+1))
+		_ = os.Rename(fmt.Sprintf("%s.%d", logFile, i), fmt.Sprintf("%s.%d", logFile, i+1))
 	}
 
-	_ = os.Rename(l.fileConfig.LogFile, l.fileConfig.LogFile+".1")
-
+	rotatedFile := logFile + ".1"
 	if l.fileConfig.LogCompress {
-		src := l.fileConfig.LogFile + ".1"
-		l.compressWg.Add(1)
-		go func() {
-			defer l.compressWg.Done()
-			_ = l.compressFile(src)
-		}()
+		rotatedFile = fmt.Sprintf("%s.%d.%d.tmp", logFile, l.procPID, rotationID)
 	}
+	rotateErr := os.Rename(logFile, rotatedFile)
 
 	var err error
-	l.logFileHandle, err = os.OpenFile(l.fileConfig.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	l.logFileHandle, err = os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		l.logFileHandle = os.Stdout
 	}
@@ -319,7 +308,38 @@ func (l *BaseLogger) LogRotate() error {
 	// Notify post-rotation hooks (e.g. runtime crash output) that the underlying file has changed.
 	invokeRotateHooks()
 
+	if l.fileConfig.LogCompress && rotateErr == nil {
+		l.compressWg.Add(1)
+		go l.compressRotatedFile(rotatedFile, logFile, rotationID, fileCount)
+	}
+
 	return nil
+}
+
+func (l *BaseLogger) compressRotatedFile(fname string, logFile string, rotationID uint64, fileCount int) {
+	defer l.compressWg.Done()
+
+	if err := l.compressFile(fname); err != nil {
+		l.rotateMu.Lock()
+		l.logger.Printf("Failed to compress rotated log file %s: %v", fname, err)
+		l.rotateMu.Unlock()
+		return
+	}
+
+	l.rotateMu.Lock()
+	defer l.rotateMu.Unlock()
+
+	age := l.rotationID - rotationID + 1
+	compressedFile := fname + ".gz"
+	if fileCount > 1 && age >= uint64(fileCount) {
+		_ = os.Remove(compressedFile)
+		return
+	}
+
+	destination := fmt.Sprintf("%s.%d.gz", logFile, age)
+	if err := os.Rename(compressedFile, destination); err != nil {
+		l.logger.Printf("Failed to finalize compressed log file %s: %v", fname, err)
+	}
 }
 
 // compressFile gzip-compresses src to src+".gz" and removes src on success.

--- a/common/log/base_logger.go
+++ b/common/log/base_logger.go
@@ -34,6 +34,7 @@
 package log
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"log"
@@ -54,6 +55,7 @@ type LogFileConfig struct {
 	LogLevel       common.LogLevel
 	LogTag         string
 	LogGoroutineID bool
+	LogCompress    bool
 
 	currentLogSize uint64
 }
@@ -67,6 +69,7 @@ type BaseLogger struct {
 	procPID       int
 
 	fileConfig LogFileConfig
+	compressWg sync.WaitGroup
 }
 
 func newBaseLogger(config LogFileConfig) (*BaseLogger, error) {
@@ -210,6 +213,9 @@ func (l *BaseLogger) Destroy() error {
 	close(l.channel)
 	l.workerDone.Wait()
 
+	// wait for any in-flight async compression to finish before closing the handle
+	l.compressWg.Wait()
+
 	if err := l.logFileHandle.Close(); err != nil {
 		return err
 	}
@@ -251,7 +257,6 @@ func (l *BaseLogger) logDumper(id int, channel <-chan string) {
 
 		l.fileConfig.currentLogSize += (uint64)(len(j))
 		if l.fileConfig.currentLogSize > l.fileConfig.LogSize {
-			//fmt.Println("Calling logrotate : ", l.fileConfig.currentLogSize, " : ", l.fileConfig.logSize)
 			_ = l.LogRotate()
 		}
 	}
@@ -263,28 +268,44 @@ func (l *BaseLogger) LogRotate() error {
 		return nil
 	}
 
+	// ensure any previous async compression has finished before shifting files
+	l.compressWg.Wait()
+
 	if err := l.logFileHandle.Close(); err != nil {
 		return err
 	}
 
-	var fname string
-	var fnameNew string
-	fname = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, (l.fileConfig.LogFileCount - 1))
+	var fname, fnameNew string
 
-	//fmt.Println("Deleting : ", fname)
+	// delete the oldest file (plain or compressed)
+	fname = fmt.Sprintf("%s.%d.gz", l.fileConfig.LogFile, l.fileConfig.LogFileCount-1)
+	os.Remove(fname)
+	fname = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, l.fileConfig.LogFileCount-1)
 	os.Remove(fname)
 
+	// shift .N-1 → .N, preferring .gz variant
 	for i := l.fileConfig.LogFileCount - 2; i > 0; i-- {
-		fname = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, i)
-		fnameNew = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, (i + 1))
-
-		// Move each file to next number 8 -> 9, 7 -> 8, 6 -> 7 ...
-		//fmt.Println("Renaming : ", fname, " : ", fnameNew)
-		_ = os.Rename(fname, fnameNew)
+		fname = fmt.Sprintf("%s.%d.gz", l.fileConfig.LogFile, i)
+		fnameNew = fmt.Sprintf("%s.%d.gz", l.fileConfig.LogFile, i+1)
+		if _, err := os.Stat(fname); err == nil {
+			_ = os.Rename(fname, fnameNew)
+		} else {
+			fname = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, i)
+			fnameNew = fmt.Sprintf("%s.%d", l.fileConfig.LogFile, i+1)
+			_ = os.Rename(fname, fnameNew)
+		}
 	}
 
-	//fmt.Println("Renaming : ", l.fileConfig.logFile, l.fileConfig.logFile+".1")
 	_ = os.Rename(l.fileConfig.LogFile, l.fileConfig.LogFile+".1")
+
+	if l.fileConfig.LogCompress {
+		src := l.fileConfig.LogFile + ".1"
+		l.compressWg.Add(1)
+		go func() {
+			defer l.compressWg.Done()
+			_ = l.compressFile(src)
+		}()
+	}
 
 	var err error
 	l.logFileHandle, err = os.OpenFile(l.fileConfig.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
@@ -292,12 +313,44 @@ func (l *BaseLogger) LogRotate() error {
 		l.logFileHandle = os.Stdout
 	}
 
-	// init the log
 	l.logger.SetOutput(l.logFileHandle)
 	l.fileConfig.currentLogSize = 0
 
 	// Notify post-rotation hooks (e.g. runtime crash output) that the underlying file has changed.
 	invokeRotateHooks()
 
+	return nil
+}
+
+// compressFile gzip-compresses src to src+".gz" and removes src on success.
+func (l *BaseLogger) compressFile(fname string) error {
+	src, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+	dst, err := os.Create(fname + ".gz")
+	if err != nil {
+		src.Close()
+		return err
+	}
+	gz := gzip.NewWriter(dst)
+	_, err = io.Copy(gz, src)
+	src.Close()
+	if err != nil {
+		gz.Close()
+		dst.Close()
+		os.Remove(fname + ".gz")
+		return err
+	}
+	if err = gz.Close(); err != nil {
+		dst.Close()
+		os.Remove(fname + ".gz")
+		return err
+	}
+	if err = dst.Close(); err != nil {
+		os.Remove(fname + ".gz")
+		return err
+	}
+	os.Remove(fname)
 	return nil
 }

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -88,6 +88,7 @@ func NewLogger(name string, config common.LogConfig) (Logger, error) {
 			LogFileCount:   int(config.FileCount),
 			LogTag:         config.Tag,
 			LogGoroutineID: config.LogGoroutineID,
+			LogCompress:    config.LogCompress,
 		})
 		if err != nil {
 			return nil, err

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -34,6 +34,9 @@
 package log
 
 import (
+	"compress/gzip"
+	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -910,5 +913,275 @@ func TestSilentLogger_GetLogLevel(t *testing.T) {
 	l := &SilentLogger{}
 	if l.GetLogLevel() != common.ELogLevel.LOG_OFF() {
 		t.Errorf("expected LOG_OFF, got %v", l.GetLogLevel())
+	}
+}
+
+// ---- compression tests -----------------------------------------------------
+
+func gzFileContent(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open gz %s: %v", path, err)
+	}
+	defer f.Close()
+	r, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip.NewReader %s: %v", path, err)
+	}
+	defer r.Close()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read gz %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestCompress_ProducesGzFile(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogCompress:  true,
+	})
+	l.Info("before-compress-rotate")
+	drainLogger(l)
+
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("LogRotate: %v", err)
+	}
+	l.compressWg.Wait()
+
+	if !fileExists(path + ".1.gz") {
+		t.Errorf("expected %s.1.gz to exist", path)
+	}
+	if fileExists(path + ".1") {
+		t.Error("plain .1 should have been removed after compression")
+	}
+}
+
+func TestCompress_GzContentIsValid(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogCompress:  true,
+	})
+	l.Info("gz-content-check")
+	drainLogger(l)
+
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("LogRotate: %v", err)
+	}
+	l.compressWg.Wait()
+
+	content := gzFileContent(t, path+".1.gz")
+	if !strings.Contains(content, "gz-content-check") {
+		t.Error("compressed file does not contain expected message")
+	}
+}
+
+func TestCompress_ShiftsGzFiles(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogCompress:  true,
+	})
+
+	l.Info("first")
+	drainLogger(l)
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("rotate 1: %v", err)
+	}
+	l.compressWg.Wait()
+
+	l.Info("second")
+	drainLogger(l)
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("rotate 2: %v", err)
+	}
+	l.compressWg.Wait()
+
+	if !fileExists(path + ".2.gz") {
+		t.Error("expected .2.gz after two compressed rotations")
+	}
+}
+
+func TestCompress_DeletesOldestGz(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 3,
+		LogCompress:  true,
+	})
+
+	for i := 0; i < 3; i++ {
+		drainLogger(l)
+		if err := l.LogRotate(); err != nil {
+			t.Fatalf("rotate %d: %v", i+1, err)
+		}
+		l.compressWg.Wait()
+	}
+
+	if fileExists(path+".3.gz") || fileExists(path+".3") {
+		t.Error(".3 or .3.gz should be deleted with LogFileCount=3")
+	}
+}
+
+func TestCompress_TransitionFromPlainFiles(t *testing.T) {
+	// Start without compression, rotate once to create a plain .1 file,
+	// then enable compression and rotate again — .1 (plain) should shift
+	// to .2 (plain) and new .1.gz should appear.
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogCompress:  false,
+	})
+
+	l.Info("plain-first")
+	drainLogger(l)
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("plain rotate: %v", err)
+	}
+
+	// Enable compression and rotate again
+	l.fileConfig.LogCompress = true
+	l.Info("compress-second")
+	drainLogger(l)
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("compress rotate: %v", err)
+	}
+	l.compressWg.Wait()
+
+	if !fileExists(path + ".1.gz") {
+		t.Error("expected .1.gz after compressed rotation")
+	}
+	if !fileExists(path + ".2") {
+		t.Error("expected plain .2 (shifted from old .1)")
+	}
+}
+
+func TestCompress_NoCompressModeStillPlain(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogCompress:  false,
+	})
+	l.Info("plain-log")
+	drainLogger(l)
+
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("LogRotate: %v", err)
+	}
+
+	if !fileExists(path + ".1") {
+		t.Error("expected plain .1 when compression is disabled")
+	}
+	if fileExists(path + ".1.gz") {
+		t.Error("unexpected .gz file when compression is disabled")
+	}
+}
+
+func TestCompress_AutoRotationProducesGz(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogSize:      1,
+		LogCompress:  true,
+	})
+
+	l.Info("auto-compress-trigger")
+	drainLogger(l)
+	l.compressWg.Wait()
+
+	if !fileExists(path + ".1.gz") {
+		t.Error("auto-rotation with compression did not produce .1.gz")
+	}
+}
+
+// ---- compressFile unit tests -----------------------------------------------
+
+func TestCompressFile_ProducesGz(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "plain.log")
+	if err := os.WriteFile(src, []byte("hello compress"), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := l.compressFile(src); err != nil {
+		t.Fatalf("compressFile: %v", err)
+	}
+	if !fileExists(src + ".gz") {
+		t.Error("expected .gz file")
+	}
+	if fileExists(src) {
+		t.Error("original file should be removed after compression")
+	}
+}
+
+func TestCompressFile_ContentRoundTrip(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "round.log")
+	want := "round-trip content check"
+	if err := os.WriteFile(src, []byte(want), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := l.compressFile(src); err != nil {
+		t.Fatalf("compressFile: %v", err)
+	}
+
+	got := gzFileContent(t, src+".gz")
+	if got != want {
+		t.Errorf("content mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestCompressFile_MissingSrc(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+	err := l.compressFile("/nonexistent/path/log.txt")
+	if err == nil {
+		t.Error("expected error for missing source file")
+	}
+}
+
+func TestCompressFile_EmptyFile(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "empty.log")
+	if err := os.WriteFile(src, []byte{}, 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := l.compressFile(src); err != nil {
+		t.Fatalf("compressFile on empty file: %v", err)
+	}
+	if !fileExists(src + ".gz") {
+		t.Error("expected .gz for empty file")
+	}
+}
+
+func TestCompressFile_LargeContent(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "large.log")
+	line := strings.Repeat("abcdefghijklmnopqrstuvwxyz0123456789\n", 1000)
+	data := strings.Repeat(line, 100)
+	if err := os.WriteFile(src, []byte(data), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := l.compressFile(src); err != nil {
+		t.Fatalf("compressFile large: %v", err)
+	}
+	if !fileExists(src + ".gz") {
+		t.Error("expected .gz for large file")
+	}
+	got := gzFileContent(t, src+".gz")
+	if got != data {
+		t.Error("large file round-trip content mismatch")
 	}
 }

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -844,7 +844,7 @@ func TestNewLogger_BaseType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLogger base: %v", err)
 	}
-	defer l.Destroy()
+	defer func() { _ = l.Destroy() }()
 	if l.GetType() != "base" {
 		t.Errorf("expected type 'base', got %s", l.GetType())
 	}
@@ -880,7 +880,7 @@ func TestNewLogger_DefaultTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLogger: %v", err)
 	}
-	defer l.Destroy()
+	defer func() { _ = l.Destroy() }()
 	// Smoke test: logger should be usable (tag defaulted to FileSystemName)
 	l.Info("tag-default-check")
 }

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -35,19 +35,15 @@ package log
 
 import (
 	"compress/gzip"
-	"fmt"
 	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
-
-	"fmt"
-	"strings"
-
 	"testing"
 	"time"
 
@@ -56,8 +52,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
-
-// ---- original suite --------------------------------------------------------
 
 type LoggerTestSuite struct {
 	suite.Suite
@@ -447,741 +441,116 @@ func TestLoggerTestSuite(t *testing.T) {
 	suite.Run(t, new(LoggerTestSuite))
 }
 
-// ---- helpers ---------------------------------------------------------------
-
-func makeLogger(t *testing.T, cfg LogFileConfig) (*BaseLogger, string) {
+func newCompressionTestLogger(t *testing.T, compress bool) (*BaseLogger, string) {
 	t.Helper()
-	dir := t.TempDir()
-	if cfg.LogFile == "" {
-		cfg.LogFile = filepath.Join(dir, "test.log")
-	} else {
-		cfg.LogFile = filepath.Join(dir, cfg.LogFile)
-	}
-	if cfg.LogLevel == common.ELogLevel.INVALID() {
-		cfg.LogLevel = common.ELogLevel.LOG_DEBUG()
-	}
-	if cfg.LogFileCount == 0 {
-		cfg.LogFileCount = 5
-	}
-	if cfg.LogSize == 0 {
-		cfg.LogSize = 1024 * 1024
-	}
-	l, err := newBaseLogger(cfg)
+
+	logFile := filepath.Join(t.TempDir(), "blobfuse2.log")
+	logger, err := newBaseLogger(LogFileConfig{
+		LogFile:      logFile,
+		LogSize:      1024 * 1024,
+		LogFileCount: 3,
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogCompress:  compress,
+	})
 	if err != nil {
 		t.Fatalf("newBaseLogger: %v", err)
 	}
 	t.Cleanup(func() {
-		close(l.channel)
-		l.workerDone.Wait()
-		if l.logFileHandle != os.Stdout {
-			_ = l.logFileHandle.Close()
+		if err := logger.Destroy(); err != nil {
+			t.Errorf("Destroy: %v", err)
 		}
 	})
-	return l, cfg.LogFile
+
+	return logger, logFile
 }
 
-func fileContent(t *testing.T, path string) string {
+func readCompressedLog(t *testing.T, path string) string {
 	t.Helper()
-	b, err := os.ReadFile(path)
+
+	file, err := os.Open(path)
 	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
+		t.Fatalf("open compressed log: %v", err)
 	}
-	return string(b)
-}
+	defer file.Close()
 
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-// drainLogger flushes the async channel by closing it and waiting for the
-// worker, then re-initialises it so the logger remains usable.
-func drainLogger(l *BaseLogger) {
-	close(l.channel)
-	l.workerDone.Wait()
-	l.channel = make(chan string, 100000)
-	l.workerDone.Add(1)
-	go l.logDumper(1, l.channel)
-}
-
-// ---- init / defaults -------------------------------------------------------
-
-func TestInit_DefaultLogLevel(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{})
-	if l.fileConfig.LogLevel != common.ELogLevel.LOG_DEBUG() {
-		t.Errorf("default log level: got %v, want LOG_DEBUG", l.fileConfig.LogLevel)
-	}
-}
-
-func TestInit_DefaultLogSize(t *testing.T) {
-	dir := t.TempDir()
-	l, err := newBaseLogger(LogFileConfig{LogFile: filepath.Join(dir, "test.log")})
+	reader, err := gzip.NewReader(file)
 	if err != nil {
-		t.Fatalf("newBaseLogger: %v", err)
+		t.Fatalf("create gzip reader: %v", err)
 	}
-	defer func() { close(l.channel); l.workerDone.Wait(); l.logFileHandle.Close() }()
-	expected := uint64(common.DefaultMaxLogFileSize) * 1024 * 1024
-	if l.fileConfig.LogSize != expected {
-		t.Errorf("default log size: got %d, want %d", l.fileConfig.LogSize, expected)
-	}
-}
+	defer reader.Close()
 
-func TestInit_DefaultLogFileCount(t *testing.T) {
-	dir := t.TempDir()
-	l, err := newBaseLogger(LogFileConfig{LogFile: filepath.Join(dir, "test.log")})
+	content, err := io.ReadAll(reader)
 	if err != nil {
-		t.Fatalf("newBaseLogger: %v", err)
+		t.Fatalf("read compressed log: %v", err)
 	}
-	defer func() { close(l.channel); l.workerDone.Wait(); l.logFileHandle.Close() }()
-	if l.fileConfig.LogFileCount != common.DefaultLogFileCount {
-		t.Errorf("default log file count: got %d, want %d", l.fileConfig.LogFileCount, common.DefaultLogFileCount)
-	}
+	return string(content)
 }
 
-func TestInit_StdoutFallback(t *testing.T) {
-	cfg := LogFileConfig{
-		LogFile:      "stdout",
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogSize:      1024 * 1024,
-	}
-	l, err := newBaseLogger(cfg)
-	if err != nil {
-		t.Fatalf("newBaseLogger stdout: %v", err)
-	}
-	if l.logFileHandle != os.Stdout {
-		t.Error("expected stdout handle")
-	}
-	close(l.channel)
-	l.workerDone.Wait()
-}
+func TestBaseLoggerCompressesRotatedFile(t *testing.T) {
+	logger, logFile := newCompressionTestLogger(t, true)
+	logger.logger.Println("compressed-entry")
 
-// ---- log level filtering ---------------------------------------------------
-
-func TestLevelFilter_Debug(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-	l.Debug("debug-msg")
-	drainLogger(l)
-	if !strings.Contains(fileContent(t, path), "debug-msg") {
-		t.Error("DEBUG message missing at LOG_DEBUG level")
-	}
-}
-
-func TestLevelFilter_DebugSuppressedAtInfo(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_INFO()})
-	l.Debug("hidden-debug")
-	drainLogger(l)
-	if strings.Contains(fileContent(t, path), "hidden-debug") {
-		t.Error("DEBUG message should be suppressed at LOG_INFO level")
-	}
-}
-
-func TestLevelFilter_InfoVisible(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_INFO()})
-	l.Info("info-msg")
-	drainLogger(l)
-	if !strings.Contains(fileContent(t, path), "info-msg") {
-		t.Error("INFO message missing at LOG_INFO level")
-	}
-}
-
-func TestLevelFilter_WarnSuppressedAtErr(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_ERR()})
-	l.Warn("hidden-warn")
-	drainLogger(l)
-	if strings.Contains(fileContent(t, path), "hidden-warn") {
-		t.Error("WARN message should be suppressed at LOG_ERR level")
-	}
-}
-
-func TestLevelFilter_CritAlwaysVisible(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_CRIT()})
-	l.Crit("crit-msg")
-	drainLogger(l)
-	if !strings.Contains(fileContent(t, path), "crit-msg") {
-		t.Error("CRIT message missing at LOG_CRIT level")
-	}
-}
-
-func TestLevelFilter_Trace(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_TRACE()})
-	l.Trace("trace-msg")
-	drainLogger(l)
-	if !strings.Contains(fileContent(t, path), "trace-msg") {
-		t.Error("TRACE message missing at LOG_TRACE level")
-	}
-}
-
-func TestSetLogLevel_ChangesFiltering(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-	l.SetLogLevel(common.ELogLevel.LOG_ERR())
-	l.Info("suppressed-info")
-	drainLogger(l)
-	if strings.Contains(fileContent(t, path), "suppressed-info") {
-		t.Error("INFO should be suppressed after SetLogLevel(ERR)")
-	}
-}
-
-// ---- output format ---------------------------------------------------------
-
-func TestOutputFormat_ContainsTag(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogTag: "mytag", LogLevel: common.ELogLevel.LOG_DEBUG()})
-	l.Info("tagged-line")
-	drainLogger(l)
-	if !strings.Contains(fileContent(t, path), "mytag") {
-		t.Error("log tag missing from output")
-	}
-}
-
-func TestOutputFormat_ContainsLevel(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-	l.Err("err-line")
-	drainLogger(l)
-	if !strings.Contains(fileContent(t, path), "LOG_ERR") {
-		t.Error("log level string missing from output")
-	}
-}
-
-func TestOutputFormat_ContainsPID(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-	l.Info("pid-line")
-	drainLogger(l)
-	pid := fmt.Sprintf("[%d]", os.Getpid())
-	if !strings.Contains(fileContent(t, path), pid) {
-		t.Error("PID missing from output")
-	}
-}
-
-func TestOutputFormat_GoroutineID(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogGoroutineID: true})
-	l.Info("gid-line")
-	drainLogger(l)
-	content := fileContent(t, path)
-	if !strings.Contains(content, "gid-line") {
-		t.Error("message missing when LogGoroutineID=true")
-	}
-}
-
-// ---- SetLogFile ------------------------------------------------------------
-
-func TestSetLogFile_RedirectsOutput(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-
-	dir := t.TempDir()
-	newPath := filepath.Join(dir, "new.log")
-
-	if err := l.SetLogFile(newPath); err != nil {
-		t.Fatalf("SetLogFile: %v", err)
-	}
-
-	l.Info("after-redirect")
-	drainLogger(l)
-
-	if !strings.Contains(fileContent(t, newPath), "after-redirect") {
-		t.Error("message not written to new log file after SetLogFile")
-	}
-}
-
-func TestSetLogFile_InvalidPath(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-	err := l.SetLogFile("/nonexistent/path/log.txt")
-	if err == nil {
-		t.Error("expected error for invalid log file path")
-	}
-}
-
-// ---- LogRotate mechanics ---------------------------------------------------
-
-func TestLogRotate_CreatesRotatedFile(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
-	l.Info("before-rotate")
-	drainLogger(l)
-
-	if err := l.LogRotate(); err != nil {
+	if err := logger.LogRotate(); err != nil {
 		t.Fatalf("LogRotate: %v", err)
 	}
+	logger.compressWg.Wait()
 
-	rotated := path + ".1"
-	if !fileExists(rotated) {
-		t.Errorf("expected rotated file %s to exist", rotated)
+	if content := readCompressedLog(t, logFile+".1.gz"); !strings.Contains(content, "compressed-entry") {
+		t.Fatalf("compressed log does not contain entry: %q", content)
+	}
+	if _, err := os.Stat(logFile + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("plain rotated log still exists: %v", err)
 	}
 }
 
-func TestLogRotate_NewFileIsWritable(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("LogRotate: %v", err)
-	}
-	l.Info("after-rotate")
-	drainLogger(l)
+func TestBaseLoggerPreservesOrderAcrossRapidCompressedRotations(t *testing.T) {
+	logger, logFile := newCompressionTestLogger(t, true)
 
-	if !strings.Contains(fileContent(t, path), "after-rotate") {
-		t.Error("messages after rotation not written to new log file")
+	logger.logger.Println("first-rotation")
+	if err := logger.LogRotate(); err != nil {
+		t.Fatalf("first LogRotate: %v", err)
+	}
+	logger.logger.Println("second-rotation")
+	if err := logger.LogRotate(); err != nil {
+		t.Fatalf("second LogRotate: %v", err)
+	}
+	logger.logger.Println("third-rotation")
+	if err := logger.LogRotate(); err != nil {
+		t.Fatalf("third LogRotate: %v", err)
+	}
+	logger.compressWg.Wait()
+
+	if content := readCompressedLog(t, logFile+".1.gz"); !strings.Contains(content, "third-rotation") {
+		t.Fatalf("newest compressed log has wrong content: %q", content)
+	}
+	if content := readCompressedLog(t, logFile+".2.gz"); !strings.Contains(content, "second-rotation") {
+		t.Fatalf("older compressed log has wrong content: %q", content)
+	}
+	if _, err := os.Stat(logFile + ".3.gz"); !os.IsNotExist(err) {
+		t.Fatalf("compressed log retention exceeded file count: %v", err)
 	}
 }
 
-func TestLogRotate_ShiftsFiles(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
+func TestLogRotateDoesNotWaitForCompression(t *testing.T) {
+	logger, _ := newCompressionTestLogger(t, false)
+	logger.compressWg.Add(1)
 
-	// Create two rotations so .1 becomes .2
-	l.Info("rot1")
-	drainLogger(l)
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("rotate 1: %v", err)
-	}
-	l.Info("rot2")
-	drainLogger(l)
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("rotate 2: %v", err)
-	}
-
-	if !fileExists(path + ".2") {
-		t.Error("expected .2 file after two rotations")
-	}
-}
-
-func TestLogRotate_DeletesOldestFile(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 3})
-
-	// 3 rotations with count=3 should delete the oldest
-	for i := 0; i < 3; i++ {
-		drainLogger(l)
-		if err := l.LogRotate(); err != nil {
-			t.Fatalf("rotate %d: %v", i+1, err)
-		}
-	}
-
-	// .3 should not exist (only 3 files allowed, index 1-2 + current)
-	if fileExists(path + ".3") {
-		t.Error(".3 file should have been deleted with LogFileCount=3")
-	}
-}
-
-func TestLogRotate_ResetsCurrentSize(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
-	l.fileConfig.currentLogSize = 999999
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("LogRotate: %v", err)
-	}
-	if l.fileConfig.currentLogSize != 0 {
-		t.Error("currentLogSize should be reset to 0 after rotation")
-	}
-}
-
-func TestLogRotate_StdoutIsNoop(t *testing.T) {
-	cfg := LogFileConfig{
-		LogFile:      "stdout",
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogSize:      1024 * 1024,
-	}
-	l, err := newBaseLogger(cfg)
-	if err != nil {
-		t.Fatalf("newBaseLogger: %v", err)
-	}
-	defer func() {
-		close(l.channel)
-		l.workerDone.Wait()
+	rotationDone := make(chan error, 1)
+	go func() {
+		rotationDone <- logger.LogRotate()
 	}()
 
-	if err := l.LogRotate(); err != nil {
-		t.Errorf("LogRotate on stdout should not error: %v", err)
-	}
-}
-
-// ---- auto-rotation ---------------------------------------------------------
-
-func TestAutoRotate_TriggersOnSizeExceeded(t *testing.T) {
-	smallSize := uint64(1) // 1 byte — rotate after first message
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogSize:      smallSize,
-	})
-
-	l.Info("trigger-rotate")
-	drainLogger(l)
-
-	if !fileExists(path + ".1") {
-		t.Error("auto-rotation did not produce .1 file")
-	}
-}
-
-// ---- Destroy ---------------------------------------------------------------
-
-func TestDestroy_FlushesMessages(t *testing.T) {
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "destroy.log")
-	cfg := LogFileConfig{
-		LogFile:      logPath,
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogSize:      1024 * 1024,
-	}
-	l, err := newBaseLogger(cfg)
-	if err != nil {
-		t.Fatalf("newBaseLogger: %v", err)
-	}
-
-	l.Info("flush-me")
-	if err := l.Destroy(); err != nil {
-		t.Fatalf("Destroy: %v", err)
-	}
-
-	if !strings.Contains(fileContent(t, logPath), "flush-me") {
-		t.Error("message not flushed before Destroy returned")
-	}
-}
-
-// ---- NewLogger dispatch / public API ---------------------------------------
-
-func TestNewLogger_BaseType(t *testing.T) {
-	dir := t.TempDir()
-	cfg := common.LogConfig{
-		FilePath:    filepath.Join(dir, "base.log"),
-		MaxFileSize: 1,
-		FileCount:   5,
-		Level:       common.ELogLevel.LOG_DEBUG(),
-	}
-	l, err := NewLogger("base", cfg)
-	if err != nil {
-		t.Fatalf("NewLogger base: %v", err)
-	}
-	defer func() { _ = l.Destroy() }()
-	if l.GetType() != "base" {
-		t.Errorf("expected type 'base', got %s", l.GetType())
-	}
-}
-
-func TestNewLogger_SilentType(t *testing.T) {
-	l, err := NewLogger("silent", common.LogConfig{})
-	if err != nil {
-		t.Fatalf("NewLogger silent: %v", err)
-	}
-	if l.GetType() != "silent" {
-		t.Errorf("expected type 'silent', got %s", l.GetType())
-	}
-}
-
-func TestNewLogger_InvalidType(t *testing.T) {
-	_, err := NewLogger("bogus", common.LogConfig{})
-	if err == nil {
-		t.Error("expected error for invalid logger type")
-	}
-}
-
-func TestNewLogger_DefaultTag(t *testing.T) {
-	dir := t.TempDir()
-	cfg := common.LogConfig{
-		FilePath:    filepath.Join(dir, "tag.log"),
-		MaxFileSize: 1,
-		FileCount:   5,
-		Level:       common.ELogLevel.LOG_DEBUG(),
-		Tag:         "",
-	}
-	l, err := NewLogger("base", cfg)
-	if err != nil {
-		t.Fatalf("NewLogger: %v", err)
-	}
-	defer func() { _ = l.Destroy() }()
-	// Smoke test: logger should be usable (tag defaulted to FileSystemName)
-	l.Info("tag-default-check")
-}
-
-// ---- SilentLogger ----------------------------------------------------------
-
-func TestSilentLogger_NoPanic(t *testing.T) {
-	l := &SilentLogger{}
-	l.Debug("d")
-	l.Trace("t")
-	l.Info("i")
-	l.Warn("w")
-	l.Err("e")
-	l.Crit("c")
-	_ = l.LogRotate()
-	_ = l.Destroy()
-}
-
-func TestSilentLogger_GetType(t *testing.T) {
-	l := &SilentLogger{}
-	if l.GetType() != "silent" {
-		t.Errorf("expected 'silent', got %s", l.GetType())
-	}
-}
-
-func TestSilentLogger_GetLogLevel(t *testing.T) {
-	l := &SilentLogger{}
-	if l.GetLogLevel() != common.ELogLevel.LOG_OFF() {
-		t.Errorf("expected LOG_OFF, got %v", l.GetLogLevel())
-	}
-}
-
-// ---- compression tests -----------------------------------------------------
-
-func gzFileContent(t *testing.T, path string) string {
-	t.Helper()
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open gz %s: %v", path, err)
-	}
-	defer f.Close()
-	r, err := gzip.NewReader(f)
-	if err != nil {
-		t.Fatalf("gzip.NewReader %s: %v", path, err)
-	}
-	defer r.Close()
-	b, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read gz %s: %v", path, err)
-	}
-	return string(b)
-}
-
-func TestCompress_ProducesGzFile(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogCompress:  true,
-	})
-	l.Info("before-compress-rotate")
-	drainLogger(l)
-
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("LogRotate: %v", err)
-	}
-	l.compressWg.Wait()
-
-	if !fileExists(path + ".1.gz") {
-		t.Errorf("expected %s.1.gz to exist", path)
-	}
-	if fileExists(path + ".1") {
-		t.Error("plain .1 should have been removed after compression")
-	}
-}
-
-func TestCompress_GzContentIsValid(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogCompress:  true,
-	})
-	l.Info("gz-content-check")
-	drainLogger(l)
-
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("LogRotate: %v", err)
-	}
-	l.compressWg.Wait()
-
-	content := gzFileContent(t, path+".1.gz")
-	if !strings.Contains(content, "gz-content-check") {
-		t.Error("compressed file does not contain expected message")
-	}
-}
-
-func TestCompress_ShiftsGzFiles(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogCompress:  true,
-	})
-
-	l.Info("first")
-	drainLogger(l)
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("rotate 1: %v", err)
-	}
-	l.compressWg.Wait()
-
-	l.Info("second")
-	drainLogger(l)
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("rotate 2: %v", err)
-	}
-	l.compressWg.Wait()
-
-	if !fileExists(path + ".2.gz") {
-		t.Error("expected .2.gz after two compressed rotations")
-	}
-}
-
-func TestCompress_DeletesOldestGz(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 3,
-		LogCompress:  true,
-	})
-
-	for i := 0; i < 3; i++ {
-		drainLogger(l)
-		if err := l.LogRotate(); err != nil {
-			t.Fatalf("rotate %d: %v", i+1, err)
+	select {
+	case err := <-rotationDone:
+		logger.compressWg.Done()
+		if err != nil {
+			t.Fatalf("LogRotate: %v", err)
 		}
-		l.compressWg.Wait()
-	}
-
-	if fileExists(path+".3.gz") || fileExists(path+".3") {
-		t.Error(".3 or .3.gz should be deleted with LogFileCount=3")
-	}
-}
-
-func TestCompress_TransitionFromPlainFiles(t *testing.T) {
-	// Start without compression, rotate once to create a plain .1 file,
-	// then enable compression and rotate again — .1 (plain) should shift
-	// to .2 (plain) and new .1.gz should appear.
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogCompress:  false,
-	})
-
-	l.Info("plain-first")
-	drainLogger(l)
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("plain rotate: %v", err)
-	}
-
-	// Enable compression and rotate again
-	l.fileConfig.LogCompress = true
-	l.Info("compress-second")
-	drainLogger(l)
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("compress rotate: %v", err)
-	}
-	l.compressWg.Wait()
-
-	if !fileExists(path + ".1.gz") {
-		t.Error("expected .1.gz after compressed rotation")
-	}
-	if !fileExists(path + ".2") {
-		t.Error("expected plain .2 (shifted from old .1)")
-	}
-}
-
-func TestCompress_NoCompressModeStillPlain(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogCompress:  false,
-	})
-	l.Info("plain-log")
-	drainLogger(l)
-
-	if err := l.LogRotate(); err != nil {
-		t.Fatalf("LogRotate: %v", err)
-	}
-
-	if !fileExists(path + ".1") {
-		t.Error("expected plain .1 when compression is disabled")
-	}
-	if fileExists(path + ".1.gz") {
-		t.Error("unexpected .gz file when compression is disabled")
-	}
-}
-
-func TestCompress_AutoRotationProducesGz(t *testing.T) {
-	l, path := makeLogger(t, LogFileConfig{
-		LogLevel:     common.ELogLevel.LOG_DEBUG(),
-		LogFileCount: 5,
-		LogSize:      1,
-		LogCompress:  true,
-	})
-
-	l.Info("auto-compress-trigger")
-	drainLogger(l)
-	l.compressWg.Wait()
-
-	if !fileExists(path + ".1.gz") {
-		t.Error("auto-rotation with compression did not produce .1.gz")
-	}
-}
-
-// ---- compressFile unit tests -----------------------------------------------
-
-func TestCompressFile_ProducesGz(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-
-	dir := t.TempDir()
-	src := filepath.Join(dir, "plain.log")
-	if err := os.WriteFile(src, []byte("hello compress"), 0644); err != nil {
-		t.Fatalf("write src: %v", err)
-	}
-
-	if err := l.compressFile(src); err != nil {
-		t.Fatalf("compressFile: %v", err)
-	}
-	if !fileExists(src + ".gz") {
-		t.Error("expected .gz file")
-	}
-	if fileExists(src) {
-		t.Error("original file should be removed after compression")
-	}
-}
-
-func TestCompressFile_ContentRoundTrip(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-
-	dir := t.TempDir()
-	src := filepath.Join(dir, "round.log")
-	want := "round-trip content check"
-	if err := os.WriteFile(src, []byte(want), 0644); err != nil {
-		t.Fatalf("write src: %v", err)
-	}
-
-	if err := l.compressFile(src); err != nil {
-		t.Fatalf("compressFile: %v", err)
-	}
-
-	got := gzFileContent(t, src+".gz")
-	if got != want {
-		t.Errorf("content mismatch: got %q, want %q", got, want)
-	}
-}
-
-func TestCompressFile_MissingSrc(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-	err := l.compressFile("/nonexistent/path/log.txt")
-	if err == nil {
-		t.Error("expected error for missing source file")
-	}
-}
-
-func TestCompressFile_EmptyFile(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-
-	dir := t.TempDir()
-	src := filepath.Join(dir, "empty.log")
-	if err := os.WriteFile(src, []byte{}, 0644); err != nil {
-		t.Fatalf("write src: %v", err)
-	}
-
-	if err := l.compressFile(src); err != nil {
-		t.Fatalf("compressFile on empty file: %v", err)
-	}
-	if !fileExists(src + ".gz") {
-		t.Error("expected .gz for empty file")
-	}
-}
-
-func TestCompressFile_LargeContent(t *testing.T) {
-	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
-
-	dir := t.TempDir()
-	src := filepath.Join(dir, "large.log")
-	line := strings.Repeat("abcdefghijklmnopqrstuvwxyz0123456789\n", 1000)
-	data := strings.Repeat(line, 100)
-	if err := os.WriteFile(src, []byte(data), 0644); err != nil {
-		t.Fatalf("write src: %v", err)
-	}
-
-	if err := l.compressFile(src); err != nil {
-		t.Fatalf("compressFile large: %v", err)
-	}
-	if !fileExists(src + ".gz") {
-		t.Error("expected .gz for large file")
-	}
-	got := gzFileContent(t, src+".gz")
-	if got != data {
-		t.Error("large file round-trip content mismatch")
+	case <-time.After(time.Second):
+		logger.compressWg.Done()
+		if err := <-rotationDone; err != nil {
+			t.Fatalf("LogRotate after compression release: %v", err)
+		}
+		t.Fatal("LogRotate waited for in-flight compression")
 	}
 }

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -41,6 +41,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+
+	"fmt"
+	"strings"
+
 	"testing"
 	"time"
 
@@ -49,6 +53,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
+
+// ---- original suite --------------------------------------------------------
 
 type LoggerTestSuite struct {
 	suite.Suite
@@ -436,4 +442,473 @@ func (lts *LoggerTestSuite) TestSetupCrashOutputRegistersHookAndHandler() {
 
 func TestLoggerTestSuite(t *testing.T) {
 	suite.Run(t, new(LoggerTestSuite))
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+func makeLogger(t *testing.T, cfg LogFileConfig) (*BaseLogger, string) {
+	t.Helper()
+	dir := t.TempDir()
+	if cfg.LogFile == "" {
+		cfg.LogFile = filepath.Join(dir, "test.log")
+	} else {
+		cfg.LogFile = filepath.Join(dir, cfg.LogFile)
+	}
+	if cfg.LogLevel == common.ELogLevel.INVALID() {
+		cfg.LogLevel = common.ELogLevel.LOG_DEBUG()
+	}
+	if cfg.LogFileCount == 0 {
+		cfg.LogFileCount = 5
+	}
+	if cfg.LogSize == 0 {
+		cfg.LogSize = 1024 * 1024
+	}
+	l, err := newBaseLogger(cfg)
+	if err != nil {
+		t.Fatalf("newBaseLogger: %v", err)
+	}
+	t.Cleanup(func() {
+		close(l.channel)
+		l.workerDone.Wait()
+		if l.logFileHandle != os.Stdout {
+			_ = l.logFileHandle.Close()
+		}
+	})
+	return l, cfg.LogFile
+}
+
+func fileContent(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// drainLogger flushes the async channel by closing it and waiting for the
+// worker, then re-initialises it so the logger remains usable.
+func drainLogger(l *BaseLogger) {
+	close(l.channel)
+	l.workerDone.Wait()
+	l.channel = make(chan string, 100000)
+	l.workerDone.Add(1)
+	go l.logDumper(1, l.channel)
+}
+
+// ---- init / defaults -------------------------------------------------------
+
+func TestInit_DefaultLogLevel(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{})
+	if l.fileConfig.LogLevel != common.ELogLevel.LOG_DEBUG() {
+		t.Errorf("default log level: got %v, want LOG_DEBUG", l.fileConfig.LogLevel)
+	}
+}
+
+func TestInit_DefaultLogSize(t *testing.T) {
+	dir := t.TempDir()
+	l, err := newBaseLogger(LogFileConfig{LogFile: filepath.Join(dir, "test.log")})
+	if err != nil {
+		t.Fatalf("newBaseLogger: %v", err)
+	}
+	defer func() { close(l.channel); l.workerDone.Wait(); l.logFileHandle.Close() }()
+	expected := uint64(common.DefaultMaxLogFileSize) * 1024 * 1024
+	if l.fileConfig.LogSize != expected {
+		t.Errorf("default log size: got %d, want %d", l.fileConfig.LogSize, expected)
+	}
+}
+
+func TestInit_DefaultLogFileCount(t *testing.T) {
+	dir := t.TempDir()
+	l, err := newBaseLogger(LogFileConfig{LogFile: filepath.Join(dir, "test.log")})
+	if err != nil {
+		t.Fatalf("newBaseLogger: %v", err)
+	}
+	defer func() { close(l.channel); l.workerDone.Wait(); l.logFileHandle.Close() }()
+	if l.fileConfig.LogFileCount != common.DefaultLogFileCount {
+		t.Errorf("default log file count: got %d, want %d", l.fileConfig.LogFileCount, common.DefaultLogFileCount)
+	}
+}
+
+func TestInit_StdoutFallback(t *testing.T) {
+	cfg := LogFileConfig{
+		LogFile:      "stdout",
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogSize:      1024 * 1024,
+	}
+	l, err := newBaseLogger(cfg)
+	if err != nil {
+		t.Fatalf("newBaseLogger stdout: %v", err)
+	}
+	if l.logFileHandle != os.Stdout {
+		t.Error("expected stdout handle")
+	}
+	close(l.channel)
+	l.workerDone.Wait()
+}
+
+// ---- log level filtering ---------------------------------------------------
+
+func TestLevelFilter_Debug(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+	l.Debug("debug-msg")
+	drainLogger(l)
+	if !strings.Contains(fileContent(t, path), "debug-msg") {
+		t.Error("DEBUG message missing at LOG_DEBUG level")
+	}
+}
+
+func TestLevelFilter_DebugSuppressedAtInfo(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_INFO()})
+	l.Debug("hidden-debug")
+	drainLogger(l)
+	if strings.Contains(fileContent(t, path), "hidden-debug") {
+		t.Error("DEBUG message should be suppressed at LOG_INFO level")
+	}
+}
+
+func TestLevelFilter_InfoVisible(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_INFO()})
+	l.Info("info-msg")
+	drainLogger(l)
+	if !strings.Contains(fileContent(t, path), "info-msg") {
+		t.Error("INFO message missing at LOG_INFO level")
+	}
+}
+
+func TestLevelFilter_WarnSuppressedAtErr(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_ERR()})
+	l.Warn("hidden-warn")
+	drainLogger(l)
+	if strings.Contains(fileContent(t, path), "hidden-warn") {
+		t.Error("WARN message should be suppressed at LOG_ERR level")
+	}
+}
+
+func TestLevelFilter_CritAlwaysVisible(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_CRIT()})
+	l.Crit("crit-msg")
+	drainLogger(l)
+	if !strings.Contains(fileContent(t, path), "crit-msg") {
+		t.Error("CRIT message missing at LOG_CRIT level")
+	}
+}
+
+func TestLevelFilter_Trace(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_TRACE()})
+	l.Trace("trace-msg")
+	drainLogger(l)
+	if !strings.Contains(fileContent(t, path), "trace-msg") {
+		t.Error("TRACE message missing at LOG_TRACE level")
+	}
+}
+
+func TestSetLogLevel_ChangesFiltering(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+	l.SetLogLevel(common.ELogLevel.LOG_ERR())
+	l.Info("suppressed-info")
+	drainLogger(l)
+	if strings.Contains(fileContent(t, path), "suppressed-info") {
+		t.Error("INFO should be suppressed after SetLogLevel(ERR)")
+	}
+}
+
+// ---- output format ---------------------------------------------------------
+
+func TestOutputFormat_ContainsTag(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogTag: "mytag", LogLevel: common.ELogLevel.LOG_DEBUG()})
+	l.Info("tagged-line")
+	drainLogger(l)
+	if !strings.Contains(fileContent(t, path), "mytag") {
+		t.Error("log tag missing from output")
+	}
+}
+
+func TestOutputFormat_ContainsLevel(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+	l.Err("err-line")
+	drainLogger(l)
+	if !strings.Contains(fileContent(t, path), "LOG_ERR") {
+		t.Error("log level string missing from output")
+	}
+}
+
+func TestOutputFormat_ContainsPID(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+	l.Info("pid-line")
+	drainLogger(l)
+	pid := fmt.Sprintf("[%d]", os.Getpid())
+	if !strings.Contains(fileContent(t, path), pid) {
+		t.Error("PID missing from output")
+	}
+}
+
+func TestOutputFormat_GoroutineID(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogGoroutineID: true})
+	l.Info("gid-line")
+	drainLogger(l)
+	content := fileContent(t, path)
+	if !strings.Contains(content, "gid-line") {
+		t.Error("message missing when LogGoroutineID=true")
+	}
+}
+
+// ---- SetLogFile ------------------------------------------------------------
+
+func TestSetLogFile_RedirectsOutput(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+
+	dir := t.TempDir()
+	newPath := filepath.Join(dir, "new.log")
+
+	if err := l.SetLogFile(newPath); err != nil {
+		t.Fatalf("SetLogFile: %v", err)
+	}
+
+	l.Info("after-redirect")
+	drainLogger(l)
+
+	if !strings.Contains(fileContent(t, newPath), "after-redirect") {
+		t.Error("message not written to new log file after SetLogFile")
+	}
+}
+
+func TestSetLogFile_InvalidPath(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG()})
+	err := l.SetLogFile("/nonexistent/path/log.txt")
+	if err == nil {
+		t.Error("expected error for invalid log file path")
+	}
+}
+
+// ---- LogRotate mechanics ---------------------------------------------------
+
+func TestLogRotate_CreatesRotatedFile(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
+	l.Info("before-rotate")
+	drainLogger(l)
+
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("LogRotate: %v", err)
+	}
+
+	rotated := path + ".1"
+	if !fileExists(rotated) {
+		t.Errorf("expected rotated file %s to exist", rotated)
+	}
+}
+
+func TestLogRotate_NewFileIsWritable(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("LogRotate: %v", err)
+	}
+	l.Info("after-rotate")
+	drainLogger(l)
+
+	if !strings.Contains(fileContent(t, path), "after-rotate") {
+		t.Error("messages after rotation not written to new log file")
+	}
+}
+
+func TestLogRotate_ShiftsFiles(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
+
+	// Create two rotations so .1 becomes .2
+	l.Info("rot1")
+	drainLogger(l)
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("rotate 1: %v", err)
+	}
+	l.Info("rot2")
+	drainLogger(l)
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("rotate 2: %v", err)
+	}
+
+	if !fileExists(path + ".2") {
+		t.Error("expected .2 file after two rotations")
+	}
+}
+
+func TestLogRotate_DeletesOldestFile(t *testing.T) {
+	l, path := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 3})
+
+	// 3 rotations with count=3 should delete the oldest
+	for i := 0; i < 3; i++ {
+		drainLogger(l)
+		if err := l.LogRotate(); err != nil {
+			t.Fatalf("rotate %d: %v", i+1, err)
+		}
+	}
+
+	// .3 should not exist (only 3 files allowed, index 1-2 + current)
+	if fileExists(path + ".3") {
+		t.Error(".3 file should have been deleted with LogFileCount=3")
+	}
+}
+
+func TestLogRotate_ResetsCurrentSize(t *testing.T) {
+	l, _ := makeLogger(t, LogFileConfig{LogLevel: common.ELogLevel.LOG_DEBUG(), LogFileCount: 5})
+	l.fileConfig.currentLogSize = 999999
+	if err := l.LogRotate(); err != nil {
+		t.Fatalf("LogRotate: %v", err)
+	}
+	if l.fileConfig.currentLogSize != 0 {
+		t.Error("currentLogSize should be reset to 0 after rotation")
+	}
+}
+
+func TestLogRotate_StdoutIsNoop(t *testing.T) {
+	cfg := LogFileConfig{
+		LogFile:      "stdout",
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogSize:      1024 * 1024,
+	}
+	l, err := newBaseLogger(cfg)
+	if err != nil {
+		t.Fatalf("newBaseLogger: %v", err)
+	}
+	defer func() {
+		close(l.channel)
+		l.workerDone.Wait()
+	}()
+
+	if err := l.LogRotate(); err != nil {
+		t.Errorf("LogRotate on stdout should not error: %v", err)
+	}
+}
+
+// ---- auto-rotation ---------------------------------------------------------
+
+func TestAutoRotate_TriggersOnSizeExceeded(t *testing.T) {
+	smallSize := uint64(1) // 1 byte — rotate after first message
+	l, path := makeLogger(t, LogFileConfig{
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogSize:      smallSize,
+	})
+
+	l.Info("trigger-rotate")
+	drainLogger(l)
+
+	if !fileExists(path + ".1") {
+		t.Error("auto-rotation did not produce .1 file")
+	}
+}
+
+// ---- Destroy ---------------------------------------------------------------
+
+func TestDestroy_FlushesMessages(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "destroy.log")
+	cfg := LogFileConfig{
+		LogFile:      logPath,
+		LogLevel:     common.ELogLevel.LOG_DEBUG(),
+		LogFileCount: 5,
+		LogSize:      1024 * 1024,
+	}
+	l, err := newBaseLogger(cfg)
+	if err != nil {
+		t.Fatalf("newBaseLogger: %v", err)
+	}
+
+	l.Info("flush-me")
+	if err := l.Destroy(); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+
+	if !strings.Contains(fileContent(t, logPath), "flush-me") {
+		t.Error("message not flushed before Destroy returned")
+	}
+}
+
+// ---- NewLogger dispatch / public API ---------------------------------------
+
+func TestNewLogger_BaseType(t *testing.T) {
+	dir := t.TempDir()
+	cfg := common.LogConfig{
+		FilePath:    filepath.Join(dir, "base.log"),
+		MaxFileSize: 1,
+		FileCount:   5,
+		Level:       common.ELogLevel.LOG_DEBUG(),
+	}
+	l, err := NewLogger("base", cfg)
+	if err != nil {
+		t.Fatalf("NewLogger base: %v", err)
+	}
+	defer l.Destroy()
+	if l.GetType() != "base" {
+		t.Errorf("expected type 'base', got %s", l.GetType())
+	}
+}
+
+func TestNewLogger_SilentType(t *testing.T) {
+	l, err := NewLogger("silent", common.LogConfig{})
+	if err != nil {
+		t.Fatalf("NewLogger silent: %v", err)
+	}
+	if l.GetType() != "silent" {
+		t.Errorf("expected type 'silent', got %s", l.GetType())
+	}
+}
+
+func TestNewLogger_InvalidType(t *testing.T) {
+	_, err := NewLogger("bogus", common.LogConfig{})
+	if err == nil {
+		t.Error("expected error for invalid logger type")
+	}
+}
+
+func TestNewLogger_DefaultTag(t *testing.T) {
+	dir := t.TempDir()
+	cfg := common.LogConfig{
+		FilePath:    filepath.Join(dir, "tag.log"),
+		MaxFileSize: 1,
+		FileCount:   5,
+		Level:       common.ELogLevel.LOG_DEBUG(),
+		Tag:         "",
+	}
+	l, err := NewLogger("base", cfg)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	defer l.Destroy()
+	// Smoke test: logger should be usable (tag defaulted to FileSystemName)
+	l.Info("tag-default-check")
+}
+
+// ---- SilentLogger ----------------------------------------------------------
+
+func TestSilentLogger_NoPanic(t *testing.T) {
+	l := &SilentLogger{}
+	l.Debug("d")
+	l.Trace("t")
+	l.Info("i")
+	l.Warn("w")
+	l.Err("e")
+	l.Crit("c")
+	_ = l.LogRotate()
+	_ = l.Destroy()
+}
+
+func TestSilentLogger_GetType(t *testing.T) {
+	l := &SilentLogger{}
+	if l.GetType() != "silent" {
+		t.Errorf("expected 'silent', got %s", l.GetType())
+	}
+}
+
+func TestSilentLogger_GetLogLevel(t *testing.T) {
+	l := &SilentLogger{}
+	if l.GetLogLevel() != common.ELogLevel.LOG_OFF() {
+		t.Errorf("expected LOG_OFF, got %v", l.GetLogLevel())
+	}
 }

--- a/common/types.go
+++ b/common/types.go
@@ -159,6 +159,7 @@ type LogConfig struct {
 	TimeTracker    bool
 	Tag            string // logging tag which can be either blobfuse2 or bfusemon
 	LogGoroutineID bool   // whether to log goroutine id in each log line
+	LogCompress    bool   // compress rolled-over log files (base logger only)
 }
 
 // Flags for block

--- a/setup/advancedConfig.yaml
+++ b/setup/advancedConfig.yaml
@@ -49,6 +49,7 @@ logging:
   max-file-size-mb: <maximum allowed size for each log file (in MB). Default - 512 MB>
   file-count: <maximum number of files to be rotated to preserve old logs. Default - 10>
   goroutine-id: <true|false enable goroutine id in logs for better debugging. Default - true if log level is log_debug, else false>
+  compress: <true|false enable gzip compression of rolled-over log files. Only applies when type is 'base'. Default - false>
 
 # Pipeline configuration. Choose components to be engaged. The order below is the priority order that needs to be followed.
 components:


### PR DESCRIPTION
<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [x] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature**:

  - Add gzip compression to the base logger files when the log rotation happens, the rotated files would have name suffix of "gz"(f.e., blobfuse2.log.1.gz) 
  - Compression happens in seperate go routine, so it doesn't stall the ongoing I/O

## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
