### PR TITLE
Fix kernel list cache compatibility detection for older libfuse runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 **Features**
 
 **Bug Fixes**
+- Correct kernel list cache compatibility detection. Libfuse 3.5 through 3.15 expose `cache_readdir`, but versions before 3.16.1 do not forward it through the high-level `opendir` path used by blobfuse2. Blobfuse2 now enables the feature only when it was built with compatible headers, the loaded libfuse runtime is 3.16.1 or newer, and the kernel supports FUSE protocol 7.28 or newer. Stock Ubuntu 20.04, 22.04, and 24.04 ship older libfuse runtimes, so kernel list caching remains disabled there. Unsupported environments receive a warning identifying the failing compatibility layer.
 
 **Other Changes**
 - Reduce Azure Storage REST calls for single-page directory listings by avoiding per-directory marker lookups for markerless virtual directories.

--- a/azure-pipeline-templates/build-release.yml
+++ b/azure-pipeline-templates/build-release.yml
@@ -40,6 +40,25 @@ steps:
     workingDirectory: ${{ parameters.work_dir }}
     displayName: "Building Blobfuse2"
 
+  # Verify that fuse3 release headers expose cache_readdir and that blobfuse2's
+  # compatibility check recognizes the libfuse 3.16.1 forwarding boundary.
+  # Older runtimes are supported build targets; blobfuse2 detects them at mount
+  # time and disables kernel list caching with an accurate warning.
+  - script: |
+      if [[ "${{ parameters.tags }}" != "fuse3" ]]; then
+        exit 0
+      fi
+
+      fuse_version=`pkg-config --modversion fuse3`
+      echo "Building with libfuse ${fuse_version}"
+
+      gcc $(pkg-config --cflags fuse3) tools/check_kernel_list_cache.c \
+        $(pkg-config --libs fuse3) \
+        -o /tmp/check-kernel-list-cache
+      /tmp/check-kernel-list-cache
+    workingDirectory: ${{ parameters.work_dir }}
+    displayName: "Verify kernel list cache compatibility detection"
+
   # Verifying whether built binary is correct
   - script: |
       sudo chmod +x ./blobfuse2

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -371,7 +371,8 @@ stages:
 
                   echo '---------------------------------------------------'
                   echo 'Verifying kernel list cache compatibility detection'
-                  echo "Building with libfuse \$(pkg-config --modversion fuse3)"
+                  echo 'Building with libfuse:'
+                  pkg-config --modversion fuse3
                   gcc \$(pkg-config --cflags fuse3) tools/check_kernel_list_cache.c \$(pkg-config --libs fuse3) -o /tmp/check-kernel-list-cache
                   /tmp/check-kernel-list-cache
 

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -370,6 +370,12 @@ stages:
                   ./blobfuse2 --version
 
                   echo '---------------------------------------------------'
+                  echo 'Verifying kernel list cache compatibility detection'
+                  echo "Building with libfuse \$(pkg-config --modversion fuse3)"
+                  gcc \$(pkg-config --cflags fuse3) tools/check_kernel_list_cache.c \$(pkg-config --libs fuse3) -o /tmp/check-kernel-list-cache
+                  /tmp/check-kernel-list-cache
+
+                  echo '---------------------------------------------------'
                   echo 'Building health-monitor (bfusemon) binary'
                   ./build.sh health
                   chmod +x ./bfusemon

--- a/blobfuse2-release.yaml
+++ b/blobfuse2-release.yaml
@@ -370,13 +370,6 @@ stages:
                   ./blobfuse2 --version
 
                   echo '---------------------------------------------------'
-                  echo 'Verifying kernel list cache compatibility detection'
-                  echo 'Building with libfuse:'
-                  pkg-config --modversion fuse3
-                  gcc \$(pkg-config --cflags fuse3) tools/check_kernel_list_cache.c \$(pkg-config --libs fuse3) -o /tmp/check-kernel-list-cache
-                  /tmp/check-kernel-list-cache
-
-                  echo '---------------------------------------------------'
                   echo 'Building health-monitor (bfusemon) binary'
                   ./build.sh health
                   chmod +x ./bfusemon

