### PR TITLE
Clarify max_background parameter naming and enhance FUSE initialization logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.
+- Renamed `max-fuse-threads` configuration parameter to `max-background` to accurately reflect libfuse's `max_background` API, which controls pending background requests rather than thread count.
 
 ## 2.5.3 (2026-03-25)
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.
-- Renamed `max-fuse-threads` configuration parameter to `max-background` to accurately reflect libfuse's `max_background` API, which controls pending background requests rather than thread count.
-
+- Deprecated `max-fuse-threads` configuration parameter in favor of `max-background` to accurately reflect libfuse's `max_background` API (max pending background requests rather than thread count).
 ## 2.5.3 (2026-03-25)
 **Features**
 - Add rate limit functionality for ingress bandwidth (bytes downloaded per second) and operations per second ([PR #2093](https://github.com/Azure/azure-storage-fuse/pull/2093))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.
-- Deprecated `max-fuse-threads` configuration parameter in favor of `max-background` to accurately reflect libfuse's `max_background` API (max pending background requests rather than thread count).
+
 ## 2.5.3 (2026-03-25)
 **Features**
 - Add rate limit functionality for ingress bandwidth (bytes downloaded per second) and operations per second ([PR #2093](https://github.com/Azure/azure-storage-fuse/pull/2093))

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -104,9 +104,11 @@ type LibfuseOptions struct {
 	nonEmptyMount           bool   `config:"nonempty" yaml:"nonempty,omitempty"`
 	Uid                     uint32 `config:"uid" yaml:"uid,omitempty"`
 	Gid                     uint32 `config:"gid" yaml:"gid,omitempty"`
-	MaxBackground           uint32 `config:"max-background" yaml:"max-background,omitempty"`
-	DirectIO                bool   `config:"direct-io" yaml:"direct-io,omitempty"`
-	Umask                   uint32 `config:"umask" yaml:"umask,omitempty"`
+	// MaxBackground is exposed via config as "max-fuse-threads" for backward compatibility.
+	// Internally renamed to reflect it maps to libfuse max_background (pending I/O requests, not threads).
+	MaxBackground uint32 `config:"max-fuse-threads" yaml:"max-fuse-threads,omitempty"`
+	DirectIO      bool   `config:"direct-io" yaml:"direct-io,omitempty"`
+	Umask         uint32 `config:"umask" yaml:"umask,omitempty"`
 }
 
 const compName = "libfuse"
@@ -252,7 +254,7 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		}
 	}
 
-	if config.IsSet(compName + ".max-background") {
+	if config.IsSet(compName + ".max-fuse-threads") {
 		lf.maxBackground = opt.MaxBackground
 	} else {
 		lf.maxBackground = defaultMaxBackground

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -117,7 +117,7 @@ const defaultAttrExpiration = 120
 const defaultNegativeEntryExpiration = 120
 
 // defaultMaxBackground is the libfuse max_background parameter default (max pending requests, not threads)
-// It controls how many async I/O requests that fuse kernel module will keep outstanding to fuse userspace.
+// It controls how many async I/O requests the FUSE kernel module keeps outstanding to FUSE userspace.
 const defaultMaxBackground = 128
 
 var fuseFS *Libfuse

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -116,7 +116,7 @@ const defaultEntryExpiration = 120
 const defaultAttrExpiration = 120
 const defaultNegativeEntryExpiration = 120
 
-// maxBackground is the libfuse max_background parameter (max pending requests, not threads)
+// defaultMaxBackground is the libfuse max_background parameter default (max pending requests, not threads)
 // It controls how many async I/O requests that fuse kernel module will keep outstanding to fuse userspace.
 const defaultMaxBackground = 128
 

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -72,7 +72,6 @@ type Libfuse struct {
 	ignoreOpenFlags       bool
 	nonEmptyMount         bool
 	lsFlags               common.BitMap64
-	maxFuseThreads        uint32
 	directIO              bool
 	umask                 uint32
 	disableKernelCache    bool

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -353,7 +353,7 @@ func (lf *Libfuse) Configure(_ bool) error {
 		}
 	}
 
-	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max-background %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v, disableKernelCache %v",
+	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max_background %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v, disableKernelCache %v",
 		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxBackground, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask, lf.disableKernelCache)
 
 	return nil

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -76,6 +76,7 @@ type Libfuse struct {
 	directIO              bool
 	umask                 uint32
 	disableKernelCache    bool
+	maxBackground         uint32 // libfuse max_background: max pending background requests
 }
 
 // To support pagination in readdir calls this structure holds a block of items for a given directory
@@ -104,7 +105,7 @@ type LibfuseOptions struct {
 	nonEmptyMount           bool   `config:"nonempty" yaml:"nonempty,omitempty"`
 	Uid                     uint32 `config:"uid" yaml:"uid,omitempty"`
 	Gid                     uint32 `config:"gid" yaml:"gid,omitempty"`
-	MaxFuseThreads          uint32 `config:"max-fuse-threads" yaml:"max-fuse-threads,omitempty"`
+	MaxBackground           uint32 `config:"max-background" yaml:"max-background,omitempty"`
 	DirectIO                bool   `config:"direct-io" yaml:"direct-io,omitempty"`
 	Umask                   uint32 `config:"umask" yaml:"umask,omitempty"`
 }
@@ -113,7 +114,10 @@ const compName = "libfuse"
 const defaultEntryExpiration = 120
 const defaultAttrExpiration = 120
 const defaultNegativeEntryExpiration = 120
-const defaultMaxFuseThreads = 128
+
+// maxBackground is the libfuse max_background parameter (max pending requests, not threads)
+// It controls how many async I/O requests that fuse kernel module will keep outstanding to fuse userspace.
+const defaultMaxBackground = 128
 
 var fuseFS *Libfuse
 
@@ -249,10 +253,10 @@ func (lf *Libfuse) Validate(opt *LibfuseOptions) error {
 		}
 	}
 
-	if config.IsSet(compName + ".max-fuse-threads") {
-		lf.maxFuseThreads = opt.MaxFuseThreads
+	if config.IsSet(compName + ".max-background") {
+		lf.maxBackground = opt.MaxBackground
 	} else {
-		lf.maxFuseThreads = defaultMaxFuseThreads
+		lf.maxBackground = defaultMaxBackground
 	}
 
 	log.Info("Libfuse::Validate : UID %v, GID %v", lf.ownerUID, lf.ownerGID)
@@ -348,8 +352,8 @@ func (lf *Libfuse) Configure(_ bool) error {
 		}
 	}
 
-	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max-fuse-threads %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v, disableKernelCache %v",
-		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxFuseThreads, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask, lf.disableKernelCache)
+	log.Crit("Libfuse::Configure : read-only %t, allow-other %t, allow-root %t, default-perm %d, entry-timeout %d, attr-time %d, negative-timeout %d, ignore-open-flags %t, nonempty %t, direct_io %t, max-background %d, fuse-trace %t, extension %s, disable-writeback-cache %t, dirPermission %v, mountPath %v, umask %v, disableKernelCache %v",
+		lf.readOnly, lf.allowOther, lf.allowRoot, lf.filePermission, lf.entryExpiration, lf.attributeExpiration, lf.negativeTimeout, lf.ignoreOpenFlags, lf.nonEmptyMount, lf.directIO, lf.maxBackground, lf.traceEnable, lf.extensionPath, lf.disableWritebackCache, lf.dirPermission, lf.mountPath, lf.umask, lf.disableKernelCache)
 
 	return nil
 }

