### PR TITLE
Fix az CLI install failure on Ubuntu 26 in nightly pipeline

### DIFF
--- a/azure-pipeline-templates/package-install.yml
+++ b/azure-pipeline-templates/package-install.yml
@@ -34,7 +34,7 @@ steps:
       if ! command -v az >/dev/null 2>&1; then
         echo "AzCli deb install failed (likely unsupported distro codename), falling back to pip install"
         sudo apt-get install -y python3 python3-venv
-        sudo python3 -m venv /opt/azure-cli
+        sudo python3 -m venv --clear /opt/azure-cli
         sudo /opt/azure-cli/bin/pip install --upgrade pip
         sudo /opt/azure-cli/bin/pip install azure-cli
         sudo ln -sf /opt/azure-cli/bin/az /usr/local/bin/az

--- a/azure-pipeline-templates/package-install.yml
+++ b/azure-pipeline-templates/package-install.yml
@@ -33,10 +33,10 @@ steps:
       curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash || true
       if ! command -v az >/dev/null 2>&1; then
         echo "AzCli deb install failed (likely unsupported distro codename), falling back to pip install"
-        sudo apt-get install python3 python3-venv -y
-        python3 -m venv /opt/azure-cli
-        /opt/azure-cli/bin/pip install --upgrade pip
-        /opt/azure-cli/bin/pip install azure-cli
+        sudo apt-get install -y python3 python3-venv
+        sudo python3 -m venv /opt/azure-cli
+        sudo /opt/azure-cli/bin/pip install --upgrade pip
+        sudo /opt/azure-cli/bin/pip install azure-cli
         sudo ln -sf /opt/azure-cli/bin/az /usr/local/bin/az
       fi
       az --version

--- a/azure-pipeline-templates/package-install.yml
+++ b/azure-pipeline-templates/package-install.yml
@@ -30,7 +30,15 @@ steps:
       fusermount3 -V
       fusermount -V
       echo "***********************Install AzCli*************************"
-      curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash || true
+      if ! command -v az >/dev/null 2>&1; then
+        echo "AzCli deb install failed (likely unsupported distro codename), falling back to pip install"
+        sudo apt-get install python3 python3-venv -y
+        python3 -m venv /opt/azure-cli
+        /opt/azure-cli/bin/pip install --upgrade pip
+        /opt/azure-cli/bin/pip install azure-cli
+        sudo ln -sf /opt/azure-cli/bin/az /usr/local/bin/az
+      fi
       az --version
     displayName: 'Libfuse Setup ${{ parameters.distro_version }} for ubuntu'
     condition: eq(variables['distro'], 'ubuntu')


### PR DESCRIPTION
## Problem
The nightly pipeline fails at the Libfuse Setup stage on Ubuntu 26 with:
```
az: command not found
```
This happens because `https://aka.ms/InstallAzureCLIDeb` does not yet provide an Azure CLI repo package for Ubuntu 26's codename, so the deb install silently fails and `az` is never installed.

## Fix
- Tolerate deb install failure (`|| true`)
- If `az` is still missing, fall back to installing Azure CLI in a Python venv via `pip` and symlink it to `/usr/local/bin/az`

This keeps existing Ubuntu versions working while unblocking Ubuntu 26.