--- a/component/libfuse/libfuse.go
+++ b/component/libfuse/libfuse.go
@@ -420,6 +420,6 @@ func init() {
 	ignoreOpenFlags := config.AddBoolFlag("ignore-open-flags", true, "Ignore unsupported open flags (APPEND, WRONLY) by blobfuse when writeback caching is enabled.")
 	config.BindPFlag(compName+".ignore-open-flags", ignoreOpenFlags)
 
-	kernelListCacheTtl := config.AddUint32Flag("kernel-list-cache-timeout", 0, "Enable kernel caching of directory listings and set TTL in seconds (fuse3 only). 0 = disabled.")
+	kernelListCacheTtl := config.AddUint32Flag("kernel-list-cache-timeout", 0, "Enable kernel caching of directory listings and set TTL in seconds (fuse3 only; requires libfuse 3.16.1+ and Linux 5.1+). 0 = disabled.")
 	config.BindPFlag(compName+".kernel-list-cache-expiration-sec", kernelListCacheTtl)
 }

--- a/component/libfuse/libfuse_compat.h
+++ b/component/libfuse/libfuse_compat.h
@@ -1,0 +1,22 @@
+#ifndef BLOBFUSE_LIBFUSE_COMPAT_H
+#define BLOBFUSE_LIBFUSE_COMPAT_H
+
+#include <stdio.h>
+
+static int libfuse_version_supports_dir_cache(const char *version)
+{
+    unsigned int major = 0;
+    unsigned int minor = 0;
+    unsigned int patch = 0;
+    char major_separator = '\0';
+    char minor_separator = '\0';
+
+    if (version == NULL ||
+        sscanf(version, "%u%c%u%c%u", &major, &major_separator, &minor, &minor_separator, &patch) != 5 ||
+        major_separator != '.' || minor_separator != '.')
+        return 0;
+
+    return major > 3 || (major == 3 && (minor > 16 || (minor == 16 && patch >= 1)));
+}
+
+#endif // BLOBFUSE_LIBFUSE_COMPAT_H

