### PR TITLE
[block-cache]Reduce auto tuned memory pool size from 80% to 60%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   ```
 
 **Breaking Changes**
-- Reduce the default block-cache memory pool size from 80% to 60% of free memory when `block_cache.mem-size-mb` is not configured.
+- Reduce the default block-cache memory pool size from 80% of free memory to 60% of available memory when `block_cache.mem-size-mb` is not configured. Users can continue to set the block-cache memory limit explicitly with `block_cache.mem-size-mb` or the `--block-cache-pool-size` CLI option.
 
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
     max-size-mb: 256   # set explicitly to override auto-tuning
   ```
 
-**Breaking Changes**
-- Reduce the default block-cache memory pool size from 80% of free memory to 60% of available memory when `block_cache.mem-size-mb` is not configured. Users can continue to set the block-cache memory limit explicitly with `block_cache.mem-size-mb` or the `--block-cache-pool-size` CLI option.
-
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))
 - Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))
@@ -18,6 +15,7 @@
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.
+- Reduce the default block-cache memory pool size from 80% of free memory to 60% of available memory when `block_cache.mem-size-mb` is not configured. This change improves mountpoint resilience by leaving more memory headroom for system processes, reducing the risk of out-of-memory conditions when concurrent workloads compete for memory resources. Users can continue to set the block-cache memory limit explicitly with `block_cache.mem-size-mb` or the `--block-cache-pool-size` CLI option. ([PR #2260](https://github.com/Azure/azure-storage-fuse/pull/2260)).
 
 ## 2.5.3 (2026-03-25)
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
     max-size-mb: 256   # set explicitly to override auto-tuning
   ```
 
+**Breaking Changes**
+- Reduce the default block-cache memory pool size from 80% to 60% of free memory when `block_cache.mem-size-mb` is not configured.
+
 **Bug Fixes**
 - Fix CPK-encrypted blob attribute lookup duplicating the prefix path when subdirectory is configured ([PR #2199](https://github.com/Azure/azure-storage-fuse/pull/2199))
 - Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))

--- a/NOTICE
+++ b/NOTICE
@@ -4600,4 +4600,217 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+
+
+
+
+****************************************************************************
+
+============================================================================
+>>> github.com/prometheus/procfs
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
 --------------------- END OF THIRD PARTY NOTICE --------------------------------

--- a/common/util.go
+++ b/common/util.go
@@ -56,6 +56,7 @@ import (
 	"syscall"
 
 	"github.com/petermattis/goid"
+	"github.com/prometheus/procfs"
 	"gopkg.in/ini.v1"
 )
 
@@ -658,4 +659,32 @@ func TotalMemoryBytes() uint64 {
 		return 0
 	}
 	return uint64(info.Totalram) * uint64(info.Unit)
+}
+
+// GetAvailableMemoryBytes returns the available system memory in bytes.
+// It uses MemAvailable from /proc/meminfo and falls back to MemFree when MemAvailable is unavailable.
+func GetAvailableMemoryBytes() (uint64, error) {
+	fs, err := procfs.NewDefaultFS()
+	if err != nil {
+		return 0, err
+	}
+
+	memInfo, err := fs.Meminfo()
+	if err != nil {
+		return 0, err
+	}
+
+	return getAvailableMemoryBytesFromMeminfo(memInfo)
+}
+
+func getAvailableMemoryBytesFromMeminfo(memInfo procfs.Meminfo) (uint64, error) {
+	if memInfo.MemAvailableBytes != nil && *memInfo.MemAvailableBytes > 0 {
+		return *memInfo.MemAvailableBytes, nil
+	}
+
+	if memInfo.MemFreeBytes != nil && *memInfo.MemFreeBytes > 0 {
+		return *memInfo.MemFreeBytes, nil
+	}
+
+	return 0, fmt.Errorf("neither MemAvailable nor MemFree found in /proc/meminfo")
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -40,10 +40,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
 
+	"github.com/prometheus/procfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -673,4 +676,91 @@ func TestTotalMemoryBytesIsPositive(t *testing.T) {
 func TestTotalMemoryBytesAtLeast1MB(t *testing.T) {
 	mem := TotalMemoryBytes()
 	assert.GreaterOrEqual(t, mem, uint64(1<<20), "TotalMemoryBytes should be at least 1 MB")
+}
+
+func (suite *utilTestSuite) TestGetAvailableMemoryBytes() {
+	availableMemory, err := GetAvailableMemoryBytes()
+	suite.assert.NoError(err)
+
+	meminfoMemory, err := readAvailableMemoryBytesFromProcMeminfo()
+	suite.assert.NoError(err)
+
+	var difference uint64
+	if availableMemory > meminfoMemory {
+		difference = availableMemory - meminfoMemory
+	} else {
+		difference = meminfoMemory - availableMemory
+	}
+
+	tolerance := meminfoMemory / 100
+	suite.assert.LessOrEqual(difference, tolerance)
+}
+
+func (suite *utilTestSuite) TestGetAvailableMemoryBytesFromMeminfoFallback() {
+	availableMemory := uint64(1024)
+	freeMemory := uint64(512)
+
+	actual, err := getAvailableMemoryBytesFromMeminfo(procfs.Meminfo{
+		MemAvailableBytes: &availableMemory,
+		MemFreeBytes:      &freeMemory,
+	})
+	suite.assert.NoError(err)
+	suite.assert.Equal(availableMemory, actual)
+
+	actual, err = getAvailableMemoryBytesFromMeminfo(procfs.Meminfo{
+		MemFreeBytes: &freeMemory,
+	})
+	suite.assert.NoError(err)
+	suite.assert.Equal(freeMemory, actual)
+
+	zeroMemory := uint64(0)
+	actual, err = getAvailableMemoryBytesFromMeminfo(procfs.Meminfo{
+		MemAvailableBytes: &zeroMemory,
+		MemFreeBytes:      &freeMemory,
+	})
+	suite.assert.NoError(err)
+	suite.assert.Equal(freeMemory, actual)
+
+	actual, err = getAvailableMemoryBytesFromMeminfo(procfs.Meminfo{
+		MemAvailableBytes: &zeroMemory,
+		MemFreeBytes:      &zeroMemory,
+	})
+	suite.assert.Error(err)
+	suite.assert.Equal(uint64(0), actual)
+}
+
+func readAvailableMemoryBytesFromProcMeminfo() (uint64, error) {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0, err
+	}
+
+	var memFree uint64
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		value, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, err
+		}
+
+		value *= 1024
+		switch fields[0] {
+		case "MemAvailable:":
+			if value > 0 {
+				return value, nil
+			}
+		case "MemFree:":
+			memFree = value
+		}
+	}
+
+	if memFree > 0 {
+		return memFree, nil
+	}
+
+	return 0, fmt.Errorf("neither MemAvailable nor MemFree found in /proc/meminfo")
 }

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -364,7 +364,7 @@ func (bc *BlockCache) getDefaultMemSize() uint64 {
 		return uint64(4192) * _1MB
 	}
 
-	return uint64(0.8 * (float64)(sysinfo.Freeram) * float64(sysinfo.Unit))
+	return uint64(0.6 * (float64)(sysinfo.Freeram) * float64(sysinfo.Unit))
 }
 
 // CreateFile: Create a new file

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -356,15 +356,13 @@ func (bc *BlockCache) getDefaultDiskSize(path string) uint64 {
 }
 
 func (bc *BlockCache) getDefaultMemSize() uint64 {
-	var sysinfo syscall.Sysinfo_t
-	err := syscall.Sysinfo(&sysinfo)
-
+	availableMemory, err := common.GetAvailableMemoryBytes()
 	if err != nil {
 		log.Info("BlockCache::getDefaultMemSize : config error %s [%s]. Assigning a pre-defined value of 4GB.", bc.Name(), err.Error())
 		return uint64(4192) * _1MB
 	}
 
-	return uint64(0.6 * (float64)(sysinfo.Freeram) * float64(sysinfo.Unit))
+	return uint64(0.6 * float64(availableMemory))
 }
 
 // CreateFile: Create a new file

--- a/component/block_cache/block_cache.go
+++ b/component/block_cache/block_cache.go
@@ -358,7 +358,7 @@ func (bc *BlockCache) getDefaultDiskSize(path string) uint64 {
 func (bc *BlockCache) getDefaultMemSize() uint64 {
 	availableMemory, err := common.GetAvailableMemoryBytes()
 	if err != nil {
-		log.Info("BlockCache::getDefaultMemSize : config error %s [%s]. Assigning a pre-defined value of 4GB.", bc.Name(), err.Error())
+		log.Info("BlockCache::getDefaultMemSize : config error %s [%s]. Assigning a pre-defined value of 4192MB (~4GB).", bc.Name(), err.Error())
 		return uint64(4192) * _1MB
 	}
 

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -212,14 +212,9 @@ func (suite *blockCacheTestSuite) TestMemory() {
 
 	suite.assert.NoError(err)
 	suite.assert.Equal("block_cache", tobj.blockCache.Name())
-	cmd := exec.Command("bash", "-c", "free -b | grep Mem | awk '{print $4}'")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err = cmd.Run()
+	availableMemory, err := common.GetAvailableMemoryBytes()
 	suite.assert.NoError(err)
-	free, err := strconv.Atoi(strings.TrimSpace(out.String()))
-	suite.assert.NoError(err)
-	expected := uint64(0.6 * float64(free))
+	expected := uint64(0.6 * float64(availableMemory))
 	actual := tobj.blockCache.memSize
 	difference := math.Abs(float64(actual) - float64(expected))
 	tolerance := 0.10 * float64(math.Max(float64(actual), float64(expected)))
@@ -256,14 +251,9 @@ func (suite *blockCacheTestSuite) TestStatfsMemory() {
 
 	suite.assert.NoError(err)
 	suite.assert.Equal("block_cache", tobj.blockCache.Name())
-	cmd := exec.Command("bash", "-c", "free -b | grep Mem | awk '{print $4}'")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err = cmd.Run()
+	availableMemory, err := common.GetAvailableMemoryBytes()
 	suite.assert.NoError(err)
-	free, err := strconv.Atoi(strings.TrimSpace(out.String()))
-	suite.assert.NoError(err)
-	expected := uint64(0.6 * float64(free))
+	expected := uint64(0.6 * float64(availableMemory))
 	stat, ret, err := tobj.blockCache.StatFs()
 	suite.assert.True(ret)
 	suite.assert.NoError(err)

--- a/component/block_cache/block_cache_test.go
+++ b/component/block_cache/block_cache_test.go
@@ -219,7 +219,7 @@ func (suite *blockCacheTestSuite) TestMemory() {
 	suite.assert.NoError(err)
 	free, err := strconv.Atoi(strings.TrimSpace(out.String()))
 	suite.assert.NoError(err)
-	expected := uint64(0.8 * float64(free))
+	expected := uint64(0.6 * float64(free))
 	actual := tobj.blockCache.memSize
 	difference := math.Abs(float64(actual) - float64(expected))
 	tolerance := 0.10 * float64(math.Max(float64(actual), float64(expected)))
@@ -263,7 +263,7 @@ func (suite *blockCacheTestSuite) TestStatfsMemory() {
 	suite.assert.NoError(err)
 	free, err := strconv.Atoi(strings.TrimSpace(out.String()))
 	suite.assert.NoError(err)
-	expected := uint64(0.8 * float64(free))
+	expected := uint64(0.6 * float64(free))
 	stat, ret, err := tobj.blockCache.StatFs()
 	suite.assert.True(ret)
 	suite.assert.NoError(err)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/montanaflynn/stats v0.9.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+	github.com/prometheus/procfs v0.20.1
 	github.com/radovskyb/watcher v1.0.7
 	github.com/sevlyar/go-daemon v0.1.6
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -64,6 +64,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
+github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
 github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=


### PR DESCRIPTION
## Summary
- Reduce block-cache default memory pool auto-tuning from 80% of free memory to 60% of available memory.
- Use Prometheus procfs parsing for `/proc/meminfo` and fall back from `MemAvailable` to `MemFree` when needed.
- Document that users can still override the block-cache memory limit with `block_cache.mem-size-mb` or `--block-cache-pool-size`.

## Validation
- `go test -v -timeout=10m ./common --tags=unittest,fuse3 -run 'TestUtil/TestGetAvailableMemoryBytes'`
- `go test -v -timeout=10m ./component/block_cache --tags=unittest,fuse3 -run 'TestBlockCacheTestSuite/(TestMemory|TestStatfsMemory)$'`
```