### PR TITLE
Support kernel list caching with a TTL parameter to configure the staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
     timeout-sec: 120
     max-size-mb: 256   # set explicitly to override auto-tuning
   ```
+- Kernel directory-listing cache (fuse3 only). When `kernel-list-cache-expiration-sec` is set to a non-zero value in the `libfuse` config section, blobfuse2 instructs the kernel to cache `readdir` results for that many seconds. Repeat `ls` calls within the TTL are served entirely from the kernel's page cache without any userspace round-trip, significantly reducing latency and backend API traffic for read-heavy workloads. After the TTL expires the next `opendir` call signals the kernel to discard the stale listing and issue a fresh `READDIRPLUS`. A background sweeper proactively invalidates entries that were never re-opened, keeping kernel memory usage bounded. Example configuration:
+  ```yaml
+  libfuse:
+    kernel-list-cache-expiration-sec: 30   # 0 disables kernel caching (default)
+  ```
+  Alternatively, pass `--kernel-list-cache-timeout=<seconds>` on the `mount` command line.
 
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
     timeout-sec: 120
     max-size-mb: 256   # set explicitly to override auto-tuning
   ```
-- Kernel directory-listing cache (fuse3 only). When `kernel-list-cache-expiration-sec` is set to a non-zero value in the `libfuse` config section, blobfuse2 instructs the kernel to cache `readdir` results for that many seconds. Repeat `ls` calls within the TTL are served entirely from the kernel's page cache without any userspace round-trip, significantly reducing latency and backend API traffic for read-heavy workloads. After the TTL expires the next `opendir` call signals the kernel to discard the stale listing and issue a fresh `READDIRPLUS`. A background sweeper proactively invalidates entries that were never re-opened, keeping kernel memory usage bounded. Example configuration:
+- Kernel directory-listing cache (fuse3 only). When `kernel-list-cache-expiration-sec` is set in the `libfuse` config section, blobfuse2 instructs the kernel to cache `readdir` results for that many seconds. Repeat `ls` calls within the TTL are served entirely from the kernel's page cache without any userspace round-trip, significantly reducing latency and backend API traffic for read-heavy workloads. After the TTL expires the next `opendir` call signals the kernel to discard the stale listing and issue a fresh `READDIRPLUS`. A background sweeper proactively invalidates entries that were never re-opened, keeping kernel memory usage bounded. The default TTL is **120 seconds** (matching the other libfuse timeouts); set to `0` to disable. Example configuration:
   ```yaml
   libfuse:
-    kernel-list-cache-expiration-sec: 30   # 0 disables kernel caching (default)
+    kernel-list-cache-expiration-sec: 120   # 0 disables kernel list caching
   ```
   Alternatively, pass `--kernel-list-cache-timeout=<seconds>` on the `mount` command line.
 