--- a/component/libfuse/libfuse_compat.h
+++ b/component/libfuse/libfuse_compat.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 
+// Kernel list caching through the high-level API requires libfuse 3.16.1 or newer.
 static int libfuse_version_supports_dir_cache(const char *version)
 {
     unsigned int major = 0;

--- a/component/libfuse/libfuse_handler.go
+++ b/component/libfuse/libfuse_handler.go
@@ -273,12 +273,25 @@ func libfuse_init(conn *C.fuse_conn_info_t, cfg *C.fuse_config_t) (res unsafe.Po
 	C.set_fuse_ptr(C.fuse_get_context().fuse)
 
 	if fuseFS.kernelListCacheTtlInSec > 0 {
-		if C.kernel_supports_dir_cache(conn) != 0 {
+		kernelListCacheSupport := C.kernel_supports_dir_cache(conn)
+		kernelListCacheSupported := true
+		if kernelListCacheSupport < 0 {
+			if kernelListCacheSupport == -2 {
+				log.Warn("Libfuse::libfuse_init : Loaded libfuse runtime does not forward cache_readdir through the high-level API (requires libfuse 3.16.1+), disabling kernel-list-cache")
+			} else {
+				log.Warn("Libfuse::libfuse_init : blobfuse2 was built against libfuse headers without cache_readdir (requires libfuse 3.5+), disabling kernel-list-cache")
+			}
+			kernelListCacheSupported = false
+		} else if kernelListCacheSupport == 0 {
+			log.Warn("Libfuse::libfuse_init : Kernel fuse proto %d.%d does not support FOPEN_CACHE_DIR (requires 7.28 / Linux 5.1+), disabling kernel-list-cache",
+				conn.proto_major, conn.proto_minor)
+			kernelListCacheSupported = false
+		}
+
+		if kernelListCacheSupported {
 			log.Info("Libfuse::libfuse_init : Kernel supports FOPEN_CACHE_DIR (fuse proto %d.%d), kernel-list-cache enabled with timeout %d sec",
 				conn.proto_major, conn.proto_minor, fuseFS.kernelListCacheTtlInSec)
 		} else {
-			log.Warn("Libfuse::libfuse_init : Kernel fuse proto %d.%d does not support FOPEN_CACHE_DIR (requires 7.28 / Linux 5.1+), disabling kernel-list-cache",
-				conn.proto_major, conn.proto_minor)
 			fuseFS.kernelListCacheTtlInSec = 0
 			if fuseFS.kernelListCacheTracker != nil {
 				fuseFS.kernelListCacheTracker.stop()

--- a/component/libfuse/libfuse_handler_test_wrapper.go
+++ b/component/libfuse/libfuse_handler_test_wrapper.go
@@ -108,14 +108,20 @@ func (suite *libfuseTestSuite) cleanupTest() {
 
 func (suite *libfuseTestSuite) TestKernelListCacheKernelSupport() {
 	conn := C.fuse_conn_info_t{}
+	conn.proto_major = 7
 	conn.proto_minor = 27
-	if C.kernel_supports_dir_cache(&conn) < 0 {
-		suite.T().Skip("cache_readdir requires libfuse 3.5 or newer")
+	support := C.kernel_supports_dir_cache(&conn)
+	if support == -1 {
+		suite.T().Skip("cache_readdir requires libfuse 3.5 or newer build headers")
+	} else if support == -2 {
+		suite.T().Skip("kernel list caching requires a libfuse 3.16.1 or newer runtime")
 	}
 
-	suite.assert.Equal(C.int(0), C.kernel_supports_dir_cache(&conn))
+	suite.assert.Equal(C.int(0), support)
 	conn.proto_minor = 28
 	suite.assert.Equal(C.int(1), C.kernel_supports_dir_cache(&conn))
+	conn.proto_major = 8
+	suite.assert.Equal(C.int(0), C.kernel_supports_dir_cache(&conn))
 }
 
 func testMkDir(suite *libfuseTestSuite) {

--- a/component/libfuse/libfuse_handler_test_wrapper.go
+++ b/component/libfuse/libfuse_handler_test_wrapper.go
@@ -111,17 +111,20 @@ func (suite *libfuseTestSuite) TestKernelListCacheKernelSupport() {
 	conn.proto_major = 7
 	conn.proto_minor = 27
 	support := C.kernel_supports_dir_cache(&conn)
-	if support == -1 {
+	switch support {
+	case -1:
 		suite.T().Skip("cache_readdir requires libfuse 3.5 or newer build headers")
-	} else if support == -2 {
+	case -2:
 		suite.T().Skip("kernel list caching requires a libfuse 3.16.1 or newer runtime")
 	}
 
 	suite.assert.Equal(C.int(0), support)
 	conn.proto_minor = 28
-	suite.assert.Equal(C.int(1), C.kernel_supports_dir_cache(&conn))
+	support = C.kernel_supports_dir_cache(&conn)
+	suite.assert.Equal(C.int(1), support)
 	conn.proto_major = 8
-	suite.assert.Equal(C.int(0), C.kernel_supports_dir_cache(&conn))
+	support = C.kernel_supports_dir_cache(&conn)
+	suite.assert.Equal(C.int(0), support)
 }
 
 func testMkDir(suite *libfuseTestSuite) {

--- a/component/libfuse/libfuse_handler_test_wrapper.go
+++ b/component/libfuse/libfuse_handler_test_wrapper.go
@@ -106,6 +106,18 @@ func (suite *libfuseTestSuite) cleanupTest() {
 	suite.mockCtrl.Finish()
 }
 
+func (suite *libfuseTestSuite) TestKernelListCacheKernelSupport() {
+	conn := C.fuse_conn_info_t{}
+	conn.proto_minor = 27
+	if C.kernel_supports_dir_cache(&conn) < 0 {
+		suite.T().Skip("cache_readdir requires libfuse 3.5 or newer")
+	}
+
+	suite.assert.Equal(C.int(0), C.kernel_supports_dir_cache(&conn))
+	conn.proto_minor = 28
+	suite.assert.Equal(C.int(1), C.kernel_supports_dir_cache(&conn))
+}
+
 func testMkDir(suite *libfuseTestSuite) {
 	defer suite.cleanupTest()
 	name := "path"

--- a/component/libfuse/libfuse_handler_test_wrapper.go
+++ b/component/libfuse/libfuse_handler_test_wrapper.go
@@ -124,7 +124,7 @@ func (suite *libfuseTestSuite) TestKernelListCacheKernelSupport() {
 	suite.assert.Equal(C.int(1), support)
 	conn.proto_major = 8
 	support = C.kernel_supports_dir_cache(&conn)
-	suite.assert.Equal(C.int(0), support)
+	suite.assert.Equal(C.int(1), support)
 }
 
 func testMkDir(suite *libfuseTestSuite) {

--- a/component/libfuse/libfuse_wrapper.h
+++ b/component/libfuse/libfuse_wrapper.h
@@ -213,13 +213,13 @@ static void set_fuse_ptr(struct fuse *f) {
  * Although the field was added in 3.5, the high-level opendir path did not
  * forward it to the kernel until libfuse 3.16.1. There is no FUSE_CAP_* flag
  * for this feature, so the kernel check uses the negotiated FUSE protocol
- * minor version instead.
+ * version instead.
  *
  * FOPEN_CACHE_DIR was introduced in Linux 5.1 together with FUSE protocol
  * version 7.28 (FUSE_KERNEL_MINOR_VERSION 28 in include/uapi/linux/fuse.h).
- * Kernels older than 5.1 negotiate a proto_minor < 28 and silently ignore the
- * cache_readdir bit, so we disable the feature rather than leaving the user
- * wondering why their listing cache has no effect.
+ * Kernels older than 5.1 negotiate a protocol below 7.28 and silently ignore
+ * the cache_readdir bit, so we disable the feature rather than leaving the
+ * user wondering why their listing cache has no effect.
  */
 static int kernel_supports_dir_cache(fuse_conn_info_t *conn) {
 #if !LIBFUSE_HAS_CACHE_READDIR
@@ -229,7 +229,7 @@ static int kernel_supports_dir_cache(fuse_conn_info_t *conn) {
     if (!libfuse_version_supports_dir_cache(fuse_pkgversion()))
         return -2;
 
-    return conn->proto_minor >= 28;
+    return conn->proto_major == 7 && conn->proto_minor >= 28;
 #endif
 }
 

--- a/component/libfuse/libfuse_wrapper.h
+++ b/component/libfuse/libfuse_wrapper.h
@@ -51,23 +51,19 @@
 #include <fuse.h>
 #else
 #include <fuse3/fuse.h>
+#include "libfuse_compat.h"
 #endif
 
 /*
- * cache_readdir in fuse_file_info was added in libfuse 3.5.0.
- * Older distro packages (e.g. libfuse 3.2 on CentOS 8.5, 3.3 on RHEL 8.6)
- * do not expose this field, so writing it causes compilation failures.
+ * cache_readdir and FUSE_CAP_NO_OPENDIR_SUPPORT were both added in libfuse
+ * 3.5.0. Older distro packages do not expose the field, so writing it causes
+ * compilation failures.
  *
- * NOTE: FUSE_MAJOR_VERSION / FUSE_MINOR_VERSION are the *libfuse library*
- * version macros (defined in the generated libfuse_config.h, included
- * transitively through fuse3/fuse.h).  They are NOT the kernel module
- * protocol version (those are FUSE_KERNEL_VERSION / FUSE_KERNEL_MINOR_VERSION
- * in linux/fuse.h).  On distros that ship a pre-3.5 libfuse package the
- * macros will still be present (libfuse_config.h is always generated), so
- * this check reliably detects the installed library version at build time.
+ * Do not use FUSE_MAJOR_VERSION / FUSE_MINOR_VERSION here. Before libfuse
+ * 3.10, those macros described the public interface version rather than the
+ * package version; libfuse 3.5 through 3.9 therefore reported version 3.2.
  */
-#if !defined(__FUSE2__) && defined(FUSE_MAJOR_VERSION) && defined(FUSE_MINOR_VERSION) && \
-    ((FUSE_MAJOR_VERSION > 3) || (FUSE_MAJOR_VERSION == 3 && FUSE_MINOR_VERSION >= 5))
+#if !defined(__FUSE2__) && defined(FUSE_CAP_NO_OPENDIR_SUPPORT)
 #define LIBFUSE_HAS_CACHE_READDIR 1
 #else
 #define LIBFUSE_HAS_CACHE_READDIR 0
@@ -211,9 +207,13 @@ static void set_fuse_ptr(struct fuse *f) {
 }
 
 /*
- * Returns 1 if the kernel supports FOPEN_CACHE_DIR (the cache_readdir bit in
- * fuse_file_info).  There is no FUSE_CAP_* flag for this feature, so we gate
- * on the negotiated FUSE protocol minor version instead.
+ * Returns 1 when FOPEN_CACHE_DIR is supported, 0 when the kernel does not
+ * support it, -1 when the build headers do not expose cache_readdir, and -2
+ * when the loaded libfuse runtime predates high-level cache_readdir support.
+ * Although the field was added in 3.5, the high-level opendir path did not
+ * forward it to the kernel until libfuse 3.16.1. There is no FUSE_CAP_* flag
+ * for this feature, so the kernel check uses the negotiated FUSE protocol
+ * minor version instead.
  *
  * FOPEN_CACHE_DIR was introduced in Linux 5.1 together with FUSE protocol
  * version 7.28 (FUSE_KERNEL_MINOR_VERSION 28 in include/uapi/linux/fuse.h).
@@ -224,14 +224,12 @@ static void set_fuse_ptr(struct fuse *f) {
 static int kernel_supports_dir_cache(fuse_conn_info_t *conn) {
 #if !LIBFUSE_HAS_CACHE_READDIR
     (void)conn;
-    return 0;
+    return -1;
 #else
-#ifdef FUSE_CAP_CACHE_READDIR
-    /* Use the capability bit if a future libfuse version defines it. */
-    return (conn->capable & FUSE_CAP_CACHE_READDIR) != 0;
-#else
+    if (!libfuse_version_supports_dir_cache(fuse_pkgversion()))
+        return -2;
+
     return conn->proto_minor >= 28;
-#endif
 #endif
 }
 

--- a/component/libfuse/libfuse_wrapper.h
+++ b/component/libfuse/libfuse_wrapper.h
@@ -229,7 +229,7 @@ static int kernel_supports_dir_cache(fuse_conn_info_t *conn) {
     if (!libfuse_version_supports_dir_cache(fuse_pkgversion()))
         return -2;
 
-    return conn->proto_major == 7 && conn->proto_minor >= 28;
+    return conn->proto_major > 7 || (conn->proto_major == 7 && conn->proto_minor >= 28);
 #endif
 }
 

--- a/sampleBlockCacheConfig.yaml
+++ b/sampleBlockCacheConfig.yaml
@@ -14,7 +14,6 @@ libfuse:
   attribute-expiration-sec: 120
   entry-expiration-sec: 120
   negative-entry-expiration-sec: 240
-  kernel-list-cache-expiration-sec: 120
 
 block_cache:
   block-size-mb: 32

--- a/sampleFileCacheConfig.yaml
+++ b/sampleFileCacheConfig.yaml
@@ -14,7 +14,6 @@ libfuse:
   attribute-expiration-sec: 120
   entry-expiration-sec: 120
   negative-entry-expiration-sec: 240
-  kernel-list-cache-expiration-sec: 120
 
 file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>

--- a/sampleFileCacheWithSASConfig.yaml
+++ b/sampleFileCacheWithSASConfig.yaml
@@ -14,7 +14,6 @@ libfuse:
   attribute-expiration-sec: 120
   entry-expiration-sec: 120
   negative-entry-expiration-sec: 240
-  kernel-list-cache-expiration-sec: 120
 
 file_cache:
   path: /<PATH>/<TO>/<CACHE_DIR>

--- a/setup/advancedConfig.yaml
+++ b/setup/advancedConfig.yaml
@@ -70,6 +70,8 @@ libfuse:
   fuse-trace: true|false <enable libfuse api trace logs for debugging>
   extension: <physical path to extension library>
   direct-io: true|false <enable to bypass the kernel cache. It also disables blobfuse2 data and metadata caching. Default - false>
+  # Requires libfuse 3.16.1+ and FUSE protocol 7.28 / Linux 5.1+.
+  # Stock Ubuntu 20.04, 22.04, and 24.04 ship older libfuse versions.
   kernel-list-cache-expiration-sec: <enable kernel caching of directory listings and set TTL in seconds (fuse3 only). 0 = disabled. Default - 120 sec>
 
 # Entry Cache configuration

--- a/tools/check_kernel_list_cache.c
+++ b/tools/check_kernel_list_cache.c
@@ -1,0 +1,37 @@
+#define FUSE_USE_VERSION 39
+#define _FILE_OFFSET_BITS 64
+
+#include <fuse.h>
+#include "../component/libfuse/libfuse_compat.h"
+
+#ifndef FUSE_CAP_NO_OPENDIR_SUPPORT
+#error "FUSE_CAP_NO_OPENDIR_SUPPORT is required"
+#endif
+
+int main(void)
+{
+    const char *runtime_version = fuse_pkgversion();
+    struct fuse_file_info file_info = {0};
+
+    if (libfuse_version_supports_dir_cache("3.5.0") ||
+        libfuse_version_supports_dir_cache("3.16.0") ||
+        !libfuse_version_supports_dir_cache("3.16.1") ||
+        !libfuse_version_supports_dir_cache("3.18.0-rc0") ||
+        libfuse_version_supports_dir_cache("invalid"))
+        return 1;
+
+    file_info.cache_readdir = 1;
+    if (file_info.cache_readdir != 1)
+        return 1;
+
+    if (libfuse_version_supports_dir_cache(runtime_version)) {
+        printf("libfuse runtime %s forwards cache_readdir through the high-level API\n",
+               runtime_version);
+    } else {
+        printf("libfuse runtime %s does not forward cache_readdir; "
+               "blobfuse2 will disable kernel list caching\n",
+               runtime_version != NULL ? runtime_version : "unknown");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This change corrects how Blobfuse2 detects support for kernel directory-list caching.

Detects cache_readdir header availability without relying on misleading libfuse version macros.
Requires libfuse 3.16.1+ at runtime because earlier versions do not forward cache_readdir through the high-level opendir API.
Separately reports unsupported build headers, libfuse runtime, and kernel FUSE protocol.
Keeps release builds working with older libfuse versions while validating compatibility detection in CI.
Removes kernel list caching from sample configurations because most supported distributions do not currently provide a compatible libfuse runtime.
Documents the libfuse 3.16.1+ and Linux 5.1+/FUSE 7.28 requirements.
Stock Ubuntu 20.04, 22.04, and 24.04 remain supported, but kernel list caching is disabled there with an accurate warning.

Validation

FUSE2 and FUSE3 unit suites pass.
Compatibility probe passes with both libfuse 3.9 and 3.18.
Release pipeline YAML and sample configurations parse successfully.
