### PR TITLE
Removes Kubernetes namespace +service based discovery method for cache server discovery in distributed cache.

### DIFF
--- a/component/dist_cache/dist_cache.go
+++ b/component/dist_cache/dist_cache.go
@@ -70,8 +70,6 @@ const (
 // identity-vs-tuning split used by azstorage.
 const (
 	EnvDistCacheDiscoveryEndpoint = "DIST_CACHE_DISCOVERY_ENDPOINT"
-	EnvDistCacheK8sService        = "DIST_CACHE_K8S_SERVICE"
-	EnvDistCacheK8sNamespace      = "DIST_CACHE_K8S_NAMESPACE"
 	EnvDistCacheServerList        = "DIST_CACHE_SERVER_LIST"
 )
 
@@ -79,8 +77,6 @@ const (
 // Precedence via viper: CLI flag > env > YAML > default.
 func RegisterEnvVariables() {
 	config.BindEnv(compName+".discovery-endpoint", EnvDistCacheDiscoveryEndpoint)
-	config.BindEnv(compName+".k8s-service", EnvDistCacheK8sService)
-	config.BindEnv(compName+".k8s-namespace", EnvDistCacheK8sNamespace)
 	config.BindEnv(compName+".server-list", EnvDistCacheServerList)
 }
 
@@ -88,10 +84,6 @@ func RegisterEnvVariables() {
 type DistCacheOptions struct {
 	// Discovery (preferred — auto-detects servers)
 	DiscoveryEndpoint string `config:"discovery-endpoint" yaml:"discovery-endpoint,omitempty"`
-
-	// Kubernetes DNS discovery
-	K8sService   string `config:"k8s-service"   yaml:"k8s-service,omitempty"`
-	K8sNamespace string `config:"k8s-namespace" yaml:"k8s-namespace,omitempty"`
 
 	// Static fallback
 	ServerList string `config:"server-list" yaml:"server-list,omitempty"`
@@ -156,25 +148,22 @@ func (dc *DistCache) Configure(isParent bool) error {
 	}
 
 	// At least one discovery method must be set (YAML, CLI flag, or env).
-	if conf.DiscoveryEndpoint == "" && conf.K8sService == "" && conf.ServerList == "" {
-		return fmt.Errorf("dist_cache: no server discovery configured (set discovery-endpoint, k8s-service, or server-list)")
+	if conf.DiscoveryEndpoint == "" && conf.ServerList == "" {
+		return fmt.Errorf("dist_cache: no server discovery configured (set discovery-endpoint or server-list)")
 	}
 
 	// Warn if multiple discovery methods are configured. The dcache client
-	// applies them in precedence order: discovery-endpoint > k8s DNS > server-list;
+	// applies them in precedence order: discovery-endpoint > server-list;
 	// lower-precedence entries are effectively ignored.
 	var configured []string
 	if conf.DiscoveryEndpoint != "" {
 		configured = append(configured, "discovery-endpoint")
 	}
-	if conf.K8sService != "" {
-		configured = append(configured, "k8s-service")
-	}
 	if conf.ServerList != "" {
 		configured = append(configured, "server-list")
 	}
 	if len(configured) > 1 {
-		log.Warn("DistCache::Configure : multiple discovery methods configured (%s); precedence is discovery-endpoint > k8s DNS > server-list, lower-precedence entries will only be used as a fallback",
+		log.Warn("DistCache::Configure : multiple discovery methods configured (%s); precedence is discovery-endpoint > server-list, lower-precedence entries will only be used as a fallback",
 			strings.Join(configured, ", "))
 	}
 
@@ -231,8 +220,6 @@ func (dc *DistCache) Configure(isParent bool) error {
 
 	log.Info("DistCache::Configure : block-size=%d", dc.chunkSize)
 	log.Info("DistCache::Configure : discovery-endpoint=%s", dc.conf.DiscoveryEndpoint)
-	log.Info("DistCache::Configure : k8s-service=%s", dc.conf.K8sService)
-	log.Info("DistCache::Configure : k8s-namespace=%s", dc.conf.K8sNamespace)
 	log.Info("DistCache::Configure : server-list=%s", dc.conf.ServerList)
 	log.Info("DistCache::Configure : port=%d", dc.conf.Port)
 	log.Info("DistCache::Configure : ttl-seconds=%d", dc.conf.TTLSeconds)
@@ -258,9 +245,6 @@ func (dc *DistCache) Start(ctx context.Context) error {
 
 	if dc.conf.DiscoveryEndpoint != "" {
 		opts = append(opts, dcache.WithDiscoveryURL(dc.conf.DiscoveryEndpoint))
-	}
-	if dc.conf.K8sService != "" && dc.conf.K8sNamespace != "" {
-		opts = append(opts, dcache.WithK8sDiscovery(dc.conf.K8sService, dc.conf.K8sNamespace))
 	}
 	if dc.conf.ServerList != "" {
 		servers := strings.Split(dc.conf.ServerList, ",")

--- a/component/dist_cache/dist_cache_test.go
+++ b/component/dist_cache/dist_cache_test.go
@@ -1215,25 +1215,6 @@ dist_cache: {}
 	assert.Equal(t, "127.0.0.1:9000", dc.conf.DiscoveryEndpoint)
 }
 
-// TestRegisterEnvVariables_BindsK8sServiceAndNamespace verifies that both
-// K8s discovery env vars land in conf.
-func TestRegisterEnvVariables_BindsK8sServiceAndNamespace(t *testing.T) {
-	loadConfig(t, `
-azstorage:
-  account-name: myacct
-  container: mycontainer
-dist_cache: {}
-`)
-	RegisterEnvVariables()
-	t.Setenv(EnvDistCacheK8sService, "dcache-svc")
-	t.Setenv(EnvDistCacheK8sNamespace, "cache-ns")
-
-	dc := NewDistCacheComponent().(*DistCache)
-	require.NoError(t, dc.Configure(true))
-	assert.Equal(t, "dcache-svc", dc.conf.K8sService)
-	assert.Equal(t, "cache-ns", dc.conf.K8sNamespace)
-}
-
 // TestRegisterEnvVariables_BindsServerList verifies the env-only path for
 // server-list: no YAML entry, only the env var, Configure must succeed.
 func TestRegisterEnvVariables_BindsServerList(t *testing.T) {

--- a/sampleDistCacheConfig.yaml
+++ b/sampleDistCacheConfig.yaml
@@ -28,17 +28,12 @@ libfuse:
   negative-entry-expiration-sec: 240
 
 # Distributed cache configuration
-# At least one discovery method must be configured: discovery-endpoint, k8s-service, or server-list.
+# At least one discovery method must be configured: discovery-endpoint or server-list.
 dist_cache:
   # Option 1: Discovery endpoint (recommended for production)
   discovery-endpoint: "cacheserver-discovery.my-namespace.svc.cluster.local:9065"
 
-  # Option 2: Kubernetes DNS discovery
-  # k8s-service: cacheserver
-  # k8s-namespace: my-namespace
-  # port: 9065
-
-  # Option 3: Static server list (comma-separated host:port)
+  # Option 2: Static server list (comma-separated host:port)
   # server-list: "cacheserver-0:9065,cacheserver-1:9065,cacheserver-2:9065"
 
   # Optional: L1 tuning (applied to the auto-inserted block_cache component)

--- a/setup/advancedConfig.yaml
+++ b/setup/advancedConfig.yaml
@@ -119,10 +119,7 @@ attr_cache:
 # Distributed cache advanced configuration
 # See setup/baseConfig.yaml for the base dist_cache options (e.g. discovery-endpoint).
 dist_cache:
-  k8s-service: <Kubernetes headless service name for DNS-based discovery>
-  k8s-namespace: <Kubernetes namespace where the cache service runs>
-  port: <cache server port used when Kubernetes DNS falls back from SRV to A records and for discovery responses that omit a port. SRV records provide their own port. Default - 9065. The discovery-endpoint and each server-list entry must include their own port>
-  # OR
+  port: <cache server port used for discovery responses that omit a port. Default - 9065. The discovery-endpoint and each server-list entry must include their own port>
   server-list: <comma-separated list of cache server addresses, e.g., "host1:9065,host2:9065,host3:9065">
   ttl-seconds: <TTL for cached data in seconds. Default - 0 (no expiry)>
   verify-checksum: <true|false, per-chunk CRC32 verification on the L2 client. On mismatch: with bypass-on-error=true (default) fall through to azstorage, otherwise return EIO. Default - true>


### PR DESCRIPTION
Removes Kubernetes namespace +service based discovery method for cache server discovery in distributed cache/ dist_cache.

Now, Cache Server Discovery in distributed cache can be done in two ways:
1. discovery-endpoint 
2. server-list 

Reason:
A Kubernetes Service only reflects currently available cache servers and does not represent actual ring membership, which is managed by the cache controller. Relying on Service endpoints can lead to incorrect ring formation during node restarts, transient outages, or membership reconciliation.

Major Changes:
1. Removed K8sService and K8sNamespace configuration fields.
2.  Removed DIST_CACHE_K8S_SERVICE and DIST_CACHE_K8S_NAMESPACE environment variables and their Viper bindings.
3.  Removed WithK8sDiscovery wiring from DistCache.Start.
4.  Updated the required-discovery validation error message.
5.  Updated the multiple-methods-configured warning to reflect the new discovery method precedence.
6.  Removed Kubernetes service/namespace configuration entries and related documentation from: sampleDistCacheConfig.yaml,  setup/advancedConfig.yaml
7. Removed TestRegisterEnvVariables_BindsK8sServiceAndNamespace.