--- a/component/libfuse/integration_harness_test.go
+++ b/component/libfuse/integration_harness_test.go
@@ -1,0 +1,193 @@
+//go:build integration && !fuse2
+
+/*
+    _____           _____   _____   ____          ______  _____  ------
+   |     |  |      |     | |     | |     |     | |       |            |
+   |     |  |      |     | |     | |     |     | |       |            |
+   | --- |  |      |     | |-----| |---- |     | |-----| |-----  ------
+   |     |  |      |     | |     | |     |     |       | |       |
+   | ____|  |_____ | ____| | ____| |     |_____|  _____| |_____  |_____
+
+
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2020-2026 Microsoft Corporation. All rights reserved.
+   Author : <blobfusedev@microsoft.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package libfuse
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-storage-fuse/v2/common"
+	"github.com/Azure/azure-storage-fuse/v2/common/log"
+	"github.com/Azure/azure-storage-fuse/v2/internal"
+)
+
+// integrationHarness manages a live FUSE mount for integration tests.
+//
+// The caller supplies any internal.Component as the backend and the libfuse
+// section of the YAML config. The harness owns mount-path creation, FUSE
+// startup, and teardown — everything else is the caller's concern.
+//
+// Typical usage:
+//
+//	backend := newCountingBackend()
+//	h := newIntegrationHarness(t, backend, "libfuse:\n  kernel-list-cache-expiration-sec: 30\n")
+//	h.start(t)
+//	defer h.stop(t)
+//	// interact with h.MountDir, backend directly
+type integrationHarness struct {
+	MountDir string
+	lf       *Libfuse
+	cancel   context.CancelFunc
+	done     chan struct{}
+}
+
+// newIntegrationHarness wires up the pipeline and creates a temp mount directory.
+// libfuseCfg is the "libfuse:" section of the YAML config (without mount-path,
+// which the harness injects automatically). Pass "" for defaults.
+// The caller must call h.start(t) before interacting with MountDir and h.stop(t)
+// in a defer to unmount and clean up.
+func newIntegrationHarness(t *testing.T, backend internal.Component, libfuseCfg string) *integrationHarness {
+	t.Helper()
+	checkFuseAvailable(t)
+
+	mountDir, err := os.MkdirTemp("", "blobfuse-integration-*")
+	if err != nil {
+		t.Fatalf("failed to create temp mount dir: %v", err)
+	}
+
+	cfg := fmt.Sprintf("mount-path: %s\n%s", mountDir, libfuseCfg)
+	lf := newTestLibfuse(backend, cfg)
+
+	_, cancel := context.WithCancel(context.Background())
+	return &integrationHarness{
+		MountDir: mountDir,
+		lf:       lf,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+	}
+}
+
+// start launches the FUSE event loop in a goroutine and blocks until the
+// mount point is visible in /proc/mounts (up to 5 s).
+func (h *integrationHarness) start(t *testing.T) {
+	t.Helper()
+
+	// ForegroundMount=true suppresses the SIGUSR2 sent to the parent process by
+	// NotifyMountToParent inside libfuse_init.  Save and restore the original
+	// value so other tests in the same binary are not affected.
+	origForeground := common.ForegroundMount
+	common.ForegroundMount = true
+	t.Cleanup(func() { common.ForegroundMount = origForeground })
+
+	go func() {
+		defer close(h.done)
+		// Start blocks inside C.start_fuse (fuse_main) until the mount is
+		// unmounted externally via fusermount3 -u.
+		if err := h.lf.Start(context.Background()); err != nil {
+			// A non-nil error from Start means fuse_main failed (e.g. mount
+			// permission denied). The test will time out in waitForMount and
+			// report a clear message.
+			log.Err("integrationHarness::start : %v", err)
+		}
+	}()
+
+	if !waitForMount(h.MountDir, 5*time.Second) {
+		h.lf.Stop()
+		os.RemoveAll(h.MountDir)
+		t.Fatalf("FUSE mount at %s did not appear within 5s — is FUSE available and are permissions sufficient?", h.MountDir)
+	}
+}
+
+// stop unmounts the FUSE filesystem, waits for the goroutine to finish, then
+// cleans up the mount directory.
+func (h *integrationHarness) stop(t *testing.T) {
+	t.Helper()
+
+	// Trigger unmount so fuse_main returns and the goroutine can exit.
+	for _, bin := range []string{"fusermount3", "fusermount"} {
+		if err := exec.Command(bin, "-u", h.MountDir).Run(); err == nil {
+			break
+		}
+	}
+	h.cancel()
+
+	select {
+	case <-h.done:
+	case <-time.After(5 * time.Second):
+		t.Log("warn: FUSE goroutine did not exit within 5s after unmount")
+	}
+
+	// Clean up tracker goroutine, stats collector, etc.
+	_ = h.lf.Stop()
+	os.RemoveAll(h.MountDir)
+}
+
+// listDir calls os.ReadDir against MountDir (or a subdirectory) and fails the
+// test on error. dir is relative to MountDir; pass "" for the root.
+func (h *integrationHarness) listDir(t *testing.T, dir string) {
+	t.Helper()
+	target := h.MountDir
+	if dir != "" {
+		target = h.MountDir + "/" + dir
+	}
+	if _, err := os.ReadDir(target); err != nil {
+		t.Fatalf("ReadDir(%q) failed: %v", target, err)
+	}
+}
+
+// waitForMount polls /proc/mounts until mountDir appears or timeout elapses.
+func waitForMount(mountDir string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, _ := os.ReadFile("/proc/mounts")
+		if strings.Contains(string(data), mountDir) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+// checkFuseAvailable skips the test if FUSE is not usable by the current process.
+func checkFuseAvailable(t *testing.T) {
+	t.Helper()
+	if _, err := os.Stat("/dev/fuse"); err != nil {
+		t.Skip("FUSE not available (/dev/fuse missing): ", err)
+	}
+	if os.Getuid() != 0 {
+		// Non-root can mount FUSE only when /etc/fuse.conf contains
+		// "user_allow_other".  Check for that rather than skipping blindly.
+		data, _ := os.ReadFile("/etc/fuse.conf")
+		if !strings.Contains(string(data), "user_allow_other") {
+			t.Skip("FUSE integration tests require root or 'user_allow_other' in /etc/fuse.conf")
+		}
+	}
+}

--- a/component/libfuse/kernel_list_cache.go
+++ b/component/libfuse/kernel_list_cache.go
@@ -140,6 +140,7 @@ func (t *kernelListCacheTracker) sweepExpired() {
 			return
 		}
 	}
+
 	ttl := t.ttl
 	var expired []string
 	t.lru.DeleteIf(func(path string, item *dirCacheItem) bool {
@@ -149,6 +150,8 @@ func (t *kernelListCacheTracker) sweepExpired() {
 		}
 		return false
 	})
+
+	var failed int
 	for _, path := range expired {
 		// Proactive optimization: evict the kernel's cached listing for this path so
 		// it can reclaim page cache memory sooner.  Correctness does not depend on
@@ -158,8 +161,9 @@ func (t *kernelListCacheTracker) sweepExpired() {
 		// for fresh data.
 		if err := fuseFS.InvalidateKernelListCache("/" + strings.TrimSuffix(path, "/")); err != nil {
 			log.Warn("kernelListCacheTracker::sweepExpired : failed to invalidate %s [%s]", path, err)
+			failed++
 		}
 	}
-	log.Debug("kernelListCacheTracker::sweepExpired : evicted %d entries, lru %d MB / %d MB",
-		len(expired), t.lru.Size()>>20, t.lru.MaxSize()>>20)
+	log.Debug("kernelListCacheTracker::sweepExpired : evicted %d entries (%d invalidation failures), lru %d MB / %d MB",
+		len(expired), failed, t.lru.Size()>>20, t.lru.MaxSize()>>20)
 }

--- a/component/libfuse/kernel_list_cache.go
+++ b/component/libfuse/kernel_list_cache.go
@@ -134,8 +134,9 @@ func (t *kernelListCacheTracker) ttlSweeper() {
 // The idle gate (identical to AttrCache.sweepExpired) skips the sweep when the cache
 // is under active use to avoid write-lock contention with opendir traffic.
 func (t *kernelListCacheTracker) sweepExpired() {
+	idleThreshold := t.ttl / 2
 	if last := t.lastOp.Load(); last != 0 {
-		if time.Now().Unix()-last < int64(t.ttl/(2*time.Second)) {
+		if time.Since(time.Unix(last, 0)) < idleThreshold {
 			return
 		}
 	}

--- a/component/libfuse/kernel_list_cache.go
+++ b/component/libfuse/kernel_list_cache.go
@@ -1,0 +1,164 @@
+//go:build !fuse2
+
+/*
+    _____           _____   _____   ____          ______  _____  ------
+   |     |  |      |     | |     | |     |     | |       |            |
+   |     |  |      |     | |     | |     |     | |       |            |
+   | --- |  |      |     | |-----| |---- |     | |-----| |-----  ------
+   |     |  |      |     | |     | |     |     |       | |       |
+   | ____|  |_____ | ____| | ____| |     |_____|  _____| |_____  |_____
+
+
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2020-2026 Microsoft Corporation. All rights reserved.
+   Author : <blobfusedev@microsoft.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package libfuse
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	cachepolicy "github.com/Azure/azure-storage-fuse/v2/common/cache_policy"
+	"github.com/Azure/azure-storage-fuse/v2/common/log"
+)
+
+// defaultKernelListCacheMaxSizeMB caps the LRU memory usage (~160k entries at avg 200B).
+const defaultKernelListCacheMaxSizeMB = 32
+
+type dirCacheItem struct {
+	cachedAt time.Time
+}
+
+func dirCacheItemSize(key string, _ *dirCacheItem) int64 {
+	// 2× for GC overhead, matching the same multiplier used in attr_cache.
+	return int64(len(key)+int(unsafe.Sizeof(dirCacheItem{}))) * 2
+}
+
+type kernelListCacheTracker struct {
+	lru    *cachepolicy.LRU[string, *dirCacheItem]
+	ttl    time.Duration
+	lastOp atomic.Int64 // Unix seconds of last trackDir; used as idle gate in sweeper
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+func newKernelListCacheTracker(ttlSec uint32) *kernelListCacheTracker {
+	return &kernelListCacheTracker{
+		lru:    cachepolicy.NewLRU[string, *dirCacheItem](defaultKernelListCacheMaxSizeMB*1024*1024, dirCacheItemSize),
+		ttl:    time.Duration(ttlSec) * time.Second,
+		stopCh: make(chan struct{}),
+	}
+}
+
+func (t *kernelListCacheTracker) start() {
+	t.wg.Add(1)
+	go func() { defer t.wg.Done(); t.ttlSweeper() }()
+}
+
+func (t *kernelListCacheTracker) stop() {
+	close(t.stopCh)
+	t.wg.Wait()
+}
+
+// trackDir records an opendir for the given directory name in blobfuse internal
+// format: "" for root, "dir/" for a subdirectory (libfuse_opendir appends the
+// trailing slash; the raw FUSE path has none). Returns whether the cached listing
+// is still fresh.
+//
+// Returns true  → within TTL; caller should set cache_readdir=1, keep_cache=1.
+// Returns false → expired or first access; caller should set cache_readdir=1, keep_cache=0
+// so the kernel discards any stale listing and fetches fresh data via READDIRPLUS.
+//
+// When the LRU evicts an entry due to the size cap, fuse_invalidate_path is NOT called.
+// This is safe: the next opendir for that path hits !found here, returns false, and the
+// caller sets keep_cache=0, causing the kernel to discard any stale listing and call
+// READDIRPLUS for fresh data.
+func (t *kernelListCacheTracker) trackDir(name string) bool {
+	t.lastOp.Store(time.Now().Unix())
+
+	now := time.Now()
+	item, found := t.lru.Get(name)
+	if !found {
+		t.lru.Put(name, &dirCacheItem{cachedAt: now})
+		return false
+	}
+	if now.Sub(item.cachedAt) >= t.ttl {
+		t.lru.Put(name, &dirCacheItem{cachedAt: now})
+		return false
+	}
+	return true
+}
+
+// ttlSweeper ticks every TTL and evicts expired entries when the cache is idle.
+// Mirrors AttrCache.ttlSweeper.
+func (t *kernelListCacheTracker) ttlSweeper() {
+	ticker := time.NewTicker(t.ttl)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			t.sweepExpired()
+		case <-t.stopCh:
+			return
+		}
+	}
+}
+
+// sweepExpired removes TTL-expired entries from the LRU and calls fuse_invalidate_path
+// for each, evicting stale listings from the kernel's dentry cache for directories
+// that have not been accessed since their TTL elapsed.
+// The idle gate (identical to AttrCache.sweepExpired) skips the sweep when the cache
+// is under active use to avoid write-lock contention with opendir traffic.
+func (t *kernelListCacheTracker) sweepExpired() {
+	if last := t.lastOp.Load(); last != 0 {
+		if time.Now().Unix()-last < int64(t.ttl/(2*time.Second)) {
+			return
+		}
+	}
+	ttl := t.ttl
+	var expired []string
+	t.lru.DeleteIf(func(path string, item *dirCacheItem) bool {
+		if time.Since(item.cachedAt) >= ttl {
+			expired = append(expired, path)
+			return true
+		}
+		return false
+	})
+	for _, path := range expired {
+		// Proactive optimization: evict the kernel's cached listing for this path so
+		// it can reclaim page cache memory sooner.  Correctness does not depend on
+		// this call — if it is skipped or fails, the next opendir for the path will
+		// have trackDir return false (either !found after LRU eviction, or expired),
+		// causing the caller to set keep_cache=0 and the kernel to call READDIRPLUS
+		// for fresh data.
+		if err := fuseFS.InvalidateKernelListCache("/" + strings.TrimSuffix(path, "/")); err != nil {
+			log.Warn("kernelListCacheTracker::sweepExpired : failed to invalidate %s [%s]", path, err)
+		}
+	}
+	log.Debug("kernelListCacheTracker::sweepExpired : evicted %d entries, lru %d MB / %d MB",
+		len(expired), t.lru.Size()>>20, t.lru.MaxSize()>>20)
+}

--- a/component/libfuse/kernel_list_cache_fuse2.go
+++ b/component/libfuse/kernel_list_cache_fuse2.go
@@ -1,0 +1,46 @@
+//go:build fuse2
+
+/*
+    _____           _____   _____   ____          ______  _____  ------
+   |     |  |      |     | |     | |     |     | |       |            |
+   |     |  |      |     | |     | |     |     | |       |            |
+   | --- |  |      |     | |-----| |---- |     | |-----| |-----  ------
+   |     |  |      |     | |     | |     |     |       | |       |
+   | ____|  |_____ | ____| | ____| |     |_____|  _____| |_____  |_____
+
+
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2020-2026 Microsoft Corporation. All rights reserved.
+   Author : <blobfusedev@microsoft.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package libfuse
+
+// kernelListCacheTracker is not supported on fuse2. This stub satisfies the
+// type reference in libfuse.go (which has no build tag) so that fuse2 builds
+// compile. newKernelListCacheTracker is never called under fuse2 because
+// libfuse2_handler.go zeroes kernelListCacheTtlInSec at init time.
+type kernelListCacheTracker struct{}
+
+func newKernelListCacheTracker(_ uint32) *kernelListCacheTracker { return &kernelListCacheTracker{} }
+func (t *kernelListCacheTracker) start()                         {}
+func (t *kernelListCacheTracker) stop()                          {}

--- a/component/libfuse/kernel_list_cache_integration_test.go
+++ b/component/libfuse/kernel_list_cache_integration_test.go
@@ -1,0 +1,249 @@
+//go:build integration && !fuse2
+
+/*
+    _____           _____   _____   ____          ______  _____  ------
+   |     |  |      |     | |     | |     |     | |       |            |
+   |     |  |      |     | |     | |     |     | |       |            |
+   | --- |  |      |     | |-----| |---- |     | |-----| |-----  ------
+   |     |  |      |     | |     | |     |     |       | |       |
+   | ____|  |_____ | ____| | ____| |     |_____|  _____| |_____  |_____
+
+
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2020-2026 Microsoft Corporation. All rights reserved.
+   Author : <blobfusedev@microsoft.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package libfuse
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-storage-fuse/v2/common"
+	"github.com/Azure/azure-storage-fuse/v2/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// CountingBackend is a minimal pipeline component that counts StreamDir calls.
+// It lets tests assert whether the kernel served a directory listing from its
+// readdir cache (count unchanged) or issued a fresh READDIRPLUS (count incremented).
+type CountingBackend struct {
+	internal.BaseComponent
+	count atomic.Int64
+	dirs  map[string][]*internal.ObjAttr
+}
+
+func (c *CountingBackend) StreamDir(options internal.StreamDirOptions) ([]*internal.ObjAttr, string, error) {
+	c.count.Add(1)
+	return c.dirs[options.Name], "", nil
+}
+
+func (c *CountingBackend) GetAttr(options internal.GetAttrOptions) (*internal.ObjAttr, error) {
+	var flags common.BitMap64
+	flags.Set(internal.PropFlagIsDir)
+	return &internal.ObjAttr{
+		Path:  options.Name,
+		Name:  options.Name,
+		Flags: flags,
+		Mode:  os.ModeDir | 0755,
+	}, nil
+}
+
+func (c *CountingBackend) StreamDirCount() int64 { return c.count.Load() }
+func (c *CountingBackend) ResetCount()           { c.count.Store(0) }
+
+func dirFlags() common.BitMap64 {
+	var bm common.BitMap64
+	bm.Set(internal.PropFlagIsDir)
+	return bm
+}
+
+func newCountingBackend() *CountingBackend {
+	root := []*internal.ObjAttr{
+		{Path: "file1.txt", Name: "file1.txt", Mode: 0644},
+		{Path: "file2.txt", Name: "file2.txt", Mode: 0644},
+		{Path: "subdir", Name: "subdir", Flags: dirFlags(), Mode: os.ModeDir | 0755},
+	}
+	sub := []*internal.ObjAttr{
+		{Path: "subdir/child.txt", Name: "child.txt", Mode: 0644},
+	}
+	return &CountingBackend{
+		dirs: map[string][]*internal.ObjAttr{
+			"":        root,
+			"subdir/": sub,
+		},
+	}
+}
+
+func klcCfg(ttlSec uint32) string {
+	return fmt.Sprintf("libfuse:\n  kernel-list-cache-expiration-sec: %d\n  allow-other: true\n", ttlSec)
+}
+
+// kernelListCacheIntegrationSuite tests the end-to-end kernel directory-listing
+// cache using a live FUSE mount.
+//
+// Run with:
+//
+//	go test -tags "integration fuse3" -v ./component/libfuse/... -timeout 120s
+type kernelListCacheIntegrationSuite struct {
+	suite.Suite
+	assert *assert.Assertions
+}
+
+func (s *kernelListCacheIntegrationSuite) SetupTest() {
+	s.assert = assert.New(s.T())
+}
+
+// TestColdCache verifies that the very first ls for a directory reaches the backend.
+func (s *kernelListCacheIntegrationSuite) TestColdCache() {
+	backend := newCountingBackend()
+	h := newIntegrationHarness(s.T(), backend, klcCfg(30))
+	h.start(s.T())
+	defer h.stop(s.T())
+
+	h.listDir(s.T(), "")
+
+	s.assert.Equal(int64(1), backend.StreamDirCount(),
+		"cold cache: backend must be called exactly once on first ls")
+}
+
+// TestHitWithinTTL verifies that a second ls within the TTL is served from the
+// kernel's readdir cache and does NOT reach the backend.
+func (s *kernelListCacheIntegrationSuite) TestHitWithinTTL() {
+	backend := newCountingBackend()
+	h := newIntegrationHarness(s.T(), backend, klcCfg(30))
+	h.start(s.T())
+	defer h.stop(s.T())
+
+	h.listDir(s.T(), "") // cold — count → 1
+	h.listDir(s.T(), "") // within TTL — kernel cache hit, count stays 1
+
+	s.assert.Equal(int64(1), backend.StreamDirCount(),
+		"within TTL: second ls must be served from kernel cache, not backend")
+}
+
+// TestMissAfterTTL verifies that an ls after TTL expiry causes the kernel to
+// discard the cached listing and issue a fresh READDIRPLUS to the backend.
+func (s *kernelListCacheIntegrationSuite) TestMissAfterTTL() {
+	const ttlSec = 3
+	backend := newCountingBackend()
+	h := newIntegrationHarness(s.T(), backend, klcCfg(ttlSec))
+	h.start(s.T())
+	defer h.stop(s.T())
+
+	h.listDir(s.T(), "") // cold — count → 1
+	s.assert.Equal(int64(1), backend.StreamDirCount())
+
+	// Wait just past the TTL.  No need for 2×: opendir itself checks trackDir
+	// and returns keep_cache=0 for expired entries, which makes the kernel
+	// discard its cached listing and issue a fresh READDIRPLUS immediately.
+	time.Sleep(time.Duration(ttlSec)*time.Second + 100*time.Millisecond)
+
+	h.listDir(s.T(), "") // TTL expired — count → 2
+
+	s.assert.Equal(int64(2), backend.StreamDirCount(),
+		"after TTL: backend must be called again for the stale directory")
+}
+
+// TestDisabledWhenTTLZero verifies that with TTL=0 every ls reaches the backend
+// (kernel caching is disabled).
+func (s *kernelListCacheIntegrationSuite) TestDisabledWhenTTLZero() {
+	backend := newCountingBackend()
+	h := newIntegrationHarness(s.T(), backend, klcCfg(0))
+	h.start(s.T())
+	defer h.stop(s.T())
+
+	h.listDir(s.T(), "") // count → 1
+	h.listDir(s.T(), "") // count → 2
+	h.listDir(s.T(), "") // count → 3
+
+	s.assert.Equal(int64(3), backend.StreamDirCount(),
+		"TTL=0: every ls must reach the backend (no kernel caching)")
+}
+
+// TestRootAndSubdirAreCachedIndependently verifies that root and subdirectory
+// listings are tracked as separate cache entries with independent TTLs.
+func (s *kernelListCacheIntegrationSuite) TestRootAndSubdirAreCachedIndependently() {
+	backend := newCountingBackend()
+	h := newIntegrationHarness(s.T(), backend, klcCfg(30))
+	h.start(s.T())
+	defer h.stop(s.T())
+
+	h.listDir(s.T(), "")       // root cold — count → 1
+	h.listDir(s.T(), "subdir") // subdir cold — count → 2
+
+	// Both within TTL: neither should reach the backend again.
+	h.listDir(s.T(), "")       // root cache hit — count stays 2
+	h.listDir(s.T(), "subdir") // subdir cache hit — count stays 2
+
+	s.assert.Equal(int64(2), backend.StreamDirCount(),
+		"root and subdir are cached independently; repeat ls must not hit backend")
+}
+
+// TestSubdirExpiredAfterTTL verifies that a subdirectory's cache entry expires
+// independently of root.
+func (s *kernelListCacheIntegrationSuite) TestSubdirExpiredAfterTTL() {
+	const ttlSec = 3
+	backend := newCountingBackend()
+	h := newIntegrationHarness(s.T(), backend, klcCfg(ttlSec))
+	h.start(s.T())
+	defer h.stop(s.T())
+
+	h.listDir(s.T(), "subdir") // cold — count → 1
+	time.Sleep(time.Duration(ttlSec)*time.Second + 100*time.Millisecond)
+	h.listDir(s.T(), "subdir") // TTL expired — count → 2
+
+	s.assert.Equal(int64(2), backend.StreamDirCount(),
+		"subdir cache must expire after TTL and trigger a fresh backend call")
+}
+
+// TestCacheHitAfterReset verifies that after the cache is reset (simulating a
+// new mount or invalidation) the first ls goes to the backend again.
+func (s *kernelListCacheIntegrationSuite) TestCacheHitAfterReset() {
+	backend := newCountingBackend()
+	h := newIntegrationHarness(s.T(), backend, klcCfg(30))
+	h.start(s.T())
+	defer h.stop(s.T())
+
+	h.listDir(s.T(), "") // cold — count → 1
+	h.listDir(s.T(), "") // hit — count stays 1
+	s.assert.Equal(int64(1), backend.StreamDirCount())
+
+	// Forcibly evict the kernel's cached listing via fuse_invalidate_path,
+	// as the TTL sweeper would do for a stale directory.
+	_ = h.lf.InvalidateKernelListCache("/")
+	backend.ResetCount()
+
+	h.listDir(s.T(), "") // cache was evicted — count → 1 again
+
+	s.assert.Equal(int64(1), backend.StreamDirCount(),
+		"after manual invalidation backend must be called again")
+}
+
+func TestKernelListCacheIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(kernelListCacheIntegrationSuite))
+}

--- a/component/libfuse/kernel_list_cache_test.go
+++ b/component/libfuse/kernel_list_cache_test.go
@@ -1,0 +1,243 @@
+//go:build !fuse2
+
+/*
+    _____           _____   _____   ____          ______  _____  ------
+   |     |  |      |     | |     | |     |     | |       |            |
+   |     |  |      |     | |     | |     |     | |       |            |
+   | --- |  |      |     | |-----| |---- |     | |-----| |-----  ------
+   |     |  |      |     | |     | |     |     |       | |       |
+   | ____|  |_____ | ____| | ____| |     |_____|  _____| |_____  |_____
+
+
+   Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+
+   Copyright © 2020-2026 Microsoft Corporation. All rights reserved.
+   Author : <blobfusedev@microsoft.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE
+*/
+
+package libfuse
+
+import (
+	"testing"
+	"time"
+
+	cachepolicy "github.com/Azure/azure-storage-fuse/v2/common/cache_policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type kernelListCacheTestSuite struct {
+	suite.Suite
+	assert *assert.Assertions
+}
+
+func (s *kernelListCacheTestSuite) SetupTest() {
+	s.assert = assert.New(s.T())
+	// sweepExpired calls fuseFS.InvalidateKernelListCache; set a non-nil instance so
+	// the call reaches C (which returns an error safely when g_fuse == NULL) instead
+	// of panicking on a nil dereference.
+	fuseFS = &Libfuse{}
+}
+
+func (s *kernelListCacheTestSuite) TeardownTest() {
+	fuseFS = nil
+}
+
+func newTestTracker(ttl time.Duration) *kernelListCacheTracker {
+	return &kernelListCacheTracker{
+		lru:    cachepolicy.NewLRU[string, *dirCacheItem](defaultKernelListCacheMaxSizeMB*1024*1024, dirCacheItemSize),
+		ttl:    ttl,
+		stopCh: make(chan struct{}),
+	}
+}
+
+// ---- trackDir ---------------------------------------------------------------
+
+// TestTrackDirNewPath verifies that a first-time opendir returns false and stores the entry.
+func (s *kernelListCacheTestSuite) TestTrackDirNewPath() {
+	t := newTestTracker(time.Hour)
+
+	result := t.trackDir("dir/")
+
+	s.assert.False(result)
+	s.assert.True(t.lru.Has("dir/"))
+}
+
+// TestTrackDirRoot verifies that root ("") is handled identically to any other path.
+func (s *kernelListCacheTestSuite) TestTrackDirRoot() {
+	t := newTestTracker(time.Hour)
+
+	result := t.trackDir("")
+
+	s.assert.False(result)
+	s.assert.True(t.lru.Has(""))
+}
+
+// TestTrackDirWithinTTL verifies that a second opendir within TTL returns true.
+func (s *kernelListCacheTestSuite) TestTrackDirWithinTTL() {
+	t := newTestTracker(time.Hour)
+	t.lru.Put("dir/", &dirCacheItem{cachedAt: time.Now()})
+
+	result := t.trackDir("dir/")
+
+	s.assert.True(result)
+}
+
+// TestTrackDirWithinTTLDoesNotResetCachedAt verifies that a cache hit does not reset
+// cachedAt, which would silently extend the TTL on every access.
+func (s *kernelListCacheTestSuite) TestTrackDirWithinTTLDoesNotResetCachedAt() {
+	t := newTestTracker(time.Hour)
+	original := time.Now().Add(-30 * time.Minute)
+	t.lru.Put("dir/", &dirCacheItem{cachedAt: original})
+
+	t.trackDir("dir/")
+
+	item, ok := t.lru.Peek("dir/")
+	s.assert.True(ok)
+	s.assert.Equal(original, item.cachedAt)
+}
+
+// TestTrackDirExpired verifies that an opendir after TTL returns false and resets cachedAt.
+func (s *kernelListCacheTestSuite) TestTrackDirExpired() {
+	t := newTestTracker(time.Hour)
+	t.lru.Put("dir/", &dirCacheItem{cachedAt: time.Now().Add(-2 * time.Hour)})
+
+	before := time.Now()
+	result := t.trackDir("dir/")
+
+	s.assert.False(result)
+	item, ok := t.lru.Peek("dir/")
+	s.assert.True(ok)
+	s.assert.False(item.cachedAt.Before(before), "cachedAt must be reset to approximately now")
+}
+
+// TestTrackDirUpdatesLastOp verifies that trackDir refreshes the idle-gate timestamp.
+func (s *kernelListCacheTestSuite) TestTrackDirUpdatesLastOp() {
+	t := newTestTracker(time.Hour)
+	before := time.Now().Unix()
+
+	t.trackDir("dir/")
+
+	s.assert.GreaterOrEqual(t.lastOp.Load(), before)
+}
+
+// ---- LRU size-cap eviction --------------------------------------------------
+
+// TestTrackDirAfterLRUEviction verifies that when the LRU silently evicts an entry
+// due to the size cap, the next trackDir for that path returns false (treated as new)
+// rather than a stale cache hit.
+func (s *kernelListCacheTestSuite) TestTrackDirAfterLRUEviction() {
+	// 1-byte limit forces immediate eviction of every inserted entry.
+	t := &kernelListCacheTracker{
+		lru:    cachepolicy.NewLRU[string, *dirCacheItem](1, dirCacheItemSize),
+		ttl:    time.Hour,
+		stopCh: make(chan struct{}),
+	}
+	t.trackDir("a/")
+	t.trackDir("b/") // "a/" evicted at or before this point
+
+	result := t.trackDir("a/") // must be treated as a new path, not a TTL hit
+
+	s.assert.False(result)
+}
+
+// ---- sweepExpired -----------------------------------------------------------
+
+// TestSweepExpiredRemovesExpiredEntries verifies that entries past their TTL are
+// deleted and entries still within TTL are kept.
+func (s *kernelListCacheTestSuite) TestSweepExpiredRemovesExpiredEntries() {
+	t := newTestTracker(100 * time.Millisecond)
+	t.lru.Put("expired/", &dirCacheItem{cachedAt: time.Now().Add(-time.Hour)})
+	t.lru.Put("fresh/", &dirCacheItem{cachedAt: time.Now()})
+	t.lastOp.Store(time.Now().Add(-time.Hour).Unix()) // idle
+
+	t.sweepExpired()
+
+	s.assert.False(t.lru.Has("expired/"))
+	s.assert.True(t.lru.Has("fresh/"))
+	s.assert.Equal(1, t.lru.Len())
+}
+
+// TestSweepExpiredKeepsFreshEntries verifies that no entries are removed when all
+// are within TTL.
+func (s *kernelListCacheTestSuite) TestSweepExpiredKeepsFreshEntries() {
+	t := newTestTracker(time.Hour)
+	t.lru.Put("a/", &dirCacheItem{cachedAt: time.Now()})
+	t.lru.Put("b/", &dirCacheItem{cachedAt: time.Now()})
+	t.lastOp.Store(time.Now().Add(-2 * time.Hour).Unix()) // idle
+
+	t.sweepExpired()
+
+	s.assert.Equal(2, t.lru.Len())
+}
+
+// TestSweepExpiredSkipsWhenActive verifies the idle gate: sweep is skipped when
+// lastOp is within TTL/2, to avoid write-lock contention during active traffic.
+func (s *kernelListCacheTestSuite) TestSweepExpiredSkipsWhenActive() {
+	t := newTestTracker(time.Hour)
+	t.lru.Put("expired/", &dirCacheItem{cachedAt: time.Now().Add(-2 * time.Hour)})
+	t.lastOp.Store(time.Now().Unix()) // very recent activity
+
+	t.sweepExpired()
+
+	s.assert.Equal(1, t.lru.Len(), "sweep must be skipped when cache is active")
+}
+
+// TestSweepExpiredRunsWhenIdle verifies that the sweep runs and removes expired
+// entries when the cache has been idle longer than TTL/2.
+func (s *kernelListCacheTestSuite) TestSweepExpiredRunsWhenIdle() {
+	t := newTestTracker(time.Hour)
+	t.lru.Put("expired/", &dirCacheItem{cachedAt: time.Now().Add(-2 * time.Hour)})
+	t.lastOp.Store(time.Now().Add(-2 * time.Hour).Unix()) // idle for 2h >> TTL/2
+
+	t.sweepExpired()
+
+	s.assert.Equal(0, t.lru.Len())
+}
+
+// ---- start / stop -----------------------------------------------------------
+
+// TestStartStop verifies that start and stop complete without deadlock.
+func (s *kernelListCacheTestSuite) TestStartStop() {
+	t := newTestTracker(50 * time.Millisecond)
+	t.start()
+	t.stop()
+}
+
+// TestSweeperGoroutineEvictsEntries is an integration test that runs the sweeper
+// goroutine end-to-end and verifies it removes expired entries after a few TTL cycles.
+func (s *kernelListCacheTestSuite) TestSweeperGoroutineEvictsEntries() {
+	const ttl = 50 * time.Millisecond
+	t := newTestTracker(ttl)
+	t.lru.Put("dir/", &dirCacheItem{cachedAt: time.Now()})
+	// lastOp == 0 bypasses the idle gate so the sweeper always runs.
+
+	t.start()
+	defer t.stop()
+
+	time.Sleep(4 * ttl)
+
+	s.assert.Equal(0, t.lru.Len(), "sweeper goroutine must have removed the expired entry")
+}
+
+func TestKernelListCacheTestSuite(t *testing.T) {
+	suite.Run(t, new(kernelListCacheTestSuite))
+}

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -55,27 +55,29 @@ import (
 // Common structure for Component
 type Libfuse struct {
 	internal.BaseComponent
-	mountPath             string
-	dirPermission         uint
-	filePermission        uint
-	readOnly              bool
-	attributeExpiration   uint32
-	entryExpiration       uint32
-	negativeTimeout       uint32
-	allowOther            bool
-	allowRoot             bool
-	ownerUID              uint32
-	ownerGID              uint32
-	traceEnable           bool
-	extensionPath         string
-	disableWritebackCache bool
-	ignoreOpenFlags       bool
-	nonEmptyMount         bool
-	lsFlags               common.BitMap64
-	directIO              bool
-	umask                 uint32
-	disableKernelCache    bool
-	maxBackground         uint32 // libfuse max_background: max pending background requests
+	mountPath               string
+	dirPermission           uint
+	filePermission          uint
+	readOnly                bool
+	attributeExpiration     uint32
+	entryExpiration         uint32
+	negativeTimeout         uint32
+	allowOther              bool
+	allowRoot               bool
+	ownerUID                uint32
+	ownerGID                uint32
+	traceEnable             bool
+	extensionPath           string
+	disableWritebackCache   bool
+	ignoreOpenFlags         bool
+	nonEmptyMount           bool
+	lsFlags                 common.BitMap64
+	directIO                bool
+	umask                   uint32
+	disableKernelCache      bool
+	maxBackground           uint32 // libfuse max_background: max pending background requests
+	kernelListCacheTtlInSec uint32
+	kernelListCacheTracker  *kernelListCacheTracker
 }
 
 // To support pagination in readdir calls this structure holds a block of items for a given directory
@@ -106,9 +108,10 @@ type LibfuseOptions struct {
 	Gid                     uint32 `config:"gid" yaml:"gid,omitempty"`
 	// MaxBackground is exposed via config as "max-fuse-threads" for backward compatibility.
 	// Internally renamed to reflect it maps to libfuse max_background (pending I/O requests, not threads).
-	MaxBackground uint32 `config:"max-fuse-threads" yaml:"max-fuse-threads,omitempty"`
-	DirectIO      bool   `config:"direct-io" yaml:"direct-io,omitempty"`
-	Umask         uint32 `config:"umask" yaml:"umask,omitempty"`
+	MaxBackground           uint32 `config:"max-fuse-threads" yaml:"max-fuse-threads,omitempty"`
+	DirectIO                bool   `config:"direct-io" yaml:"direct-io,omitempty"`
+	Umask                   uint32 `config:"umask" yaml:"umask,omitempty"`
+	KernelListCacheTtlInSec uint32 `config:"kernel-list-cache-expiration-sec" yaml:"kernel-list-cache-expiration-sec,omitempty"`
 }
 
 const compName = "libfuse"
@@ -167,6 +170,11 @@ func (lf *Libfuse) Start(ctx context.Context) error {
 	// This marks the global fuse object so shall be the first statement
 	fuseFS = lf
 
+	if lf.kernelListCacheTtlInSec > 0 {
+		lf.kernelListCacheTracker = newKernelListCacheTracker(lf.kernelListCacheTtlInSec)
+		lf.kernelListCacheTracker.start()
+	}
+
 	// This starts the libfuse process and hence shall always be the last statement
 	err := lf.initFuse()
 	if err != nil {
@@ -180,6 +188,9 @@ func (lf *Libfuse) Start(ctx context.Context) error {
 // Stop : Stop the component functionality and kill all threads started
 func (lf *Libfuse) Stop() error {
 	log.Trace("Libfuse::Stop : Stopping component %s", lf.Name())
+	if lf.kernelListCacheTracker != nil {
+		lf.kernelListCacheTracker.stop()
+	}
 	_ = lf.destroyFuse()
 	libfuseStatsCollector.Destroy()
 	return nil
@@ -200,6 +211,7 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 	lf.ownerGID = opt.Gid
 	lf.ownerUID = opt.Uid
 	lf.umask = opt.Umask
+	lf.kernelListCacheTtlInSec = opt.KernelListCacheTtlInSec
 
 	if lf.disableKernelCache {
 		opt.DirectIO = true
@@ -243,6 +255,11 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		lf.attributeExpiration = 0
 		lf.entryExpiration = 0
 		log.Crit("Libfuse::Validate : DirectIO enabled, setting fuse timeouts to 0")
+	}
+
+	if lf.directIO && lf.kernelListCacheTtlInSec > 0 {
+		log.Crit("Libfuse::Validate : kernel-list-cache incompatible with direct-io, disabling")
+		lf.kernelListCacheTtlInSec = 0
 	}
 
 	if !config.IsSet(compName+".uid") && !config.IsSet(compName+".gid") && !config.IsSet("lfuse.uid") && !config.IsSet("lfuse.gid") {
@@ -353,8 +370,8 @@ func (lf *Libfuse) Configure(_ bool) error {
 		}
 	}
 
-	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max_background %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v, disableKernelCache %v",
-		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxBackground, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask, lf.disableKernelCache)
+	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max_background %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v, disableKernelCache %v, kernelListCacheExpirationSec %v",
+		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxBackground, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask, lf.disableKernelCache, lf.kernelListCacheTtlInSec)
 
 	return nil
 }
@@ -394,4 +411,7 @@ func init() {
 
 	ignoreOpenFlags := config.AddBoolFlag("ignore-open-flags", true, "Ignore unsupported open flags (APPEND, WRONLY) by blobfuse when writeback caching is enabled.")
 	config.BindPFlag(compName+".ignore-open-flags", ignoreOpenFlags)
+
+	kernelListCacheTtl := config.AddUint32Flag("kernel-list-cache-timeout", 0, "Enable kernel caching of directory listings and set TTL in seconds (fuse3 only). 0 = disabled.")
+	config.BindPFlag(compName+".kernel-list-cache-expiration-sec", kernelListCacheTtl)
 }

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -179,6 +179,11 @@ func (lf *Libfuse) Start(ctx context.Context) error {
 	err := lf.initFuse()
 	if err != nil {
 		log.Err("Libfuse::Start : Failed to init fuse [%s]", err.Error())
+		// Clean up tracker goroutine on init failure to prevent leak
+		if lf.kernelListCacheTracker != nil {
+			lf.kernelListCacheTracker.stop()
+			lf.kernelListCacheTracker = nil
+		}
 		return err
 	}
 
@@ -190,6 +195,7 @@ func (lf *Libfuse) Stop() error {
 	log.Trace("Libfuse::Stop : Stopping component %s", lf.Name())
 	if lf.kernelListCacheTracker != nil {
 		lf.kernelListCacheTracker.stop()
+		lf.kernelListCacheTracker = nil
 	}
 	_ = lf.destroyFuse()
 	libfuseStatsCollector.Destroy()

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -218,7 +218,7 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 	lf.ownerGID = opt.Gid
 	lf.ownerUID = opt.Uid
 	lf.umask = opt.Umask
-	if config.IsSet(compName+".kernel-list-cache-expiration-sec") || config.IsSet("lfuse.kernel-list-cache-expiration-sec") {
+	if config.IsSet(compName + ".kernel-list-cache-expiration-sec") {
 		lf.kernelListCacheTtlInSec = opt.KernelListCacheTtlInSec
 	} else {
 		lf.kernelListCacheTtlInSec = defaultKernelListCacheTtlInSec

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -118,6 +118,7 @@ const compName = "libfuse"
 const defaultEntryExpiration = 120
 const defaultAttrExpiration = 120
 const defaultNegativeEntryExpiration = 120
+const defaultKernelListCacheTtlInSec = 120
 
 // defaultMaxBackground is the libfuse max_background parameter default (max pending requests, not threads)
 // It controls how many async I/O requests the FUSE kernel module keeps outstanding to FUSE userspace.
@@ -217,7 +218,11 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 	lf.ownerGID = opt.Gid
 	lf.ownerUID = opt.Uid
 	lf.umask = opt.Umask
-	lf.kernelListCacheTtlInSec = opt.KernelListCacheTtlInSec
+	if config.IsSet(compName+".kernel-list-cache-expiration-sec") || config.IsSet("lfuse.kernel-list-cache-expiration-sec") {
+		lf.kernelListCacheTtlInSec = opt.KernelListCacheTtlInSec
+	} else {
+		lf.kernelListCacheTtlInSec = defaultKernelListCacheTtlInSec
+	}
 
 	if lf.disableKernelCache {
 		opt.DirectIO = true
@@ -260,12 +265,13 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		lf.negativeTimeout = 0
 		lf.attributeExpiration = 0
 		lf.entryExpiration = 0
-		log.Crit("Libfuse::Validate : DirectIO enabled, setting fuse timeouts to 0")
-	}
 
-	if lf.directIO && lf.kernelListCacheTtlInSec > 0 {
-		log.Crit("Libfuse::Validate : kernel-list-cache incompatible with direct-io, disabling")
-		lf.kernelListCacheTtlInSec = 0
+		if lf.kernelListCacheTtlInSec > 0 {
+			log.Crit("Libfuse::Validate : kernel-list-cache incompatible with direct-io, disabling")
+			lf.kernelListCacheTtlInSec = 0
+		}
+
+		log.Crit("Libfuse::Validate : DirectIO enabled, setting fuse timeouts to 0")
 	}
 
 	if !config.IsSet(compName+".uid") && !config.IsSet(compName+".gid") && !config.IsSet("lfuse.uid") && !config.IsSet("lfuse.gid") {

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -265,11 +265,7 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		lf.negativeTimeout = 0
 		lf.attributeExpiration = 0
 		lf.entryExpiration = 0
-
-		if lf.kernelListCacheTtlInSec > 0 {
-			log.Crit("Libfuse::Validate : kernel-list-cache incompatible with direct-io, disabling")
-			lf.kernelListCacheTtlInSec = 0
-		}
+		lf.kernelListCacheTtlInSec = 0
 
 		log.Crit("Libfuse::Validate : DirectIO enabled, setting fuse timeouts to 0")
 	}

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -280,6 +280,15 @@ func libfuse2_init(conn *C.fuse_conn_info_t) (res unsafe.Pointer) {
 
 	log.Info("Libfuse::libfuse2_init : Kernel FUSE version: %d.%d, Kernel Caps : 0x%x", conn.proto_major, conn.proto_minor, conn.capable)
 
+	if fuseFS.kernelListCacheTtlInSec > 0 {
+		log.Warn("Libfuse::libfuse2_init : kernel-list-cache not supported on fuse2, disabling")
+		fuseFS.kernelListCacheTtlInSec = 0
+		if fuseFS.kernelListCacheTracker != nil {
+			fuseFS.kernelListCacheTracker.stop()
+			fuseFS.kernelListCacheTracker = nil
+		}
+	}
+
 	if (conn.capable & C.FUSE_CAP_ASYNC_READ) != 0 {
 		log.Info("Libfuse::libfuse2_init : Enable Capability : FUSE_CAP_ASYNC_READ")
 		conn.want |= C.FUSE_CAP_ASYNC_READ

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -366,8 +366,15 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 //export libfuse_destroy
 func libfuse_destroy(data unsafe.Pointer) {
 	log.Trace("Libfuse::libfuse_destroy : destroy")
-	// Clear the fuse instance pointer so that any post-unmount call to
-	// fuse_invalidate_path (e.g. from the TTL sweeper) safely returns -1
+	// Stop the TTL sweeper goroutine before clearing g_fuse to eliminate the race
+	// where the sweeper reads a non-nil g_fuse, then calls fuse_invalidate_path
+	// after the FUSE instance has been freed.
+	if fuseFS != nil && fuseFS.kernelListCacheTracker != nil {
+		fuseFS.kernelListCacheTracker.stop()
+		fuseFS.kernelListCacheTracker = nil
+	}
+	// Clear the fuse instance pointer so that any post-destroy call to
+	// fuse_invalidate_path (e.g. from a stale pointer) safely returns -1
 	// instead of dereferencing a freed libfuse struct.
 	C.set_fuse_ptr(nil)
 }

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -265,8 +265,27 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 	}
 
 	C.populate_uid_gid()
+	C.set_root_mtime()
 
 	log.Info("Libfuse::libfuse_init : Kernel FUSE version: %d.%d, Kernel Caps : 0x%x", conn.proto_major, conn.proto_minor, conn.capable)
+
+	// Capture fuse instance pointer for later use in kernel list cache invalidation
+	C.set_fuse_ptr(C.fuse_get_context().fuse)
+
+	if fuseFS.kernelListCacheTtlInSec > 0 {
+		if C.kernel_supports_dir_cache(conn) != 0 {
+			log.Info("Libfuse::libfuse_init : Kernel supports FOPEN_CACHE_DIR (fuse proto %d.%d), kernel-list-cache enabled with timeout %d sec",
+				conn.proto_major, conn.proto_minor, fuseFS.kernelListCacheTtlInSec)
+		} else {
+			log.Warn("Libfuse::libfuse_init : Kernel fuse proto %d.%d does not support FOPEN_CACHE_DIR (requires 7.28 / Linux 5.1+), disabling kernel-list-cache",
+				conn.proto_major, conn.proto_minor)
+			fuseFS.kernelListCacheTtlInSec = 0
+			if fuseFS.kernelListCacheTracker != nil {
+				fuseFS.kernelListCacheTracker.stop()
+				fuseFS.kernelListCacheTracker = nil
+			}
+		}
+	}
 
 	// Populate connection information
 	// conn.want |= C.FUSE_CAP_NO_OPENDIR_SUPPORT
@@ -347,6 +366,10 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 //export libfuse_destroy
 func libfuse_destroy(data unsafe.Pointer) {
 	log.Trace("Libfuse::libfuse_destroy : destroy")
+	// Clear the fuse instance pointer so that any post-unmount call to
+	// fuse_invalidate_path (e.g. from the TTL sweeper) safely returns -1
+	// instead of dereferencing a freed libfuse struct.
+	C.set_fuse_ptr(nil)
 }
 
 func (lf *Libfuse) fillStat(attr *internal.ObjAttr, stbuf *C.stat_t) {
@@ -487,6 +510,26 @@ func libfuse_opendir(path *C.char, fi *C.fuse_file_info_t) C.int {
 
 	handlemap.Add(handle)
 	fi.fh = C.uint64_t(uintptr(unsafe.Pointer(handle)))
+
+	if fuseFS.kernelListCacheTtlInSec > 0 {
+		// FUSE_CAP_AUTO_INVAL_DATA (enabled by the kernel by default) causes the kernel
+		// to compare the directory's mtime from GETATTR against the mtime it saw when it
+		// cached the listing.  If the mtime has changed, the kernel discards the cached
+		// readdir result and issues a fresh READDIRPLUS — bypassing cache_readdir entirely.
+		// For our TTL-based caching to work, GETATTR must therefore always return a stable
+		// (unchanging) mtime for every directory.  For root ("/") we achieve this by
+		// recording the mount start time in g_root_mtime (libfuse_wrapper.h) and returning
+		// it on every GETATTR call instead of the current wall-clock time.  The same
+		// invariant must hold for all other directories: their mtime should not change
+		// unless the directory contents have actually changed.
+		if fuseFS.kernelListCacheTracker.trackDir(name) {
+			C.enable_dir_cache(fi)
+			log.Debug("Libfuse::libfuse_opendir : kernel list cache hit for %s", name)
+		} else {
+			C.invalidate_and_enable_dir_cache(fi)
+			log.Debug("Libfuse::libfuse_opendir : kernel list cache expired/new for %s, fetching fresh", name)
+		}
+	}
 
 	return 0
 }
@@ -1214,4 +1257,15 @@ func blobfuse_cache_update(path *C.char) C.int {
 	name = common.NormalizeObjectName(name)
 	go fuseFS.NextComponent().FileUsed(name) //nolint
 	return 0
+}
+
+// InvalidateKernelListCache invalidates the kernel's cached directory listing for the given path.
+func (lf *Libfuse) InvalidateKernelListCache(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	ret := C.invalidate_dir_cache(cPath)
+	if ret != 0 {
+		return fmt.Errorf("failed to invalidate kernel list cache for %s [%d]", path, ret)
+	}
+	return nil
 }

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -355,7 +355,7 @@ func (suite *libfuseTestSuite) TestUtimens() {
 
 func (suite *libfuseTestSuite) TestKernelListCacheDefault() {
 	defer suite.cleanupTest()
-	suite.assert.Equal(uint32(0), suite.libfuse.kernelListCacheTtlInSec)
+	suite.assert.Equal(uint32(defaultKernelListCacheTtlInSec), suite.libfuse.kernelListCacheTtlInSec)
 }
 
 func (suite *libfuseTestSuite) TestKernelListCacheConfig() {

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -353,6 +353,27 @@ func (suite *libfuseTestSuite) TestUtimens() {
 	testUtimens(suite)
 }
 
+func (suite *libfuseTestSuite) TestKernelListCacheDefault() {
+	defer suite.cleanupTest()
+	suite.assert.Equal(uint32(0), suite.libfuse.kernelListCacheTtlInSec)
+}
+
+func (suite *libfuseTestSuite) TestKernelListCacheConfig() {
+	defer suite.cleanupTest()
+	suite.cleanupTest()
+	config := "libfuse:\n  kernel-list-cache-expiration-sec: 60\n"
+	suite.setupTestHelper(config)
+	suite.assert.Equal(uint32(60), suite.libfuse.kernelListCacheTtlInSec)
+}
+
+func (suite *libfuseTestSuite) TestKernelListCacheDisabledWithDirectIO() {
+	defer suite.cleanupTest()
+	suite.cleanupTest()
+	config := "libfuse:\n  direct-io: true\n  kernel-list-cache-expiration-sec: 30\n"
+	suite.setupTestHelper(config)
+	suite.assert.Equal(uint32(0), suite.libfuse.kernelListCacheTtlInSec)
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestLibfuseTestSuite(t *testing.T) {

--- a/component/libfuse/libfuse_wrapper.h
+++ b/component/libfuse/libfuse_wrapper.h
@@ -150,6 +150,13 @@ static void populate_uid_gid()
     }
 }
 
+// Stable mtime for root (/), set once at mount time so AUTO_INVAL_DATA does not
+// constantly invalidate the kernel's cached directory listing.
+static time_t g_root_mtime = 0;
+static void set_root_mtime() {
+    g_root_mtime = time(NULL);
+}
+
 // Properties for root (/) are static so just hardcoding them here
 static int get_root_properties(stat_t *stbuf)
 {
@@ -160,7 +167,9 @@ static int get_root_properties(stat_t *stbuf)
     stbuf->st_gid = fuse_opts.gid;
     stbuf->st_nlink = 2;
     stbuf->st_size = 4096;
-    stbuf->st_mtime = time(NULL);
+    // Use the stable mount-time mtime if available so AUTO_INVAL_DATA does not
+    // treat every GETATTR as a directory change and discard the cached listing.
+    stbuf->st_mtime = (g_root_mtime != 0) ? g_root_mtime : time(NULL);
     stbuf->st_atime = stbuf->st_mtime;
     stbuf->st_ctime = stbuf->st_mtime;
     return 0;
@@ -173,6 +182,72 @@ static int fill_dir_entry(fuse_fill_dir_t filler, void *buf, char *name, stat_t 
         ,(fuse_fill_dir_flags_t) fill_dir_plus
     #endif
     );
+}
+
+// Capture the fuse instance pointer from init callback for later use in invalidation
+static struct fuse *g_fuse = NULL;
+static void set_fuse_ptr(struct fuse *f) {
+    g_fuse = f;
+}
+
+/*
+ * Returns 1 if the kernel supports FOPEN_CACHE_DIR (the cache_readdir bit in
+ * fuse_file_info).  There is no FUSE_CAP_* flag for this feature, so we gate
+ * on the negotiated FUSE protocol minor version instead.
+ *
+ * FOPEN_CACHE_DIR was introduced in Linux 5.1 together with FUSE protocol
+ * version 7.28 (FUSE_KERNEL_MINOR_VERSION 28 in include/uapi/linux/fuse.h).
+ * Kernels older than 5.1 negotiate a proto_minor < 28 and silently ignore the
+ * cache_readdir bit, so we disable the feature rather than leaving the user
+ * wondering why their listing cache has no effect.
+ */
+static int kernel_supports_dir_cache(fuse_conn_info_t *conn) {
+#ifdef FUSE_CAP_CACHE_READDIR
+    /* Use the capability bit if a future libfuse version defines it. */
+    return (conn->capable & FUSE_CAP_CACHE_READDIR) != 0;
+#else
+    return conn->proto_minor >= 28;
+#endif
+}
+
+// Set cache_readdir bit in opendir response (fuse3 only)
+static void enable_dir_cache(fuse_file_info_t *fi) {
+#ifndef __FUSE2__
+    fi->cache_readdir = 1;
+    fi->keep_cache = 1;
+#endif
+}
+
+/*
+ * Like enable_dir_cache but sets keep_cache=0, telling the kernel to discard
+ * any previously cached directory listing and fetch fresh data via READDIRPLUS.
+ * Used when the blobfuse TTL for a directory has expired.
+ */
+static void invalidate_and_enable_dir_cache(fuse_file_info_t *fi) {
+#ifndef __FUSE2__
+    fi->cache_readdir = 1;
+    fi->keep_cache = 0;
+#endif
+}
+
+/*
+ * Invalidate the kernel's cached directory listing for the given path.
+ *
+ * -ENOENT is treated as success: it means the kernel had no entry cached for
+ * this path (e.g. it was never seen or was already evicted), so there is
+ * nothing to invalidate.  This matches the guidance in the fuse_invalidate_path
+ * documentation and the pattern used in libfuse's own example code.
+ */
+static int invalidate_dir_cache(const char *path) {
+#ifndef __FUSE2__
+    if (g_fuse == NULL) return -1;
+    int ret = fuse_invalidate_path(g_fuse, path);
+    if (ret == -ENOENT)
+        return 0;
+    return ret;
+#else
+    return -1;
+#endif
 }
 
 #endif //__LIBFUSE_H__

--- a/sampleBlockCacheConfig.yaml
+++ b/sampleBlockCacheConfig.yaml
@@ -14,6 +14,7 @@ libfuse:
   attribute-expiration-sec: 120
   entry-expiration-sec: 120
   negative-entry-expiration-sec: 240
+  kernel-list-cache-expiration-sec: 120
 
 block_cache:
   block-size-mb: 32

--- a/sampleFileCacheConfig.yaml
+++ b/sampleFileCacheConfig.yaml
@@ -14,6 +14,7 @@ libfuse:
   attribute-expiration-sec: 120
   entry-expiration-sec: 120
   negative-entry-expiration-sec: 240
+  kernel-list-cache-expiration-sec: 120
 
 file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>

--- a/sampleFileCacheWithSASConfig.yaml
+++ b/sampleFileCacheWithSASConfig.yaml
@@ -14,6 +14,7 @@ libfuse:
   attribute-expiration-sec: 120
   entry-expiration-sec: 120
   negative-entry-expiration-sec: 240
+  kernel-list-cache-expiration-sec: 120
 
 file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>

--- a/setup/advancedConfig.yaml
+++ b/setup/advancedConfig.yaml
@@ -70,6 +70,7 @@ libfuse:
   fuse-trace: true|false <enable libfuse api trace logs for debugging>
   extension: <physical path to extension library>
   direct-io: true|false <enable to bypass the kernel cache. It also disables blobfuse2 data and metadata caching. Default - false>
+  kernel-list-cache-expiration-sec: <enable kernel caching of directory listings and set TTL in seconds (fuse3 only). 0 = disabled. Default - 120 sec>
 
 # Entry Cache configuration
 entry_cache:


### PR DESCRIPTION

## Summary

- **Kernel directory-listing cache** (`fuse3` only): blobfuse2 can now instruct the Linux kernel to cache `readdir` results in its page cache. Repeat `ls` calls within the configured TTL window are served entirely from kernel memory — no userspace round-trip, no Azure Storage API call.

## Configuration

```yaml
libfuse:
  kernel-list-cache-expiration-sec: 120       # TTL for cached list entries (default: 120s )
```

CLI:
```
blobfuse2 mount ... --kernel-list-cache-timeout=120
```
Default is `0` (disabled), preserving existing behaviour.

## How the kernel list cache works

On every `opendir`, `libfuse_opendir` consults a `kernelListCacheTracker` (an LRU keyed by directory path) to check whether the cached listing is within TTL:

- **Within TTL** → sets `cache_readdir=1, keep_cache=1` — kernel serves the listing from its page cache, `READDIRPLUS` is never issued.
- **Expired / first access** → sets `cache_readdir=1, keep_cache=0` — kernel discards any stale listing and issues a fresh `READDIRPLUS` to blobfuse2.

A background sweeper goroutine runs every TTL interval, evicts expired entries from the LRU, and calls `fuse_invalidate_path` per entry to proactively free kernel page cache memory. Correctness does not depend on the sweeper — the `keep_cache=0` path in `opendir` is always sufficient.

**Stable mtime fix**: `FUSE_CAP_AUTO_INVAL_DATA` (enabled by the kernel by default) compares directory mtime on every `GETATTR`; if changed, it discards the cached listing regardless of `cache_readdir`. To prevent this from rendering the cache ineffective, root `"/"` now returns a fixed mtime (`g_root_mtime`) recorded once at mount time instead of the current wall-clock time.

**Dangling pointer fix**: `libfuse_destroy` now calls `C.set_fuse_ptr(nil)` to clear `g_fuse` before `fuse_main` frees the FUSE instance, preventing a SIGSEGV if the sweeper goroutine fires during unmount.

## Test plan

- [ ] Unit tests: `kernel_list_cache_test.go` — 13 tests covering `trackDir` (new path, TTL hit, TTL miss, no-reset-on-hit), LRU eviction safety, `sweepExpired` idle gate, and start/stop lifecycle
- [ ] Integration tests: `kernel_list_cache_integration_test.go` — 7 end-to-end tests with a live FUSE mount (cold cache, hit within TTL, miss after TTL, TTL=0 disables cache, root+subdir independent TTLs, subdir expiry, manual invalidation via `fuse_invalidate_path`)
- [ ] Manual: mount with `kernel-list-cache-timeout-sec: 10`, verify `ls` traffic against backend via debug logs and `StreamDirCount`
- [ ] Confirmed no regression in existing `libfuse` unit test suite (`TestConfig`, `TestConfigDefaultPermission`, etc.)