### PR TITLE
health-monitor: restrict report file and output directory permissions

### DIFF
--- a/tools/health-monitor/internal/stats_export.go
+++ b/tools/health-monitor/internal/stats_export.go
@@ -283,7 +283,9 @@ func (se *StatsExporter) getNewFile() error {
 	_ = os.Rename(fname, fnameNew)
 
 	fname = fmt.Sprintf("%v_%v.%v", baseName, hmcommon.Pid, hmcommon.OutputFileExtension)
-	se.opFile, err = os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	// Restrict report files to owner read/write only (0600) since they may
+	// contain sensitive path information from the monitored blobfuse2 process.
+	se.opFile, err = os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		log.Err("stats_exporter::getNewFile : Unable to create output file [%v]", err)
 		return err

--- a/tools/health-monitor/main.go
+++ b/tools/health-monitor/main.go
@@ -110,6 +110,26 @@ func main() {
 		hmcommon.OutputPath = currDir
 	}
 
+	// Report files may contain sensitive path information from the monitored
+	// process, so the output directory should not be accessible to other users.
+	// Create it with owner-only access (0700) when it does not already exist.
+	// If it already exists, do not silently change its permissions (the user
+	// may have intentionally chosen a shared/existing directory); only warn
+	// when the existing permissions are broader than owner-only.
+	if info, err := os.Stat(hmcommon.OutputPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(hmcommon.OutputPath, 0700); err != nil {
+			fmt.Printf("health-monitor : failed to create output directory [%s]\n", err.Error())
+			log.Err("main::main : failed to create output directory [%s]\n", err.Error())
+			return
+		}
+	} else if err != nil {
+		fmt.Printf("health-monitor : failed to stat output directory [%s]\n", err.Error())
+		log.Err("main::main : failed to stat output directory [%s]\n", err.Error())
+		return
+	} else if info.Mode().Perm()&0077 != 0 {
+		log.Warn("main::main : output directory %v is accessible by other users (mode %#o); report files may contain sensitive path information", hmcommon.OutputPath, info.Mode().Perm())
+	}
+
 	common.TransferPipe += "_" + hmcommon.Pid
 	common.PollingPipe += "_" + hmcommon.Pid
 

--- a/tools/health-monitor/main.go
+++ b/tools/health-monitor/main.go
@@ -126,6 +126,10 @@ func main() {
 		fmt.Printf("health-monitor : failed to stat output directory [%s]\n", err.Error())
 		log.Err("main::main : failed to stat output directory [%s]\n", err.Error())
 		return
+	} else if !info.IsDir() {
+		fmt.Printf("health-monitor : output path is not a directory [%s]\n", hmcommon.OutputPath)
+		log.Err("main::main : output path is not a directory [%s]", hmcommon.OutputPath)
+		return
 	} else if info.Mode().Perm()&0077 != 0 {
 		log.Warn("main::main : output directory %v is accessible by other users (mode %#o); report files may contain sensitive path information", hmcommon.OutputPath, info.Mode().Perm())
 	}

--- a/tools/health-monitor/main.go
+++ b/tools/health-monitor/main.go
@@ -103,8 +103,8 @@ func main() {
 	if hmcommon.OutputPath == "" {
 		currDir, err := os.Getwd()
 		if err != nil {
-			fmt.Printf("health-monitor : failed to get current directory [%s]\n", err.Error())
-			log.Err("main::main : failed to get current directory [%s]", err.Error())
+			fmt.Printf("health-monitor : failed to get current directory [%v]\n", err)
+			log.Err("main::main : failed to get current directory [%v]", err)
 			os.Exit(1)
 		}
 		hmcommon.OutputPath = currDir
@@ -119,8 +119,8 @@ func main() {
 	info, err := os.Stat(hmcommon.OutputPath)
 	if os.IsNotExist(err) {
 		if err := os.MkdirAll(hmcommon.OutputPath, 0700); err != nil {
-			fmt.Printf("health-monitor : failed to create output directory [%s]\n", err.Error())
-			log.Err("main::main : failed to create output directory [%s]", err.Error())
+			fmt.Printf("health-monitor : failed to create output directory [%v]\n", err)
+			log.Err("main::main : failed to create output directory [%v]", err)
 			os.Exit(1)
 		}
 		// Re-stat to handle races where the directory is created by another
@@ -129,8 +129,8 @@ func main() {
 		info, err = os.Stat(hmcommon.OutputPath)
 	}
 	if err != nil {
-		fmt.Printf("health-monitor : failed to stat output directory [%s]\n", err.Error())
-		log.Err("main::main : failed to stat output directory [%s]", err.Error())
+		fmt.Printf("health-monitor : failed to stat output directory [%v]\n", err)
+		log.Err("main::main : failed to stat output directory [%v]", err)
 		os.Exit(1)
 	} else if !info.IsDir() {
 		fmt.Printf("health-monitor : output path is not a directory [%s]\n", hmcommon.OutputPath)

--- a/tools/health-monitor/main.go
+++ b/tools/health-monitor/main.go
@@ -104,7 +104,7 @@ func main() {
 		currDir, err := os.Getwd()
 		if err != nil {
 			fmt.Printf("health-monitor : failed to get current directory [%s]\n", err.Error())
-			log.Err("main::main : failed to get current directory [%s]\n", err.Error())
+			log.Err("main::main : failed to get current directory [%s]", err.Error())
 			return
 		}
 		hmcommon.OutputPath = currDir
@@ -119,12 +119,12 @@ func main() {
 	if info, err := os.Stat(hmcommon.OutputPath); os.IsNotExist(err) {
 		if err := os.MkdirAll(hmcommon.OutputPath, 0700); err != nil {
 			fmt.Printf("health-monitor : failed to create output directory [%s]\n", err.Error())
-			log.Err("main::main : failed to create output directory [%s]\n", err.Error())
+			log.Err("main::main : failed to create output directory [%s]", err.Error())
 			return
 		}
 	} else if err != nil {
 		fmt.Printf("health-monitor : failed to stat output directory [%s]\n", err.Error())
-		log.Err("main::main : failed to stat output directory [%s]\n", err.Error())
+		log.Err("main::main : failed to stat output directory [%s]", err.Error())
 		return
 	} else if !info.IsDir() {
 		fmt.Printf("health-monitor : output path is not a directory [%s]\n", hmcommon.OutputPath)

--- a/tools/health-monitor/main.go
+++ b/tools/health-monitor/main.go
@@ -105,7 +105,7 @@ func main() {
 		if err != nil {
 			fmt.Printf("health-monitor : failed to get current directory [%s]\n", err.Error())
 			log.Err("main::main : failed to get current directory [%s]", err.Error())
-			return
+			os.Exit(1)
 		}
 		hmcommon.OutputPath = currDir
 	}
@@ -120,16 +120,16 @@ func main() {
 		if err := os.MkdirAll(hmcommon.OutputPath, 0700); err != nil {
 			fmt.Printf("health-monitor : failed to create output directory [%s]\n", err.Error())
 			log.Err("main::main : failed to create output directory [%s]", err.Error())
-			return
+			os.Exit(1)
 		}
 	} else if err != nil {
 		fmt.Printf("health-monitor : failed to stat output directory [%s]\n", err.Error())
 		log.Err("main::main : failed to stat output directory [%s]", err.Error())
-		return
+		os.Exit(1)
 	} else if !info.IsDir() {
 		fmt.Printf("health-monitor : output path is not a directory [%s]\n", hmcommon.OutputPath)
 		log.Err("main::main : output path is not a directory [%s]", hmcommon.OutputPath)
-		return
+		os.Exit(1)
 	} else if info.Mode().Perm()&0077 != 0 {
 		log.Warn("main::main : output directory %v is accessible by other users (mode %#o); report files may contain sensitive path information", hmcommon.OutputPath, info.Mode().Perm())
 	}

--- a/tools/health-monitor/main.go
+++ b/tools/health-monitor/main.go
@@ -116,13 +116,19 @@ func main() {
 	// If it already exists, do not silently change its permissions (the user
 	// may have intentionally chosen a shared/existing directory); only warn
 	// when the existing permissions are broader than owner-only.
-	if info, err := os.Stat(hmcommon.OutputPath); os.IsNotExist(err) {
+	info, err := os.Stat(hmcommon.OutputPath)
+	if os.IsNotExist(err) {
 		if err := os.MkdirAll(hmcommon.OutputPath, 0700); err != nil {
 			fmt.Printf("health-monitor : failed to create output directory [%s]\n", err.Error())
 			log.Err("main::main : failed to create output directory [%s]", err.Error())
 			os.Exit(1)
 		}
-	} else if err != nil {
+		// Re-stat to handle races where the directory is created by another
+		// process between the initial Stat and MkdirAll (possibly with broader
+		// permissions), so the permission check below is always applied.
+		info, err = os.Stat(hmcommon.OutputPath)
+	}
+	if err != nil {
 		fmt.Printf("health-monitor : failed to stat output directory [%s]\n", err.Error())
 		log.Err("main::main : failed to stat output directory [%s]", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
## Description

Fixes a permission-related information disclosure defect in the health monitor.

### Problem
- `StatsExporter.getNewFile()` created JSON reports with mode `0755` (`os.O_APPEND|os.O_CREATE|os.O_WRONLY`). Combined with the daemon's `Umask: 022`, reports remained world-readable.
- Rotation via `os.Rename` preserved those permissions.
- Reports serialize operation paths (`PipeMsg.Path`), cache paths, and rename/move source paths, which may be sensitive.
- When `output-path` is omitted, the current working directory is used as the report location.

A local user able to traverse the report directory could read these files.

### Changes
- Create report files with mode `0600` (owner read/write only) in `stats_export.go`.
- In `main.go`, create the output directory with `0700` when it does not exist. If it already exists, do not silently change its permissions (the directory may be intentionally shared); instead log a warning when the directory is accessible to other users.

### Testing
- `go build` / no compile errors.
