### PR TITLE
Mahsaini/blobfuse distributedcache ux

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -287,7 +287,7 @@ var mountCmd = &cobra.Command{
 		}
 
 		// Accept "distributed_cache" as an alias for "dist_cache" in components:
-                options.Components = aliasDistributedCacheComponent(options.Components)
+		options.Components = aliasDistributedCacheComponent(options.Components)
 
 		// Reject mixed dist_cache/L1 configs and fan out dist_cache tuning
 		// knobs onto block_cache. Runs before synthesis so it sees the user's
@@ -867,18 +867,17 @@ func normalizeDistCacheConfig(userComponents []string) error {
 	return nil
 }
 
-
 // aliasDistributedCacheComponent rewrites any "distributed_cache" entry in
 // the user's components list to the internal component name "dist_cache".
 // The registry only knows "dist_cache"; accepting "distributed_cache" here
 // keeps the user-facing YAML consistent with the section name.
 func aliasDistributedCacheComponent(components []string) []string {
-    for i, c := range components {
-        if c == "distributed_cache" {
-            components[i] = "dist_cache"
-        }
-    }
-    return components
+	for i, c := range components {
+		if c == "distributed_cache" {
+			components[i] = "dist_cache"
+		}
+	}
+	return components
 }
 
 // injectBlockCacheForDistCache splices block_cache in immediately before

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -94,6 +94,7 @@ type mountOptions struct {
 
 	// v1 support
 	Streaming         bool     `config:"streaming"`
+	DistributedCache  bool     `config:"distributed-cache"`
 	AttrCache         bool     `config:"use-attr-cache"`
 	LibfuseOptions    []string `config:"libfuse-options"`
 	BlockCache        bool     `config:"block-cache"`
@@ -285,6 +286,9 @@ var mountCmd = &cobra.Command{
 			return fmt.Errorf("failed to unmarshal config [%s]", err.Error())
 		}
 
+		// Accept "distributed_cache" as an alias for "dist_cache" in components:
+                options.Components = aliasDistributedCacheComponent(options.Components)
+
 		// Reject mixed dist_cache/L1 configs and fan out dist_cache tuning
 		// knobs onto block_cache. Runs before synthesis so it sees the user's
 		// original components list.
@@ -301,7 +305,7 @@ var mountCmd = &cobra.Command{
 				pipeline = append(pipeline, "block_cache")
 			} else if options.Preload {
 				pipeline = append(pipeline, "xload")
-			} else if config.IsSet("dist_cache") {
+			} else if config.IsSet("distributed-cache") && options.DistributedCache {
 				pipeline = append(pipeline, "dist_cache") // L2 cache
 			} else {
 				pipeline = append(pipeline, "file_cache")
@@ -809,17 +813,25 @@ func normalizeDistCacheConfig(userComponents []string) error {
 	// that omits dist_cache is silently ignored (matching how the codebase
 	// treats stray block_cache:/file_cache: sections).
 	userWantsDistCache := common.ComponentInPipeline(userComponents, "dist_cache") ||
-		(len(userComponents) == 0 && config.IsSet("dist_cache"))
+		(len(userComponents) == 0 && config.IsSet("distributed-cache"))
 	if !userWantsDistCache {
 		return nil
 	}
 
+	//readonly check
+	var readOnly bool
+	if err := config.UnmarshalKey("read-only", &readOnly); err != nil {
+		return fmt.Errorf("mount: failed to read read-only flag: %w", err)
+	}
+	if !readOnly {
+		return fmt.Errorf("mount: distributed cache is allowed only for read-only mounts; pass --read-only or set read-only: true in the config file")
+	}
 	// Reject any sibling L1 cache signal, whether in components: or as a
 	// top-level section.
 	incompatible := []string{"block_cache", "file_cache", "xload", "stream"}
 	for _, name := range incompatible {
 		if common.ComponentInPipeline(userComponents, name) || config.IsSet(name) {
-			return fmt.Errorf("mount: dist_cache is incompatible with %s; dist_cache uses block_cache as its L1 and cannot coexist with another L1 cache. Remove %s from components: and any %s: section", name, name, name)
+			return fmt.Errorf("mount: distributed_cache is a single configuration surface, remove %s from components: and any %s: section", name, name)
 		}
 	}
 
@@ -827,10 +839,20 @@ func normalizeDistCacheConfig(userComponents []string) error {
 	// block_cache defaults. Round-tripping through string relies on viper's
 	// weak-typed coercion when BlockCache reads its config.
 	fanout := []struct{ src, dst string }{
-		{"dist_cache.block-size-mb", "block_cache.block-size-mb"},
-		{"dist_cache.mem-size-mb", "block_cache.mem-size-mb"},
-		{"dist_cache.prefetch", "block_cache.prefetch"},
-		{"dist_cache.parallelism", "block_cache.parallelism"},
+		// L1 tuning fanned out to block_cache
+		{"distributed_cache.block-size-mb", "block_cache.block-size-mb"},
+		{"distributed_cache.mem-size-mb", "block_cache.mem-size-mb"},
+		{"distributed_cache.prefetch", "block_cache.prefetch"},
+		{"distributed_cache.parallelism", "block_cache.parallelism"},
+		// Native dist_cache knobs — user writes them under distributed_cache:
+		// but the component reads them from dist_cache.*.
+		{"distributed_cache.discovery-url", "dist_cache.discovery-url"},
+		{"distributed_cache.k8s-service", "dist_cache.k8s-service"},
+		{"distributed_cache.k8s-namespace", "dist_cache.k8s-namespace"},
+		{"distributed_cache.servers", "dist_cache.server-list"},
+		{"distributed_cache.port", "dist_cache.port"},
+		{"distributed_cache.ttl-seconds", "dist_cache.ttl-seconds"},
+		{"distributed_cache.verify-checksum", "dist_cache.verify-checksum"},
 	}
 	for _, m := range fanout {
 		if !config.IsSet(m.src) {
@@ -843,6 +865,20 @@ func normalizeDistCacheConfig(userComponents []string) error {
 		config.Set(m.dst, v)
 	}
 	return nil
+}
+
+
+// aliasDistributedCacheComponent rewrites any "distributed_cache" entry in
+// the user's components list to the internal component name "dist_cache".
+// The registry only knows "dist_cache"; accepting "distributed_cache" here
+// keeps the user-facing YAML consistent with the section name.
+func aliasDistributedCacheComponent(components []string) []string {
+    for i, c := range components {
+        if c == "distributed_cache" {
+            components[i] = "dist_cache"
+        }
+    }
+    return components
 }
 
 // injectBlockCacheForDistCache splices block_cache in immediately before
@@ -978,6 +1014,9 @@ func init() {
 	mountCmd.Flags().BoolVar(&options.Streaming, "streaming", false, "Enable Streaming.")
 	config.BindPFlag("streaming", mountCmd.Flags().Lookup("streaming"))
 	mountCmd.Flags().Lookup("streaming").Hidden = true
+
+	mountCmd.Flags().BoolVar(&options.DistributedCache, "distributed-cache", false, "Enable Distributed-Cache.")
+	config.BindPFlag("distributed-cache", mountCmd.Flags().Lookup("distributed-cache"))
 
 	mountCmd.Flags().BoolVar(&options.BlockCache, "block-cache", false, "Enable Block-Cache.")
 	config.BindPFlag("block-cache", mountCmd.Flags().Lookup("block-cache"))

--- a/cmd/mount_dist_cache_test.go
+++ b/cmd/mount_dist_cache_test.go
@@ -121,7 +121,7 @@ components:
 }
 
 func TestNormalizeDistCacheConfig_DistCacheOnlyInComponents(t *testing.T) {
-	// dist_cache in components: but no distributed_cache: section.
+	// distributed_cache in components: but no distributed_cache: section.
 	// Normalize should succeed and touch no block_cache keys.
 	setDistCacheYAML(t, `
 read-only: true
@@ -137,21 +137,21 @@ components:
 	assert.False(t, viper.IsSet("block_cache.block-size-mb"))
 }
 
-func TestNormalizeDistCacheConfig_DistCacheViaCLIFlagWithoutComponents(t *testing.T) {
-	// components: omitted and the --distributed-cache CLI flag is set:
-	// synthesis path in mount.go adds dist_cache to the pipeline, so
-	// normalize must run its checks and fanout.
+func TestNormalizeDistCacheConfig_DistCacheSectionWithoutComponents(t *testing.T) {
+       // dist_cache: set but components: omitted — the synthesis-path case.
 	setDistCacheYAML(t, `
 read-only: true
 distributed_cache:
   discovery-endpoint: d
 `)
 	defer viper.Reset()
-	config.Set("distributed-cache", "true")
 
 	err := normalizeDistCacheConfig(nil)
 	assert.NoError(t, err)
 }
+// A distributed_cache: section alongside an explicit components: that omits
+// distributed_cache is silently ignored, matching how the codebase treats stray
+// block_cache:/file_cache: sections. Normalize must not raise a
 
 // --- read-only gating --------------------------------------------------------
 
@@ -461,7 +461,7 @@ distributed_cache:
 `)
 	defer viper.Reset()
 
-	err := normalizeDistCacheConfig([]string{"libfuse", "dist_cache", "azstorage"})
+	err := normalizeDistCacheConfig(nil)
 	assert.NoError(t, err)
 
 	assert.True(t, viper.IsSet("block_cache.block-size-mb"))

--- a/cmd/mount_dist_cache_test.go
+++ b/cmd/mount_dist_cache_test.go
@@ -138,7 +138,7 @@ components:
 }
 
 func TestNormalizeDistCacheConfig_DistCacheSectionWithoutComponents(t *testing.T) {
-       // dist_cache: set but components: omitted — the synthesis-path case.
+	// dist_cache: set but components: omitted — the synthesis-path case.
 	setDistCacheYAML(t, `
 read-only: true
 distributed_cache:
@@ -149,6 +149,7 @@ distributed_cache:
 	err := normalizeDistCacheConfig(nil)
 	assert.NoError(t, err)
 }
+
 // A distributed_cache: section alongside an explicit components: that omits
 // distributed_cache is silently ignored, matching how the codebase treats stray
 // block_cache:/file_cache: sections. Normalize must not raise a
@@ -461,7 +462,7 @@ distributed_cache:
 `)
 	defer viper.Reset()
 
-	err := normalizeDistCacheConfig(nil)
+	err := normalizeDistCacheConfig([]string{"libfuse", "dist_cache", "azstorage"})
 	assert.NoError(t, err)
 
 	assert.True(t, viper.IsSet("block_cache.block-size-mb"))

--- a/cmd/mount_dist_cache_test.go
+++ b/cmd/mount_dist_cache_test.go
@@ -102,6 +102,7 @@ func setDistCacheYAML(t *testing.T, yaml string) {
 
 func TestNormalizeDistCacheConfig_NoDistCacheSignal(t *testing.T) {
 	setDistCacheYAML(t, `
+read-only: true
 azstorage:
   account-name: acct
   container: c
@@ -121,9 +122,10 @@ components:
 }
 
 func TestNormalizeDistCacheConfig_DistCacheOnlyInComponents(t *testing.T) {
-	// dist_cache in components: but no dist_cache: section. Normalize
+	// dist_cache in components: but no distributed_cache: section. Normalize
 	// should succeed and touch no block_cache keys.
 	setDistCacheYAML(t, `
+read-only: true
 components:
   - libfuse
   - dist_cache
@@ -137,9 +139,12 @@ components:
 }
 
 func TestNormalizeDistCacheConfig_DistCacheSectionWithoutComponents(t *testing.T) {
-	// dist_cache: set but components: omitted — the synthesis-path case.
+	// distributed_cache: set but components: omitted — the synthesis-path case.
+	// The CLI flag "distributed-cache" is the activation signal checked here.
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed-cache: true
+distributed_cache:
   discovery-url: http://d
 `)
 	defer viper.Reset()
@@ -148,13 +153,14 @@ dist_cache:
 	assert.NoError(t, err)
 }
 
-// A dist_cache: section alongside an explicit components: that omits
+// A distributed_cache: section alongside an explicit components: that omits
 // dist_cache is silently ignored, matching how the codebase treats stray
 // block_cache:/file_cache: sections. Normalize must not raise a
 // misleading "incompatible" error against the L1 the user actually chose.
 func TestNormalizeDistCacheConfig_StaleSectionWithOtherL1IsNoop(t *testing.T) {
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 file_cache:
   path: /tmp/fc
@@ -174,7 +180,8 @@ components:
 func TestNormalizeDistCacheConfig_StaleSectionNoL1IsNoop(t *testing.T) {
 	// Explicit components: without dist_cache; stray section ignored.
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
   block-size-mb: 32
 components:
@@ -190,19 +197,21 @@ components:
 
 func TestNormalizeDistCacheConfig_RejectsBlockCacheInComponents(t *testing.T) {
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 `)
 	defer viper.Reset()
 
 	err := normalizeDistCacheConfig([]string{"libfuse", "block_cache", "dist_cache", "azstorage"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "incompatible with block_cache")
+	assert.Contains(t, err.Error(), "block_cache")
 }
 
 func TestNormalizeDistCacheConfig_RejectsBlockCacheSection(t *testing.T) {
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 block_cache:
   block-size-mb: 8
@@ -211,12 +220,13 @@ block_cache:
 
 	err := normalizeDistCacheConfig([]string{"libfuse", "dist_cache", "azstorage"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "incompatible with block_cache")
+	assert.Contains(t, err.Error(), "block_cache")
 }
 
 func TestNormalizeDistCacheConfig_RejectsBothSurfaces(t *testing.T) {
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 block_cache:
   block-size-mb: 8
@@ -230,7 +240,7 @@ components:
 
 	err := normalizeDistCacheConfig([]string{"libfuse", "block_cache", "dist_cache", "azstorage"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "incompatible with block_cache")
+	assert.Contains(t, err.Error(), "block_cache")
 }
 
 // Other L1 caches (file_cache, xload, stream) are incompatible because
@@ -240,14 +250,15 @@ func TestNormalizeDistCacheConfig_RejectsOtherL1InComponents(t *testing.T) {
 	for _, name := range []string{"file_cache", "xload", "stream"} {
 		t.Run(name, func(t *testing.T) {
 			setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 `)
 			defer viper.Reset()
 
 			err := normalizeDistCacheConfig([]string{"libfuse", name, "dist_cache", "azstorage"})
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "incompatible with "+name)
+			assert.Contains(t, err.Error(), name)
 		})
 	}
 }
@@ -260,7 +271,8 @@ func TestNormalizeDistCacheConfig_RejectsOtherL1Sections(t *testing.T) {
 		{
 			name: "file_cache",
 			yaml: `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 file_cache:
   path: /tmp/fc
@@ -269,7 +281,8 @@ file_cache:
 		{
 			name: "xload",
 			yaml: `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 xload:
   path: /tmp/xl
@@ -278,7 +291,8 @@ xload:
 		{
 			name: "stream",
 			yaml: `
-dist_cache:
+read-only: true
+distributed_cache:
   discovery-url: http://d
 stream:
   block-size-mb: 16
@@ -292,14 +306,16 @@ stream:
 
 			err := normalizeDistCacheConfig([]string{"libfuse", "dist_cache", "azstorage"})
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "incompatible with "+tc.name)
+			assert.Contains(t, err.Error(), tc.name)
 		})
 	}
 }
 
 func TestNormalizeDistCacheConfig_FansOutTuningKnobs(t *testing.T) {
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed-cache: true
+distributed_cache:
   discovery-url: http://d
   block-size-mb: 32
   mem-size-mb: 4096
@@ -333,7 +349,9 @@ func TestNormalizeDistCacheConfig_UnsetKnobsAreNotForwarded(t *testing.T) {
 	// Only block-size-mb is set; the other three targets must remain unset
 	// so block_cache falls back to its own defaults.
 	setDistCacheYAML(t, `
-dist_cache:
+read-only: true
+distributed-cache: true
+distributed_cache:
   discovery-url: http://d
   block-size-mb: 32
 `)
@@ -346,4 +364,36 @@ dist_cache:
 	assert.False(t, viper.IsSet("block_cache.mem-size-mb"))
 	assert.False(t, viper.IsSet("block_cache.prefetch"))
 	assert.False(t, viper.IsSet("block_cache.parallelism"))
+}
+
+func TestNormalizeDistCache_RequiresReadOnly(t *testing.T) {
+	setDistCacheYAML(t, `
+components:
+  - libfuse
+  - dist_cache
+  - azstorage
+distributed_cache:
+  discovery-url: http://foo:9065
+`)
+	defer viper.Reset()
+
+	err := normalizeDistCacheConfig([]string{"libfuse", "dist_cache", "azstorage"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "read-only")
+}
+
+func TestNormalizeDistCache_ReadOnlyPasses(t *testing.T) {
+	setDistCacheYAML(t, `
+read-only: true
+components:
+  - libfuse
+  - dist_cache
+  - azstorage
+distributed_cache:
+  discovery-url: http://foo:9065
+`)
+	defer viper.Reset()
+
+	err := normalizeDistCacheConfig([]string{"libfuse", "dist_cache", "azstorage"})
+	assert.NoError(t, err)
 }

--- a/component/dist_cache/dist_cache.go
+++ b/component/dist_cache/dist_cache.go
@@ -95,7 +95,7 @@ type DistCacheOptions struct {
 	K8sNamespace string `config:"k8s-namespace" yaml:"k8s-namespace,omitempty"`
 
 	// Static fallback
-	ServerList string `config:"server-list" yaml:"server-list,omitempty"`
+	ServerList string `config:"server-list" yaml:"servers,omitempty"`
 
 	// Common options
 	Port       int    `config:"port"        yaml:"port,omitempty"`        // Default 9065
@@ -158,7 +158,7 @@ func (dc *DistCache) Configure(isParent bool) error {
 
 	// At least one discovery method must be set (YAML, CLI flag, or env).
 	if conf.DiscoveryURL == "" && conf.K8sService == "" && conf.ServerList == "" {
-		return fmt.Errorf("dist_cache: no server discovery configured (set discovery-url, k8s-service, or server-list)")
+		return fmt.Errorf("distributed_cache: no server discovery configured (set endpoint, k8s-service, or server-list)")
 	}
 
 	// Warn if multiple discovery methods are configured. The dcache client
@@ -635,13 +635,32 @@ func (dc *DistCache) doUpload(name, etag string, offset int64, buf *[]byte, leng
 func init() {
 	internal.AddComponent(compName, NewDistCacheComponent)
 
-	discoveryFlag := config.AddStringFlag("dist-cache-discovery-url", "",
-		"distributed cache discovery endpoint (recommended)")
+	discoveryFlag := config.AddStringFlag("distributed-cache-discovery-url", "",
+	"distributed cache discovery URL")
 	config.BindPFlag(compName+".discovery-url", discoveryFlag)
 
-	serverListFlag := config.AddStringFlag("dist-cache-server-list", "",
-		"comma-separated list of distributed cache server addresses (fallback)")
-	config.BindPFlag(compName+".server-list", serverListFlag)
+	ttlFlag := config.AddUint32Flag("distributed-cache-ttl", 0,
+		"distributed cache entry TTL in seconds (0 = no TTL)")
+	config.BindPFlag(compName+".ttl-seconds", ttlFlag)
+
+	// L1 (block_cache) knobs surfaced under the distributed-cache name; the
+	// fan-out in cmd/mount.go copies these onto block_cache when dist_cache
+	// is active in the pipeline.
+	blockSizeFlag := config.AddUint32Flag("distributed-cache-block-size", 0,
+		"block size in MB for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.block-size-mb", blockSizeFlag)
+
+	memFlag := config.AddUint32Flag("distributed-cache-memory", 0,
+		"memory size in MB for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.mem-size-mb", memFlag)
+
+	prefetchFlag := config.AddUint32Flag("distributed-cache-prefetch", 0,
+		"prefetch block count for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.prefetch", prefetchFlag)
+
+	parallelismFlag := config.AddUint32Flag("distributed-cache-parallelism", 0,
+		"download parallelism for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.parallelism", parallelismFlag)
 
 	RegisterEnvVariables()
 }

--- a/component/dist_cache/dist_cache.go
+++ b/component/dist_cache/dist_cache.go
@@ -111,8 +111,8 @@ type DistCacheOptions struct {
 // providing a shared distributed cache layer across nodes.
 type DistCache struct {
 	internal.BaseComponent
-	conf   DistCacheOptions
-	client dcacheClient
+	conf          DistCacheOptions
+	client        dcacheClient
 	chunkSize     int64
 	cachePrefix   string
 	bypassOnError bool
@@ -641,24 +641,24 @@ func init() {
 	config.BindPFlag(compName+".discovery-endpoint", discoveryFlag)
 
 	ttlFlag := config.AddUint32Flag("distributed-cache-ttl", 0,
-                "distributed cache entry TTL in seconds (0 = no TTL)")
-        config.BindPFlag(compName+".ttl-seconds", ttlFlag)
+		"distributed cache entry TTL in seconds (0 = no TTL)")
+	config.BindPFlag(compName+".ttl-seconds", ttlFlag)
 
-blockSizeFlag := config.AddUint32Flag("distributed-cache-block-size", 0,
-    "block size in MB for the distributed cache L1 (block_cache)")
-config.BindPFlag("block_cache.block-size-mb", blockSizeFlag)
+	blockSizeFlag := config.AddUint32Flag("distributed-cache-block-size", 0,
+		"block size in MB for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.block-size-mb", blockSizeFlag)
 
-memFlag := config.AddUint32Flag("distributed-cache-memory", 0,
-    "memory size in MB for the distributed cache L1 (block_cache)")
-config.BindPFlag("block_cache.mem-size-mb", memFlag)
+	memFlag := config.AddUint32Flag("distributed-cache-memory", 0,
+		"memory size in MB for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.mem-size-mb", memFlag)
 
-prefetchFlag := config.AddUint32Flag("distributed-cache-prefetch", 0,
-    "prefetch block count for the distributed cache L1 (block_cache)")
-config.BindPFlag("block_cache.prefetch", prefetchFlag)
+	prefetchFlag := config.AddUint32Flag("distributed-cache-prefetch", 0,
+		"prefetch block count for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.prefetch", prefetchFlag)
 
-parallelismFlag := config.AddUint32Flag("distributed-cache-parallelism", 0,
-    "download parallelism for the distributed cache L1 (block_cache)")
-config.BindPFlag("block_cache.parallelism", parallelismFlag)
+	parallelismFlag := config.AddUint32Flag("distributed-cache-parallelism", 0,
+		"download parallelism for the distributed cache L1 (block_cache)")
+	config.BindPFlag("block_cache.parallelism", parallelismFlag)
 
 	RegisterEnvVariables()
 


### PR DESCRIPTION
**UX for Blobfuse Tachyon Integration**

This PR improves the user experience for integrating Blobfuse with Tachyon's distributed cache by exposing configuration options through the CLI and YAML configuration.

**Changes**
Added CLI support for distributed cache configuration:

- --distributed-cache
- --dist-cache-discovery-endpoint
- --distributed-cache-block-size
- --distributed-cache-memory
- --distributed-cache-parallelism
- --distributed-cache-prefetch
- --distributed-cache-ttl

Added advanced distributed cache configuration options through YAML:

- discovery-endpoint
- servers
- k8s-service
- k8s-namespace
- block-size-mb
- mem-size-mb
- prefetch
- parallelism
- ttl-seconds
- port
- verify-checksum

Ensured that mounts using the distributed cache are allowed only in read-only mode by adding and enforcing the read-only mount requirement.
Standardized the terminology and naming conventions for distributed_cache across all user-facing configuration surfaces, including CLI flags and YAML configuration.


**Testing**

- Added/updated unit tests and verified existing test suites.
- Performed manual testing using a local setup with a running Tachyon cluster.

<!--
Thank you for contributing to the Blobfuse2.
Please verify the following before submitting your PR, thank you!
-->
## Type of Change
<!-- Place an 'x' in the relevant box(es) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Code quality improvement
- [ ] Other (describe):

## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->

- **Feature / Bug Fix**:


## How Has This Been Tested?
<!-- Describe the testing strategy and any relevant details. Include information on how the change was tested (e.g., unit tests, integration tests, manual testing). If tests were added, specify what scenarios they cover. -->

## Checklist
<!-- Place an 'x' in the relevant box(es) -->
- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Documentation update required.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] License headers are included in each file.

## Related Links
- [Issues](<link>)
<!--  please add the following info if they were relavant to the PR.
- [Documents](<link>)
- [Email Subject]
-->
