### PR TITLE
feat: expose attr_cache max-files as a CLI flag (--attr-cache-max-files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.4 (Unreleased)
 **Features**
 - Make Blobfuse2 binary FIPS compliant by building with the Microsoft Go toolchain (`systemcrypto` GOEXPERIMENT) and `CGO_ENABLED=1`, routing all `crypto/*` calls through the system OpenSSL FIPS provider ([PR #2226](https://github.com/Azure/azure-storage-fuse/pull/2226))
+- Expose the attribute cache max-files limit as a `--attr-cache-max-files` CLI flag so mountOptions/CSI users can raise the cache cap without a config file ([#2218](https://github.com/Azure/azure-storage-fuse/issues/2218))
 
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))

--- a/component/attr_cache/attr_cache.go
+++ b/component/attr_cache/attr_cache.go
@@ -688,6 +688,9 @@ func init() {
 	attrCacheTimeout := config.AddUint32Flag("attr-cache-timeout", defaultAttrCacheTimeout, "attribute cache timeout")
 	config.BindPFlag(compName+".timeout-sec", attrCacheTimeout)
 
+	attrCacheMaxFiles := config.AddIntFlag("attr-cache-max-files", defaultMaxFiles, "Maximum number of file attributes to cache in the attribute cache.")
+	config.BindPFlag(compName+".max-files", attrCacheMaxFiles)
+
 	noSymlinks := config.AddBoolFlag("no-symlinks", false, "whether or not symlinks should be supported")
 	config.BindPFlag(compName+".no-symlinks", noSymlinks)
 


### PR DESCRIPTION
## Summary
Adds an `--attr-cache-max-files` CLI flag to the attribute cache component. The flag is bound to the existing `attr_cache.max-files` config key in `init()`, mirroring the existing `attr-cache-timeout` flag registration. It defaults to `defaultMaxFiles` (5,000,000), so behavior is identical when the flag is not passed.

## Why this matters
Issue #2218 reports that `GetBlobProperties` calls continue (~20,000/min) even after a large dataset is fully cached, during AKS model training over ~13M files. The cause is that the attribute cache is capped at `defaultMaxFiles = 5,000,000`; files beyond that cap are never cached, so every access re-issues a GetProperties call.

The cap is already configurable through the YAML key `attr_cache.max-files`, but there was no command-line flag. PersistentVolume / CSI `mountOptions` users pass flags rather than a config file and therefore could not raise the limit. The maintainer (@syeleti-msft) committed to exposing this as a CLI option in the next release; this change does exactly that, keeping scope to the flag binding only (no change to the default or to cache/eviction logic).

## Testing
- `GOOS=linux GOARCH=amd64 go build ./component/attr_cache/...` — clean.
- `GOOS=linux GOARCH=amd64 go vet ./component/attr_cache/...` — clean.
- `GOOS=linux GOARCH=amd64 go test -c ./component/attr_cache/` — test binary compiles (existing config tests assert `max-files` via YAML and are unaffected; the flag default preserves current behavior).
- The change is additive flag registration in `init()`; `Configure()` already keys off `config.IsSet(compName + ".max-files")`.

Fixes #2218

AI was used for assistance.
