### PR TITLE
Return ENAMETOOLONG when renaming to a too-deep ADLS path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))
 - Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))
-- Return `ENAMETOOLONG` instead of `EIO` when renaming a file or directory to an ADLS path that exceeds the depth limit of 63 segments ([Issue #2241](https://github.com/Azure/azure-storage-fuse/issues/2241))
+- Return `ENAMETOOLONG` instead of `EIO` when renaming a directory to an ADLS path that exceeds the depth limit of 63 segments ([PR #2251](https://github.com/Azure/azure-storage-fuse/pull/2251))
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))
 - Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))
+- Return `ENAMETOOLONG` instead of `EIO` when renaming a file or directory to an ADLS path that exceeds the depth limit of 63 segments ([Issue #2241](https://github.com/Azure/azure-storage-fuse/issues/2241))
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -356,10 +356,14 @@ func (dl *Datalake) RenameFile(source string, target string, srcAttr *internal.O
 	})
 	if err != nil {
 		serr := storeDatalakeErrToErr(err)
-		if serr == ErrFileNotFound {
+		switch serr {
+		case ErrFileNotFound:
 			log.Err("Datalake::RenameFile : %s does not exist", source)
 			return syscall.ENOENT
-		} else {
+		case ErrPathTooDeep:
+			log.Err("Datalake::RenameFile : Path is too deep for %s -> %s [%s]", source, target, err.Error())
+			return syscall.ENAMETOOLONG
+		default:
 			log.Err("Datalake::RenameFile : Failed to rename file %s to %s [%s]", source, target, err.Error())
 			return err
 		}
@@ -378,10 +382,14 @@ func (dl *Datalake) RenameDirectory(source string, target string) error {
 	})
 	if err != nil {
 		serr := storeDatalakeErrToErr(err)
-		if serr == ErrFileNotFound {
+		switch serr {
+		case ErrFileNotFound:
 			log.Err("Datalake::RenameDirectory : %s does not exist", source)
 			return syscall.ENOENT
-		} else {
+		case ErrPathTooDeep:
+			log.Err("Datalake::RenameDirectory : Path is too deep for %s -> %s [%s]", source, target, err.Error())
+			return syscall.ENAMETOOLONG
+		default:
 			log.Err("Datalake::RenameDirectory : Failed to rename directory %s to %s [%s]", source, target, err.Error())
 			return err
 		}

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -360,9 +360,6 @@ func (dl *Datalake) RenameFile(source string, target string, srcAttr *internal.O
 		case ErrFileNotFound:
 			log.Err("Datalake::RenameFile : %s does not exist", source)
 			return syscall.ENOENT
-		case ErrPathTooDeep:
-			log.Err("Datalake::RenameFile : Path is too deep for %s -> %s [%s]", source, target, err.Error())
-			return syscall.ENAMETOOLONG
 		default:
 			log.Err("Datalake::RenameFile : Failed to rename file %s to %s [%s]", source, target, err.Error())
 			return err

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -356,11 +356,10 @@ func (dl *Datalake) RenameFile(source string, target string, srcAttr *internal.O
 	})
 	if err != nil {
 		serr := storeDatalakeErrToErr(err)
-		switch serr {
-		case ErrFileNotFound:
+		if serr == ErrFileNotFound {
 			log.Err("Datalake::RenameFile : %s does not exist", source)
 			return syscall.ENOENT
-		default:
+		} else {
 			log.Err("Datalake::RenameFile : Failed to rename file %s to %s [%s]", source, target, err.Error())
 			return err
 		}

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -964,6 +964,9 @@ func libfuse2_rename(src *C.char, dst *C.char) C.int {
 		err := fuseFS.NextComponent().RenameDir(internal.RenameDirOptions{Src: srcPath, Dst: dstPath})
 		if err != nil {
 			log.Err("Libfuse::libfuse2_rename : error renaming directory %s -> %s [%s]", srcPath, dstPath, err.Error())
+			if errors.Is(err, syscall.ENAMETOOLONG) {
+				return -C.ENAMETOOLONG
+			}
 			return -C.EIO
 		}
 
@@ -979,6 +982,9 @@ func libfuse2_rename(src *C.char, dst *C.char) C.int {
 		})
 		if err != nil {
 			log.Err("Libfuse::libfuse2_rename : error renaming file %s -> %s [%s]", srcPath, dstPath, err.Error())
+			if errors.Is(err, syscall.ENAMETOOLONG) {
+				return -C.ENAMETOOLONG
+			}
 			return -C.EIO
 		}
 

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -982,9 +982,6 @@ func libfuse2_rename(src *C.char, dst *C.char) C.int {
 		})
 		if err != nil {
 			log.Err("Libfuse::libfuse2_rename : error renaming file %s -> %s [%s]", srcPath, dstPath, err.Error())
-			if errors.Is(err, syscall.ENAMETOOLONG) {
-				return -C.ENAMETOOLONG
-			}
 			return -C.EIO
 		}
 

--- a/component/libfuse/libfuse2_handler_test_wrapper.go
+++ b/component/libfuse/libfuse2_handler_test_wrapper.go
@@ -460,25 +460,6 @@ func testUnlinkError(suite *libfuseTestSuite) {
 
 // Rename
 
-func testRenameFileEnametoolong(suite *libfuseTestSuite) {
-	defer suite.cleanupTest()
-	src := "src"
-	dst := "dst"
-	srcPath := C.CString("/" + src)
-	dstPath := C.CString("/" + dst)
-	defer C.free(unsafe.Pointer(srcPath))
-	defer C.free(unsafe.Pointer(dstPath))
-
-	srcAttr := &internal.ObjAttr{Name: src}
-	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: src}).Return(srcAttr, nil)
-	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: dst}).Return(nil, syscall.ENOENT)
-	options := internal.RenameFileOptions{Src: src, Dst: dst, SrcAttr: srcAttr}
-	suite.mock.EXPECT().RenameFile(options).Return(syscall.ENAMETOOLONG)
-
-	err := libfuse2_rename(srcPath, dstPath)
-	suite.assert.Equal(C.int(-C.ENAMETOOLONG), err)
-}
-
 func testRenameDirEnametoolong(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	src := "src"

--- a/component/libfuse/libfuse2_handler_test_wrapper.go
+++ b/component/libfuse/libfuse2_handler_test_wrapper.go
@@ -460,6 +460,45 @@ func testUnlinkError(suite *libfuseTestSuite) {
 
 // Rename
 
+func testRenameFileEnametoolong(suite *libfuseTestSuite) {
+	defer suite.cleanupTest()
+	src := "src"
+	dst := "dst"
+	srcPath := C.CString("/" + src)
+	dstPath := C.CString("/" + dst)
+	defer C.free(unsafe.Pointer(srcPath))
+	defer C.free(unsafe.Pointer(dstPath))
+
+	srcAttr := &internal.ObjAttr{Name: src}
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: src}).Return(srcAttr, nil)
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: dst}).Return(nil, syscall.ENOENT)
+	options := internal.RenameFileOptions{Src: src, Dst: dst, SrcAttr: srcAttr}
+	suite.mock.EXPECT().RenameFile(options).Return(syscall.ENAMETOOLONG)
+
+	err := libfuse2_rename(srcPath, dstPath)
+	suite.assert.Equal(C.int(-C.ENAMETOOLONG), err)
+}
+
+func testRenameDirEnametoolong(suite *libfuseTestSuite) {
+	defer suite.cleanupTest()
+	src := "src"
+	dst := "dst"
+	srcPath := C.CString("/" + src)
+	dstPath := C.CString("/" + dst)
+	defer C.free(unsafe.Pointer(srcPath))
+	defer C.free(unsafe.Pointer(dstPath))
+
+	srcAttr := &internal.ObjAttr{Name: src}
+	srcAttr.Flags.Set(internal.PropFlagIsDir)
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: src}).Return(srcAttr, nil)
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: dst}).Return(nil, syscall.ENOENT)
+	options := internal.RenameDirOptions{Src: src, Dst: dst}
+	suite.mock.EXPECT().RenameDir(options).Return(syscall.ENAMETOOLONG)
+
+	err := libfuse2_rename(srcPath, dstPath)
+	suite.assert.Equal(C.int(-C.ENAMETOOLONG), err)
+}
+
 func testSymlink(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	name := "path"

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -1041,6 +1041,9 @@ func libfuse_rename(src *C.char, dst *C.char, flags C.uint) C.int {
 		})
 		if err != nil {
 			log.Err("Libfuse::libfuse_rename : error renaming directory %s -> %s [%s]", srcPath, dstPath, err.Error())
+			if errors.Is(err, syscall.ENAMETOOLONG) {
+				return -C.ENAMETOOLONG
+			}
 			return -C.EIO
 		}
 