--- a/component/libfuse/libfuse2_handler.go
+++ b/component/libfuse/libfuse2_handler.go
@@ -278,7 +278,7 @@ func libfuse2_init(conn *C.fuse_conn_info_t) (res unsafe.Pointer) {
 
 	C.populate_uid_gid()
 
-	log.Info("Libfuse::libfuse2_init : Kernel Caps : %d", conn.capable)
+	log.Info("Libfuse::libfuse2_init : Kernel FUSE version: %d.%d, Kernel Caps : 0x%x", conn.proto_major, conn.proto_minor, conn.capable)
 
 	if (conn.capable & C.FUSE_CAP_ASYNC_READ) != 0 {
 		log.Info("Libfuse::libfuse2_init : Enable Capability : FUSE_CAP_ASYNC_READ")
@@ -296,11 +296,14 @@ func libfuse2_init(conn *C.fuse_conn_info_t) (res unsafe.Pointer) {
 		conn.want |= C.FUSE_CAP_SPLICE_WRITE
 	}
 
-	// Max background thread on the fuse layer for high parallelism
-	conn.max_background = C.uint(fuseFS.maxFuseThreads)
+	// Max background requests on the fuse layer
+	conn.max_background = C.uint(fuseFS.maxBackground)
 
 	// While reading a file let kernel do readahed for better perf
 	conn.max_readahead = (4 * 1024 * 1024)
+
+	log.Info("Libfuse::libfuse2_init : want: 0x%x, max_readahead: %d, max_background: %d",
+		conn.want, conn.max_readahead, conn.max_background)
 
 	return nil
 }

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -257,7 +257,7 @@ func (lf *Libfuse) destroyFuse() error {
 
 //export libfuse_init
 func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Pointer) {
-	log.Trace("Libfuse::libfuse_init : init (read : %v, write %v, read-ahead %v)", conn.max_read, conn.max_write, conn.max_readahead)
+	log.Trace("Libfuse::libfuse_init : init (max_read : %v, max_write %v, max_readahead %v)", conn.max_read, conn.max_write, conn.max_readahead)
 
 	log.Info("Libfuse::NotifyMountToParent : Notifying parent for successful mount")
 	if err := common.NotifyMountToParent(); err != nil {
@@ -266,7 +266,7 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 
 	C.populate_uid_gid()
 
-	log.Info("Libfuse::libfuse_init : Kernel Caps : %d", conn.capable)
+	log.Info("Libfuse::libfuse_init : Kernel FUSE version: %d.%d, Kernel Caps : 0x%x", conn.proto_major, conn.proto_minor, conn.capable)
 
 	// Populate connection information
 	// conn.want |= C.FUSE_CAP_NO_OPENDIR_SUPPORT
@@ -314,8 +314,8 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 		conn.want |= C.FUSE_CAP_WRITEBACK_CACHE
 	}
 
-	// Max background thread on the fuse layer for high parallelism
-	conn.max_background = C.uint(fuseFS.maxFuseThreads)
+	// Max background requests on the fuse layer
+	conn.max_background = C.uint(fuseFS.maxBackground)
 
 	// While reading a file let kernel do readahed for better perf
 	conn.max_readahead = (4 * 1024 * 1024)
@@ -337,6 +337,9 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 	if fuseFS.directIO {
 		cfg.direct_io = C.int(1)
 	}
+
+	log.Info("Libfuse::libfuse_init : want: 0x%x, max_read: %d, max_write: %d, max_readahead: %d, max_background: %d",
+		conn.want, conn.max_read, conn.max_write, conn.max_readahead, conn.max_background)
 
 	return nil
 }

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -257,7 +257,7 @@ func (lf *Libfuse) destroyFuse() error {
 
 //export libfuse_init
 func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Pointer) {
-	log.Trace("Libfuse::libfuse_init : init (max_read : %v, max_write %v, max_readahead %v)", conn.max_read, conn.max_write, conn.max_readahead)
+	log.Trace("Libfuse::libfuse_init : init (max_read: %v, max_write: %v, max_readahead: %v)", conn.max_read, conn.max_write, conn.max_readahead)
 
 	log.Info("Libfuse::NotifyMountToParent : Notifying parent for successful mount")
 	if err := common.NotifyMountToParent(); err != nil {


### PR DESCRIPTION
## Summary
Clarify libfuse parameter naming and enhance FUSE initialization logging to improve debuggability and correctness.

## Changes

### Parameter Naming Correction
- Renamed `maxFuseThreads` to `maxBackground` throughout the codebase to accurately reflect the libfuse `max_background` API parameter. This is a debug parameter for developers not used in production. so fine to rename
- Renamed constant from `defaultMaxFuseThreads` to `defaultMaxBackground`
- Added clarifying comments that `max_background` controls pending background requests, not thread count

**Affected files:**
- `component/libfuse/libfuse.go`
- `component/libfuse/libfuse_handler.go`
- `component/libfuse/libfuse2_handler.go`

### Enhanced FUSE Initialization Logging
Added kernel FUSE version and configuration parameter logging at mount initialization:
- Log kernel FUSE protocol version (`proto_major.proto_minor`) from `fuse_conn_info_t`
- Log critical configuration values: `max_background`, `max_readahead`, `max_read`, `max_write`, and capabilities
- Improves visibility into FUSE configuration for debugging version-related issues

## Why
The original parameter name `maxFuseThreads` was misleading as it actually maps to libfuse's `max_background` which controls the number of pending background requests queued before blocking writes, not the number of threads. The new naming removes ambiguity and aligns with the underlying libfuse API semantics.

Enhanced logging provides better observability into FUSE configuration at mount time, which is critical for debugging compatibility issues across different kernel and libfuse versions.

## Testing
- Configuration continues to work with the new parameter name
- Logging output includes version and configuration information
- Both FUSE 2 and FUSE 3 handlers updated consistently