### PR TITLE
Fix #2249: support blob index tag filtering on Block Blob, ADLS accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))
 - Return `ENAMETOOLONG` instead of `EIO` when renaming a directory to an ADLS path that exceeds the depth limit of 63 segments ([PR #2251](https://github.com/Azure/azure-storage-fuse/pull/2251))
 - Fix Debian 13 (trixie) release by publishing a dedicated package built against `libfuse3.so.4` (libfuse 3.17+) ([PR #2264](https://github.com/Azure/azure-storage-fuse/pull/2264))
-- Support filtering blobs by blob index tags via the `azstorage.filter` (`--filter`) option. Previously a `tag=key:value` clause silently rejected every blob because tags were never populated. Tags are now fetched only when a `tag=` filter is configured: Block Blob accounts include tags in the list response, ADLS Gen2 accounts fall back to per-blob `GetTags` since the HNS list endpoint does not return tags. ([PR #2261](https://github.com/Azure/azure-storage-fuse/pull/2261))
+- Fixed filtering of blobs by blob index tags via the `azstorage.filter` (`--filter`) option. ([PR #2261](https://github.com/Azure/azure-storage-fuse/pull/2261))
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))
 - Return `ENAMETOOLONG` instead of `EIO` when renaming a directory to an ADLS path that exceeds the depth limit of 63 segments ([PR #2251](https://github.com/Azure/azure-storage-fuse/pull/2251))
 - Fix Debian 13 (trixie) release by publishing a dedicated package built against `libfuse3.so.4` (libfuse 3.17+) ([PR #2264](https://github.com/Azure/azure-storage-fuse/pull/2264))
-- Support filtering blobs by blob index tags via the `azstorage.filter` (`--filter`) option. Previously a `tag=key:value` clause silently rejected every blob because tags were never populated. Tags are now fetched only when a `tag=` filter is configured: Block Blob accounts include tags in the list response, ADLS Gen2 accounts fall back to per-blob `GetTags` since the HNS list endpoint does not return tags. ([PR #2261](https://github.com/Azure/azure-storage-fuse/pulls/2261))
+- Support filtering blobs by blob index tags via the `azstorage.filter` (`--filter`) option. Previously a `tag=key:value` clause silently rejected every blob because tags were never populated. Tags are now fetched only when a `tag=` filter is configured: Block Blob accounts include tags in the list response, ADLS Gen2 accounts fall back to per-blob `GetTags` since the HNS list endpoint does not return tags. ([PR #2261](https://github.com/Azure/azure-storage-fuse/pull/2261))
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Return `ENAMETOOLONG` instead of `EIO` when creating a directory path that exceeds the ADLS depth limit of 63 segments ([PR #2221](https://github.com/Azure/azure-storage-fuse/pull/2221))
 - Return `ENAMETOOLONG` instead of `EIO` when renaming a directory to an ADLS path that exceeds the depth limit of 63 segments ([PR #2251](https://github.com/Azure/azure-storage-fuse/pull/2251))
 - Fix Debian 13 (trixie) release by publishing a dedicated package built against `libfuse3.so.4` (libfuse 3.17+) ([PR #2264](https://github.com/Azure/azure-storage-fuse/pull/2264))
+- Support filtering blobs by blob index tags via the `azstorage.filter` (`--filter`) option. Previously a `tag=key:value` clause silently rejected every blob because tags were never populated. Tags are now fetched only when a `tag=` filter is configured: Block Blob accounts include tags in the list response, ADLS Gen2 accounts fall back to per-blob `GetTags` since the HNS list endpoint does not return tags. ([PR #2261](https://github.com/Azure/azure-storage-fuse/pulls/2261))
 
 **Other Changes**
 - CBL-Mariner 2.0 has reached end-of-life; Blobfuse2 packages will no longer be published to Mariner 2.0 repositories.

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -590,7 +590,6 @@ func (bb *BlockBlob) GetAttr(name string) (attr *internal.ObjAttr, err error) {
 
 	attr, err = bb.getAttrUsingRest(name)
 	if err != nil {
-		log.Err("BlockBlob::GetAttr : Failed to get attributes for %s [%s]", name, err.Error())
 		return attr, err
 	}
 	if bb.Config.filter != nil && attr != nil {

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -105,6 +105,7 @@ func (bb *BlockBlob) Configure(cfg AzStorageConfig) error {
 
 	bb.listDetails = container.ListBlobsInclude{
 		Metadata:    true,
+		Tags:        bb.Config.filterHasTag,
 		Deleted:     false,
 		Snapshots:   false,
 		Permissions: false, //Added to get permissions, acl, group, owner for HNS accounts
@@ -577,23 +578,48 @@ func (bb *BlockBlob) GetAttr(name string) (attr *internal.ObjAttr, err error) {
 
 	// To support virtual directories with no marker blob, we call list instead of get properties since list will not return a 404
 	if bb.Config.virtualDirectory {
-		attr, err = bb.getAttrUsingList(name)
-	} else {
-		attr, err = bb.getAttrUsingRest(name)
+		// getAttrUsingList -> List -> processBlobItems already evaluates the
+		// filter (including tag filters), so a successful return means the blob
+		// passed the filter.
+		return bb.getAttrUsingList(name)
 	}
 
+	attr, err = bb.getAttrUsingRest(name)
 	if bb.Config.filter != nil && attr != nil {
-		if !bb.Config.filter.IsAcceptable(&blobfilter.BlobAttr{
+		filterAttr := blobfilter.BlobAttr{
 			Name:  attr.Name,
 			Mtime: attr.Mtime,
 			Size:  attr.Size,
-		}) {
+		}
+		// GetProperties does not return blob index tags. When the configured
+		// filter references tags, fetch them explicitly before deciding.
+		if bb.Config.filterHasTag && !attr.IsDir() {
+			tags, terr := bb.getBlobTags(name)
+			if terr != nil {
+				log.Warn("BlockBlob::GetAttr : Failed to get tags for %s [%s]", name, terr.Error())
+			} else {
+				filterAttr.Tags = tags
+			}
+		}
+
+		if !bb.Config.filter.IsAcceptable(&filterAttr) {
 			log.Debug("BlockBlob::GetAttr : Filtered out %s", name)
 			return nil, syscall.ENOENT
 		}
 	}
 
 	return attr, err
+}
+
+// getBlobTags fetches blob index tags for the given blob name and returns them
+// as a flat map. Returns nil if the blob has no tags.
+func (bb *BlockBlob) getBlobTags(name string) (map[string]string, error) {
+	blobClient := bb.Container.NewBlockBlobClient(filepath.Join(bb.Config.prefixPath, name))
+	resp, err := blobClient.GetTags(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseBlobTags(&resp.BlobTags), nil
 }
 
 // List : Get a list of blobs matching the given prefix
@@ -685,6 +711,7 @@ func (bb *BlockBlob) processBlobItems(blobItems []*container.BlobItem) ([]*inter
 			filterAttr.Name = blobAttr.Name
 			filterAttr.Mtime = blobAttr.Mtime
 			filterAttr.Size = blobAttr.Size
+			filterAttr.Tags = parseBlobTags(blobInfo.BlobTags)
 
 			if bb.Config.filter.IsAcceptable(&filterAttr) {
 				blobList = append(blobList, blobAttr)
@@ -1846,9 +1873,16 @@ func (bb *BlockBlob) CommitBlocks(name string, blockList []string, newEtag *stri
 func (bb *BlockBlob) SetFilter(filter string) error {
 	if filter == "" {
 		bb.Config.filter = nil
+		bb.Config.filterHasTag = false
+		bb.listDetails.Tags = false
 		return nil
 	}
 
 	bb.Config.filter = &blobfilter.BlobFilter{}
-	return bb.Config.filter.Configure(filter)
+	if err := bb.Config.filter.Configure(filter); err != nil {
+		return err
+	}
+	bb.Config.filterHasTag = filterReferencesTag(filter)
+	bb.listDetails.Tags = bb.Config.filterHasTag
+	return nil
 }

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -600,7 +600,7 @@ func (bb *BlockBlob) GetAttr(name string) (attr *internal.ObjAttr, err error) {
 		if bb.Config.filterHasTag && !attr.IsDir() {
 			tags, terr := bb.getBlobTags(name)
 			if terr != nil {
-				log.Warn("BlockBlob::GetAttr : Failed to get tags for %s [%s]", name, terr.Error())
+				log.Err("BlockBlob::GetAttr : Failed to get tags for %s [%s]", name, terr.Error())
 			} else {
 				filterAttr.Tags = tags
 			}

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -601,9 +601,9 @@ func (bb *BlockBlob) GetAttr(name string) (attr *internal.ObjAttr, err error) {
 			tags, terr := bb.getBlobTags(name)
 			if terr != nil {
 				log.Err("BlockBlob::GetAttr : Failed to get tags for %s [%s]", name, terr.Error())
-			} else {
-				filterAttr.Tags = tags
+				return attr, syscall.EACCES
 			}
+			filterAttr.Tags = tags
 		}
 
 		if !bb.Config.filter.IsAcceptable(&filterAttr) {
@@ -725,10 +725,10 @@ func (bb *BlockBlob) processBlobItems(blobItems []*container.BlobItem) ([]*inter
 				if bb.Config.isHNS {
 					tagResp, err := bb.Container.NewBlockBlobClient(*blobInfo.Name).GetTags(context.Background(), nil)
 					if err != nil {
-						log.Warn("BlockBlob::processBlobItems : Failed to get tags for %s [%s]", *blobInfo.Name, err.Error())
-					} else {
-						filterAttr.Tags = parseBlobTags(&tagResp.BlobTags)
+						log.Err("BlockBlob::processBlobItems : Failed to get tags for %s [%s]", *blobInfo.Name, err.Error())
+						return nil, nil, syscall.EACCES
 					}
+					filterAttr.Tags = parseBlobTags(&tagResp.BlobTags)
 				} else {
 					filterAttr.Tags = parseBlobTags(blobInfo.BlobTags)
 				}

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -104,8 +104,12 @@ func (bb *BlockBlob) Configure(cfg AzStorageConfig) error {
 	}
 
 	bb.listDetails = container.ListBlobsInclude{
-		Metadata:    true,
-		Tags:        bb.Config.filterHasTag,
+		Metadata: true,
+		// Include.Tags is only honored on Block Blob (flat namespace) accounts.
+		// On HNS (ADLS Gen2), the list endpoint does not populate BlobTags in
+		// the response; tags must be fetched per-blob via GetTags — handled in
+		// processBlobItems.
+		Tags:        bb.Config.filterHasTag && !bb.Config.isHNS,
 		Deleted:     false,
 		Snapshots:   false,
 		Permissions: false, //Added to get permissions, acl, group, owner for HNS accounts
@@ -711,7 +715,24 @@ func (bb *BlockBlob) processBlobItems(blobItems []*container.BlobItem) ([]*inter
 			filterAttr.Name = blobAttr.Name
 			filterAttr.Mtime = blobAttr.Mtime
 			filterAttr.Size = blobAttr.Size
-			filterAttr.Tags = parseBlobTags(blobInfo.BlobTags)
+			filterAttr.Tags = nil
+			if bb.Config.filterHasTag {
+				// HNS (ADLS Gen2) does not return blob index tags in the list response
+				// (BlobTags is nil and BlobTagCount is not populated on list items even
+				// when Include.Tags is requested). Fetch tags per-blob via GetTags so
+				// the tag filter can be evaluated. This N+1 cost only applies when a
+				// tag= filter is configured on an HNS account.
+				if bb.Config.isHNS {
+					tagResp, err := bb.Container.NewBlockBlobClient(*blobInfo.Name).GetTags(context.Background(), nil)
+					if err != nil {
+						log.Warn("BlockBlob::processBlobItems : Failed to get tags for %s [%s]", *blobInfo.Name, err.Error())
+					} else {
+						filterAttr.Tags = parseBlobTags(&tagResp.BlobTags)
+					}
+				} else {
+					filterAttr.Tags = parseBlobTags(blobInfo.BlobTags)
+				}
+			}
 
 			if bb.Config.filter.IsAcceptable(&filterAttr) {
 				blobList = append(blobList, blobAttr)
@@ -1883,6 +1904,8 @@ func (bb *BlockBlob) SetFilter(filter string) error {
 		return err
 	}
 	bb.Config.filterHasTag = filterReferencesTag(filter)
-	bb.listDetails.Tags = bb.Config.filterHasTag
+	// HNS accounts do not populate tags in the list response; leave Include.Tags off
+	// and let processBlobItems fetch tags per-blob when needed.
+	bb.listDetails.Tags = bb.Config.filterHasTag && !bb.Config.isHNS
 	return nil
 }

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -589,6 +589,10 @@ func (bb *BlockBlob) GetAttr(name string) (attr *internal.ObjAttr, err error) {
 	}
 
 	attr, err = bb.getAttrUsingRest(name)
+	if err != nil {
+		log.Err("BlockBlob::GetAttr : Failed to get attributes for %s [%s]", name, err.Error())
+		return attr, err
+	}
 	if bb.Config.filter != nil && attr != nil {
 		filterAttr := blobfilter.BlobAttr{
 			Name:  attr.Name,
@@ -621,6 +625,7 @@ func (bb *BlockBlob) getBlobTags(name string) (map[string]string, error) {
 	blobClient := bb.Container.NewBlockBlobClient(filepath.Join(bb.Config.prefixPath, name))
 	resp, err := blobClient.GetTags(context.Background(), nil)
 	if err != nil {
+		log.Err("BlockBlob::getBlobTags : Failed to get tags for %s [%s]", name, err.Error())
 		return nil, err
 	}
 	return parseBlobTags(&resp.BlobTags), nil
@@ -723,12 +728,11 @@ func (bb *BlockBlob) processBlobItems(blobItems []*container.BlobItem) ([]*inter
 				// the tag filter can be evaluated. This N+1 cost only applies when a
 				// tag= filter is configured on an HNS account.
 				if bb.Config.isHNS {
-					tagResp, err := bb.Container.NewBlockBlobClient(*blobInfo.Name).GetTags(context.Background(), nil)
+					tags, err := bb.getBlobTags(blobAttr.Path)
 					if err != nil {
-						log.Err("BlockBlob::processBlobItems : Failed to get tags for %s [%s]", *blobInfo.Name, err.Error())
 						return nil, nil, syscall.EACCES
 					}
-					filterAttr.Tags = parseBlobTags(&tagResp.BlobTags)
+					filterAttr.Tags = tags
 				} else {
 					filterAttr.Tags = parseBlobTags(blobInfo.BlobTags)
 				}

--- a/component/azstorage/block_blob_test.go
+++ b/component/azstorage/block_blob_test.go
@@ -3703,6 +3703,86 @@ func (s *blockBlobTestSuite) TestBlobFilters() {
 	s.assert.NoError(err)
 }
 
+func (s *blockBlobTestSuite) TestBlobTagFilter() {
+	defer s.cleanupTest()
+	// Setup: create files and stamp blob index tags on a subset
+	bb := s.az.storage.(*BlockBlob)
+
+	name := generateDirectoryName()
+	err := s.az.CreateDir(internal.CreateDirOptions{Name: name})
+	s.assert.NoError(err)
+
+	type blobSpec struct {
+		path string
+		tags map[string]string
+	}
+	specs := []blobSpec{
+		{name + "/a.txt", map[string]string{"domain": "optical"}},
+		{name + "/b.txt", map[string]string{"domain": "optical", "owner": "team-a"}},
+		{name + "/c.txt", map[string]string{"domain": "radar"}},
+		{name + "/d.txt", nil},
+	}
+	for _, sp := range specs {
+		_, err = s.az.CreateFile(internal.CreateFileOptions{Name: sp.path})
+		s.assert.NoError(err)
+		if sp.tags != nil {
+			client := bb.Container.NewBlockBlobClient(sp.path)
+			_, err = client.SetTags(ctx, sp.tags, nil)
+			s.assert.NoError(err)
+		}
+	}
+
+	// list should return all entries when no filter is applied
+	listAll := func() []*internal.ObjAttr {
+		out := make([]*internal.ObjAttr, 0)
+		marker := ""
+		for {
+			page, next, err := s.az.StreamDir(internal.StreamDirOptions{Name: name + "/", Token: marker, Count: 50})
+			s.assert.NoError(err)
+			out = append(out, page...)
+			marker = next
+			if marker == "" {
+				return out
+			}
+		}
+	}
+
+	s.assert.Len(listAll(), 4)
+
+	// Filter by an existing tag - should match the two blobs tagged optical
+	err = bb.SetFilter("tag=domain:optical")
+	s.assert.NoError(err)
+	s.assert.True(bb.Config.filterHasTag)
+
+	blobs := listAll()
+	s.assert.Len(blobs, 2)
+
+	got := map[string]bool{}
+	for _, b := range blobs {
+		got[filepath.Base(b.Path)] = true
+	}
+	s.assert.True(got["a.txt"])
+	s.assert.True(got["b.txt"])
+
+	// GetAttr on a non-matching blob should report ENOENT via the filter,
+	// while a matching one should succeed.
+	_, err = bb.GetAttr(name + "/c.txt")
+	s.assert.Equal(syscall.ENOENT, err)
+
+	attr, err := bb.GetAttr(name + "/a.txt")
+	s.assert.NoError(err)
+	s.assert.NotNil(attr)
+
+	// Filter that does not reference tags should not flip filterHasTag.
+	err = bb.SetFilter("name=^a.*")
+	s.assert.NoError(err)
+	s.assert.False(bb.Config.filterHasTag)
+
+	err = bb.SetFilter("")
+	s.assert.NoError(err)
+	s.assert.False(bb.Config.filterHasTag)
+}
+
 func (s *blockBlobTestSuite) UtilityFunctionTestTruncateFileToSmaller(size int, truncatedLength int) {
 	defer s.cleanupTest()
 	// Setup

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -570,8 +570,8 @@ func configureBlobFilter(azStorage *AzStorage, opt AzStorageOptions) error {
 // so we inspect the input string ourselves to know whether GetAttr paths must
 // fetch blob index tags before evaluating the filter.
 func filterReferencesTag(filter string) bool {
-	for _, clause := range strings.Split(filter, "||") {
-		for _, sub := range strings.Split(clause, "&&") {
+	for clause := range strings.SplitSeq(filter, "||") {
+		for sub := range strings.SplitSeq(clause, "&&") {
 			token := strings.TrimSpace(sub)
 			lowered := strings.ToLower(strings.Map(func(r rune) rune {
 				if r == ' ' || r == '\t' {
@@ -579,7 +579,7 @@ func filterReferencesTag(filter string) bool {
 				}
 				return r
 			}, token))
-			if strings.HasPrefix(lowered, "tag=") {
+			if strings.HasPrefix(lowered, "tag=") || strings.HasPrefix(lowered, "tag!=") {
 				return true
 			}
 		}

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -559,9 +559,37 @@ func configureBlobFilter(azStorage *AzStorage, opt AzStorageOptions) error {
 		log.Err("configureBlobFilter : Failed to configure blob filter %s", err.Error())
 		return errors.New("failed to configure blob filter")
 	}
+	azStorage.stConfig.filterHasTag = filterReferencesTag(opt.Filter)
+
+	if azStorage.stConfig.filterHasTag && azStorage.stConfig.authConfig.AccountType == EAccountType.ADLS() {
+		log.Err("configureBlobFilter : tag= filters are not supported on ADLS Gen2 accounts")
+		return errors.New("tag= filters are not supported on ADLS Gen2 accounts")
+	}
 
 	log.Crit("configureBlobFilter : Blob filter configured %s", opt.Filter)
 	return nil
+}
+
+// filterReferencesTag returns true when the raw filter expression includes a
+// `tag=` clause. The blobfilter package does not expose its parsed filter set,
+// so we inspect the input string ourselves to know whether GetAttr paths must
+// fetch blob index tags before evaluating the filter.
+func filterReferencesTag(filter string) bool {
+	for _, clause := range strings.Split(filter, "||") {
+		for _, sub := range strings.Split(clause, "&&") {
+			token := strings.TrimSpace(sub)
+			lowered := strings.ToLower(strings.Map(func(r rune) rune {
+				if r == ' ' || r == '\t' {
+					return -1
+				}
+				return r
+			}, token))
+			if strings.HasPrefix(lowered, "tag=") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ParseAndReadDynamicConfig : On config change read only the required config

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -561,11 +561,6 @@ func configureBlobFilter(azStorage *AzStorage, opt AzStorageOptions) error {
 	}
 	azStorage.stConfig.filterHasTag = filterReferencesTag(opt.Filter)
 
-	if azStorage.stConfig.filterHasTag && azStorage.stConfig.authConfig.AccountType == EAccountType.ADLS() {
-		log.Err("configureBlobFilter : tag= filters are not supported on ADLS Gen2 accounts")
-		return errors.New("tag= filters are not supported on ADLS Gen2 accounts")
-	}
-
 	log.Crit("configureBlobFilter : Blob filter configured %s", opt.Filter)
 	return nil
 }

--- a/component/azstorage/connection.go
+++ b/component/azstorage/connection.go
@@ -84,7 +84,8 @@ type AzStorageConfig struct {
 	cpkEncryptionKeySha256 string
 
 	// Blob filters
-	filter *blobfilter.BlobFilter
+	filter       *blobfilter.BlobFilter
+	filterHasTag bool // true when the configured filter references blob tags
 
 	// Rate limiting
 	capMbpsRead int64

--- a/component/azstorage/connection.go
+++ b/component/azstorage/connection.go
@@ -86,6 +86,7 @@ type AzStorageConfig struct {
 	// Blob filters
 	filter       *blobfilter.BlobFilter
 	filterHasTag bool // true when the configured filter references blob tags
+	isHNS        bool // true when the underlying account is ADLS Gen2 (hierarchical namespace)
 
 	// Rate limiting
 	capMbpsRead int64

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -457,13 +457,20 @@ func (dl *Datalake) GetAttr(name string) (blobAttr *internal.ObjAttr, err error)
 	}
 
 	if dl.Config.filter != nil {
-		// Blob index tags are not generally available on ADLS Gen2 accounts.
-		// configureBlobFilter rejects `tag=` filters on HNS accounts, so we do not fetch tags here.
-		if !dl.Config.filter.IsAcceptable(&blobfilter.BlobAttr{
+		filterAttr := &blobfilter.BlobAttr{
 			Name:  blobAttr.Name,
 			Mtime: blobAttr.Mtime,
 			Size:  blobAttr.Size,
-		}) {
+		}
+		if dl.Config.filterHasTag && !blobAttr.IsDir() {
+			tagResp, err := fileClient.GetTags(context.Background(), nil)
+			if err != nil {
+				log.Err("Datalake::GetAttr : Failed to get tags for %s [%s]", name, err.Error())
+			} else {
+				filterAttr.Tags = parseBlobTags(&tagResp.BlobTags)
+			}
+		}
+		if !dl.Config.filter.IsAcceptable(filterAttr) {
 			log.Debug("Datalake::GetAttr : Filtered out %s", name)
 			return nil, syscall.ENOENT
 		}
@@ -637,12 +644,14 @@ func (dl *Datalake) CommitBlocks(name string, blockList []string, newEtag *strin
 func (dl *Datalake) SetFilter(filter string) error {
 	if filter == "" {
 		dl.Config.filter = nil
+		dl.Config.filterHasTag = false
 	} else {
 		dl.Config.filter = &blobfilter.BlobFilter{}
 		err := dl.Config.filter.Configure(filter)
 		if err != nil {
 			return err
 		}
+		dl.Config.filterHasTag = filterReferencesTag(filter)
 	}
 
 	return dl.BlockBlob.SetFilter(filter)

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -457,6 +457,9 @@ func (dl *Datalake) GetAttr(name string) (blobAttr *internal.ObjAttr, err error)
 	}
 
 	if dl.Config.filter != nil {
+		// Blob index tags are not generally available on ADLS Gen2 accounts,
+		// so we do not fetch them here. configureBlobFilter logs a warning when
+		// a tag= filter is configured against an HNS account.
 		if !dl.Config.filter.IsAcceptable(&blobfilter.BlobAttr{
 			Name:  blobAttr.Name,
 			Mtime: blobAttr.Mtime,

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -90,6 +90,7 @@ func transformConfig(dlConfig AzStorageConfig) AzStorageConfig {
 	bbConfig := dlConfig
 	bbConfig.authConfig.AccountType = EAccountType.BLOCK()
 	bbConfig.authConfig.Endpoint = transformAccountEndpoint(dlConfig.authConfig.Endpoint)
+	bbConfig.isHNS = true
 	return bbConfig
 }
 

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -457,9 +457,8 @@ func (dl *Datalake) GetAttr(name string) (blobAttr *internal.ObjAttr, err error)
 	}
 
 	if dl.Config.filter != nil {
-		// Blob index tags are not generally available on ADLS Gen2 accounts,
-		// so we do not fetch them here. configureBlobFilter logs a warning when
-		// a tag= filter is configured against an HNS account.
+		// Blob index tags are not generally available on ADLS Gen2 accounts.
+		// configureBlobFilter rejects `tag=` filters on HNS accounts, so we do not fetch tags here.
 		if !dl.Config.filter.IsAcceptable(&blobfilter.BlobAttr{
 			Name:  blobAttr.Name,
 			Mtime: blobAttr.Mtime,

--- a/component/azstorage/datalake.go
+++ b/component/azstorage/datalake.go
@@ -467,9 +467,9 @@ func (dl *Datalake) GetAttr(name string) (blobAttr *internal.ObjAttr, err error)
 			tagResp, err := fileClient.GetTags(context.Background(), nil)
 			if err != nil {
 				log.Err("Datalake::GetAttr : Failed to get tags for %s [%s]", name, err.Error())
-			} else {
-				filterAttr.Tags = parseBlobTags(&tagResp.BlobTags)
+				return blobAttr, syscall.EACCES
 			}
+			filterAttr.Tags = parseBlobTags(&tagResp.BlobTags)
 		}
 		if !dl.Config.filter.IsAcceptable(filterAttr) {
 			log.Debug("Datalake::GetAttr : Filtered out %s", name)

--- a/component/azstorage/datalake_test.go
+++ b/component/azstorage/datalake_test.go
@@ -2954,6 +2954,81 @@ func (s *datalakeTestSuite) TestBlobFilters() {
 	s.assert.NoError(err)
 }
 
+func (s *datalakeTestSuite) TestBlobTagFilter() {
+	defer s.cleanupTest()
+	dl := s.az.storage.(*Datalake)
+
+	name := generateDirectoryName()
+	err := s.az.CreateDir(internal.CreateDirOptions{Name: name})
+	s.assert.NoError(err)
+
+	type blobSpec struct {
+		path string
+		tags map[string]string
+	}
+	specs := []blobSpec{
+		{name + "/a.txt", map[string]string{"domain": "optical"}},
+		{name + "/b.txt", map[string]string{"domain": "optical", "owner": "team-a"}},
+		{name + "/c.txt", map[string]string{"domain": "radar"}},
+		{name + "/d.txt", nil},
+	}
+	for _, sp := range specs {
+		_, err = s.az.CreateFile(internal.CreateFileOptions{Name: sp.path})
+		s.assert.NoError(err)
+		if sp.tags != nil {
+			_, err = dl.Filesystem.NewFileClient(sp.path).SetTags(ctx, sp.tags, nil)
+			s.assert.NoError(err)
+		}
+	}
+
+	listAll := func() []*internal.ObjAttr {
+		out := make([]*internal.ObjAttr, 0)
+		marker := ""
+		for {
+			page, next, err := s.az.StreamDir(internal.StreamDirOptions{Name: name + "/", Token: marker, Count: 50})
+			s.assert.NoError(err)
+			out = append(out, page...)
+			marker = next
+			if marker == "" {
+				return out
+			}
+		}
+	}
+
+	s.assert.Len(listAll(), 4)
+
+	err = dl.SetFilter("tag=domain:optical")
+	s.assert.NoError(err)
+	s.assert.True(dl.Config.filterHasTag)
+	s.assert.True(dl.BlockBlob.Config.filterHasTag)
+
+	blobs := listAll()
+	s.assert.Len(blobs, 2)
+
+	got := map[string]bool{}
+	for _, b := range blobs {
+		got[filepath.Base(b.Path)] = true
+	}
+	s.assert.True(got["a.txt"])
+	s.assert.True(got["b.txt"])
+
+	_, err = dl.GetAttr(name + "/c.txt")
+	s.assert.Equal(syscall.ENOENT, err)
+
+	attr, err := dl.GetAttr(name + "/a.txt")
+	s.assert.NoError(err)
+	s.assert.NotNil(attr)
+
+	err = dl.SetFilter("name=^a.*")
+	s.assert.NoError(err)
+	s.assert.False(dl.Config.filterHasTag)
+	s.assert.False(dl.BlockBlob.Config.filterHasTag)
+
+	err = dl.SetFilter("")
+	s.assert.NoError(err)
+	s.assert.False(dl.Config.filterHasTag)
+}
+
 func (s *datalakeTestSuite) TestList() {
 	defer s.cleanupTest()
 	// Setup

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -53,6 +53,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 	serviceBfs "github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/service"
 	"github.com/Azure/azure-storage-fuse/v2/common"
@@ -643,20 +644,20 @@ func parseRangeHeader(rangeHeader string) (int64, error) {
 	return end - start + 1, nil
 }
 
-// func parseBlobTags(tags *container.BlobTags) map[string]string {
+// parseBlobTags converts the SDK BlobTags into a flat map suitable for the
+// blobfilter package. Returns nil if no tag set is present.
+func parseBlobTags(tags *container.BlobTags) map[string]string {
+	if tags == nil || len(tags.BlobTagSet) == 0 {
+		return nil
+	}
 
-// 	if tags == nil {
-// 		return nil
-// 	}
+	blobtags := make(map[string]string, len(tags.BlobTagSet))
+	for _, tag := range tags.BlobTagSet {
+		if tag == nil || tag.Key == nil || tag.Value == nil {
+			continue
+		}
+		blobtags[*tag.Key] = *tag.Value
+	}
 
-// 	blobtags := make(map[string]string)
-// 	for _, tag := range tags.BlobTagSet {
-// 		if tag != nil {
-// 			if tag.Key != nil {
-// 				blobtags[*tag.Key] = *tag.Value
-// 			}
-// 		}
-// 	}
-
-// 	return blobtags
-// }
+	return blobtags
+}

--- a/component/azstorage/utils_test.go
+++ b/component/azstorage/utils_test.go
@@ -606,8 +606,13 @@ func (s *utilsTestSuite) TestFilterReferencesTag() {
 		{"tag=domain:optical", true},
 		{"TAG=domain:optical", true},
 		{"  Tag = domain:optical", true},
+		{"tag!=domain:optical", true},
+		{"TAG!=domain:optical", true},
+		{"  Tag != domain:optical", true},
 		{"name=^foo.* && tag=key:value", true},
 		{"name=^foo.* || tag=key:value", true},
+		{"name=^foo.* && tag!=key:value", true},
+		{"name=^foo.* || tag!=key:value", true},
 		{"size>100 && name=^foo.*", false},
 	}
 

--- a/component/azstorage/utils_test.go
+++ b/component/azstorage/utils_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azdatalake/datalakeerror"
 	"github.com/Azure/azure-storage-fuse/v2/common"
 	"github.com/Azure/azure-storage-fuse/v2/common/log"
@@ -564,6 +565,54 @@ func (s *utilsTestSuite) TestParseRangeHeader() {
 			assert.NoError(err)
 			assert.Equal(test.expected, size)
 		}
+	}
+}
+
+func (s *utilsTestSuite) TestParseBlobTags() {
+	assert := assert.New(s.T())
+
+	// nil tags
+	assert.Nil(parseBlobTags(nil))
+
+	// empty tag set
+	assert.Nil(parseBlobTags(&container.BlobTags{}))
+
+	// nil key/value entries are skipped, valid entries preserved
+	k1, v1 := "domain", "optical"
+	k2, v2 := "owner", "team-a"
+	tags := &container.BlobTags{
+		BlobTagSet: []*container.BlobTag{
+			{Key: &k1, Value: &v1},
+			nil,
+			{Key: nil, Value: &v1},
+			{Key: &k2, Value: nil},
+			{Key: &k2, Value: &v2},
+		},
+	}
+	got := parseBlobTags(tags)
+	assert.Equal(map[string]string{"domain": "optical", "owner": "team-a"}, got)
+}
+
+func (s *utilsTestSuite) TestFilterReferencesTag() {
+	assert := assert.New(s.T())
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"name=^foo.*", false},
+		{"size>100", false},
+		{"tag=domain:optical", true},
+		{"TAG=domain:optical", true},
+		{"  Tag = domain:optical", true},
+		{"name=^foo.* && tag=key:value", true},
+		{"name=^foo.* || tag=key:value", true},
+		{"size>100 && name=^foo.*", false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(c.want, filterReferencesTag(c.in), "input %q", c.in)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2249. The `--filter=tag=key:value` option (config `azstorage.filter`)
silently rejected every blob because blobfuse never populated blob index tags
into the `BlobAttr` passed to `blobfilter.IsAcceptable`.

## Changes

- **List path (`block_blob.go`)**: request `Tags: true` in `listDetails`; parse
  tags from `BlobItem.BlobTags` into the local filter `BlobAttr` so list
  results are filtered correctly.
- **GetAttr path (`block_blob.go`)**: build a local `blobfilter.BlobAttr` and,
  only when the configured filter references a `tag=` clause, issue a separate
  `GetTags` call (the blob `GetProperties` response doesn't include tags).
- **`filterHasTag` flag (`connection.go`, `config.go`, `block_blob.go`)**:
  computed once from the raw filter string via `filterReferencesTag`, so the
  hot GetAttr path skips the extra round-trip when no tag clause is configured.
- **ADLS Gen2 (`config.go`)**: blob index tags are not generally available on
  hierarchical-namespace accounts. `configureBlobFilter` but preview is available
  behind a flag. hence it is supported. listBlob APi in blob endpoint is currently
  is not supported to include tags for HNS accounts, so we call getTags API
  for every blob returned by listBlob to apply the filter
- **`parseBlobTags` helper (`utils.go`)**: converts `*container.BlobTags` to
  `map[string]string`, tolerating nil entries.

## Test plan

- [ ] `TestParseBlobTags` and `TestFilterReferencesTag` (unit) pass.
- [ ] `TestBlobTagFilter` (block_blob integration) passes against a real
      Block Blob account: list and GetAttr respect `tag=domain:optical`,
      `filterHasTag` toggles correctly across `SetFilter` calls.
- [ ] Configuring `filter: tag=...` against an ADLS Gen2 account fails mount
      with a clear error.
- [ ] Existing non-tag filters (`name=`, `size=`, …) still work on both
      Block Blob and ADLS Gen2 accounts.
- [ ] `go build ./...` and `go vet ./...` clean.