@@ -1056,6 +1059,9 @@ func libfuse_rename(src *C.char, dst *C.char, flags C.uint) C.int {
 		})
 		if err != nil {
 			log.Err("Libfuse::libfuse_rename : error renaming file %s -> %s [%s]", srcPath, dstPath, err.Error())
+			if errors.Is(err, syscall.ENAMETOOLONG) {
+				return -C.ENAMETOOLONG
+			}
 			return -C.EIO
 		}
 

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -1059,9 +1059,6 @@ func libfuse_rename(src *C.char, dst *C.char, flags C.uint) C.int {
 		})
 		if err != nil {
 			log.Err("Libfuse::libfuse_rename : error renaming file %s -> %s [%s]", srcPath, dstPath, err.Error())
-			if errors.Is(err, syscall.ENAMETOOLONG) {
-				return -C.ENAMETOOLONG
-			}
 			return -C.EIO
 		}
 

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -285,10 +285,6 @@ func (suite *libfuseTestSuite) TestUnlinkError() {
 
 // rename
 
-func (suite *libfuseTestSuite) TestRenameFileEnametoolong() {
-	testRenameFileEnametoolong(suite)
-}
-
 func (suite *libfuseTestSuite) TestRenameDirEnametoolong() {
 	testRenameDirEnametoolong(suite)
 }

--- a/component/libfuse/libfuse_handler_test.go
+++ b/component/libfuse/libfuse_handler_test.go
@@ -285,6 +285,14 @@ func (suite *libfuseTestSuite) TestUnlinkError() {
 
 // rename
 
+func (suite *libfuseTestSuite) TestRenameFileEnametoolong() {
+	testRenameFileEnametoolong(suite)
+}
+
+func (suite *libfuseTestSuite) TestRenameDirEnametoolong() {
+	testRenameDirEnametoolong(suite)
+}
+
 func (suite *libfuseTestSuite) TestSymlink() {
 	testSymlink(suite)
 }

--- a/component/libfuse/libfuse_handler_test_wrapper.go
+++ b/component/libfuse/libfuse_handler_test_wrapper.go
@@ -468,25 +468,6 @@ func testUnlinkError(suite *libfuseTestSuite) {
 
 // Rename
 
-func testRenameFileEnametoolong(suite *libfuseTestSuite) {
-	defer suite.cleanupTest()
-	src := "src"
-	dst := "dst"
-	srcPath := C.CString("/" + src)
-	dstPath := C.CString("/" + dst)
-	defer C.free(unsafe.Pointer(srcPath))
-	defer C.free(unsafe.Pointer(dstPath))
-
-	srcAttr := &internal.ObjAttr{Name: src}
-	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: src}).Return(srcAttr, nil)
-	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: dst}).Return(nil, syscall.ENOENT)
-	options := internal.RenameFileOptions{Src: src, Dst: dst, SrcAttr: srcAttr}
-	suite.mock.EXPECT().RenameFile(options).Return(syscall.ENAMETOOLONG)
-
-	err := libfuse_rename(srcPath, dstPath, 0)
-	suite.assert.Equal(C.int(-C.ENAMETOOLONG), err)
-}
-
 func testRenameDirEnametoolong(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	src := "src"

--- a/component/libfuse/libfuse_handler_test_wrapper.go
+++ b/component/libfuse/libfuse_handler_test_wrapper.go
@@ -468,6 +468,45 @@ func testUnlinkError(suite *libfuseTestSuite) {
 
 // Rename
 
+func testRenameFileEnametoolong(suite *libfuseTestSuite) {
+	defer suite.cleanupTest()
+	src := "src"
+	dst := "dst"
+	srcPath := C.CString("/" + src)
+	dstPath := C.CString("/" + dst)
+	defer C.free(unsafe.Pointer(srcPath))
+	defer C.free(unsafe.Pointer(dstPath))
+
+	srcAttr := &internal.ObjAttr{Name: src}
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: src}).Return(srcAttr, nil)
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: dst}).Return(nil, syscall.ENOENT)
+	options := internal.RenameFileOptions{Src: src, Dst: dst, SrcAttr: srcAttr}
+	suite.mock.EXPECT().RenameFile(options).Return(syscall.ENAMETOOLONG)
+
+	err := libfuse_rename(srcPath, dstPath, 0)
+	suite.assert.Equal(C.int(-C.ENAMETOOLONG), err)
+}
+
+func testRenameDirEnametoolong(suite *libfuseTestSuite) {
+	defer suite.cleanupTest()
+	src := "src"
+	dst := "dst"
+	srcPath := C.CString("/" + src)
+	dstPath := C.CString("/" + dst)
+	defer C.free(unsafe.Pointer(srcPath))
+	defer C.free(unsafe.Pointer(dstPath))
+
+	srcAttr := &internal.ObjAttr{Name: src}
+	srcAttr.Flags.Set(internal.PropFlagIsDir)
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: src}).Return(srcAttr, nil)
+	suite.mock.EXPECT().GetAttr(internal.GetAttrOptions{Name: dst}).Return(nil, syscall.ENOENT)
+	options := internal.RenameDirOptions{Src: src, Dst: dst}
+	suite.mock.EXPECT().RenameDir(options).Return(syscall.ENAMETOOLONG)
+
+	err := libfuse_rename(srcPath, dstPath, 0)
+	suite.assert.Equal(C.int(-C.ENAMETOOLONG), err)
+}
+
 func testSymlink(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	name := "path"

--- a/test/e2e_tests/dir_test.go
+++ b/test/e2e_tests/dir_test.go
@@ -280,6 +280,35 @@ func (suite *dirTestSuite) TestDirCreateDeepPath() {
 	suite.dirTestCleanup([]string{topDir})
 }
 
+// # Rename a directory to a path exceeding ADLS depth limit
+func (suite *dirTestSuite) TestDirRenameDeepPath() {
+	if !suite.adlsTest {
+		fmt.Println("Skipping TestDirRenameDeepPath: not an ADLS account")
+		return
+	}
+
+	srcDir := suite.testPath + "/renamesrc"
+	err := os.Mkdir(srcDir, 0777)
+	suite.NoError(err)
+
+	// ADLS enforces a maximum path depth of 63 segments from the container root.
+	// Renaming into a 65-level destination guarantees the limit is exceeded; the
+	// service validates the destination path depth and the rename must surface
+	// ENAMETOOLONG rather than a generic I/O error.
+	const depth = 65
+	topDir := suite.testPath + "/renamedeep"
+	deepPath := topDir
+	for i := range depth {
+		deepPath = filepath.Join(deepPath, fmt.Sprintf("l%d", i))
+	}
+
+	err = os.Rename(srcDir, deepPath)
+	suite.Error(err)
+	suite.ErrorIs(err, syscall.ENAMETOOLONG)
+
+	suite.dirTestCleanup([]string{srcDir, topDir})
+}
+
 // # Get stats of a directory
 func (suite *dirTestSuite) TestDirGetStats() {
 	dirName := suite.testPath + "/test3"

--- a/test/e2e_tests/dir_test.go
+++ b/test/e2e_tests/dir_test.go
@@ -287,22 +287,31 @@ func (suite *dirTestSuite) TestDirRenameDeepPath() {
 		return
 	}
 
+	// ADLS enforces a maximum path depth of 63 segments from the container root.
+	// Create directories one level at a time until the next level is rejected, so
+	// deepest ends up at the maximum allowed depth.
+	topDir := suite.testPath + "/renamedeep"
+	deepest := topDir
+	err := os.Mkdir(deepest, 0777)
+	suite.NoError(err)
+	for i := 0; i < 70; i++ {
+		next := filepath.Join(deepest, "l")
+		err = os.Mkdir(next, 0777)
+		if err != nil {
+			break
+		}
+		deepest = next
+	}
+	suite.ErrorIs(err, syscall.ENAMETOOLONG)
+
+	// A source directory at a shallow, valid depth.
 	srcDir := suite.testPath + "/renamesrc"
-	err := os.Mkdir(srcDir, 0777)
+	err = os.Mkdir(srcDir, 0777)
 	suite.NoError(err)
 
-	// ADLS enforces a maximum path depth of 63 segments from the container root.
-	// Renaming into a 65-level destination guarantees the limit is exceeded; the
-	// service validates the destination path depth and the rename must surface
-	// ENAMETOOLONG rather than a generic I/O error.
-	const depth = 65
-	topDir := suite.testPath + "/renamedeep"
-	deepPath := topDir
-	for i := range depth {
-		deepPath = filepath.Join(deepPath, fmt.Sprintf("l%d", i))
-	}
-
-	err = os.Rename(srcDir, deepPath)
+	// The destination parent exists and is already at the maximum allowed depth,
+	// so renaming into a child of it fails only because the path is too deep.
+	err = os.Rename(srcDir, filepath.Join(deepest, "child"))
 	suite.Error(err)
 	suite.ErrorIs(err, syscall.ENAMETOOLONG)
 


### PR DESCRIPTION
## What

ADLS rejects paths with more than 63 segments. `CreateDirectory` already returns `ENAMETOOLONG` for this case (PR #2221), but `RenameDirectory` still returned a generic `EIO`. This extends the same handling to directory rename.

## Changes

- Map the existing `ErrPathTooDeep` error to `ENAMETOOLONG` in `Datalake.RenameDirectory`.
- Surface `ENAMETOOLONG` through the fuse2 and fuse3 directory-rename handlers instead of returning `EIO`.
- Add libfuse handler unit tests for the new mapping (run in CI).
- Add an end-to-end test that renames a directory to a path exceeding the 63-segment limit and expects `ENAMETOOLONG` (skipped on non-ADLS accounts).

## Notes

`RenameFile` is left unchanged. Renaming a file does not add directory depth, so the ADLS depth limit does not apply and `ErrPathTooDeep` cannot be returned for file renames.

`CreateFile` and `CreateLink` are also left unchanged. They go through the Block Blob API, which does not report the depth limit, so the error cannot occur there.

The end-to-end test needs a live HNS account to confirm the surfaced error code.

Fixes #2241